### PR TITLE
Fix / Gateway path translation

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -53,7 +53,7 @@ ext {
 
 
     // Plugins
-    aws_sdk_version = '1.12.178'
+    aws_sdk_version = '1.12.267'
     gcp_sdk_version = '2.6.1'
     gcp_sdk_http_client_version = '1.41.8'  // Force Google HTTP client version needed for compliance
 

--- a/tracdap-services/tracdap-gateway/src/test/resources/trac-unit-gateway-http1.yaml
+++ b/tracdap-services/tracdap-gateway/src/test/resources/trac-unit-gateway-http1.yaml
@@ -34,7 +34,7 @@ routes:
 
     match:
       host: localhost
-      path: /static/docs/
+      path: /static/docs
 
     target:
       scheme: http
@@ -47,7 +47,7 @@ routes:
 
     match:
       host: localhost
-      path: /static/server_timeout/
+      path: /static/server_timeout
 
     target:
       scheme: http
@@ -60,7 +60,7 @@ routes:
 
     match:
       host: localhost
-      path: /static/server_down/
+      path: /static/server_down
 
     target:
       scheme: http


### PR DESCRIPTION
Handle trailing slashes in source / target paths for HTTP 1 proxy translation in the gateway
- Avoids adding a double slash, or removing a slash, in the translated path