### PR TITLE
Fix / Default logging config

### DIFF
--- a/dist/scripts/service-ctrl.sh
+++ b/dist/scripts/service-ctrl.sh
@@ -127,7 +127,7 @@ CLASSPATH_END)
 if [ "\${PLUGINS_ENABLED}" = "true" ]; then
     CWD=`pwd` && cd "\${PLUGINS_DIR}"
     for JAR in `find . -name "*.jar" | sed s#^./##`; do
-        CLASSPATH="\${CLASSPATH}:\${PLUGINS_EXT_DIR}/\${JAR}";
+        CLASSPATH="\${CLASSPATH}:\${PLUGINS_DIR}/\${JAR}";
     done
     cd "\${CWD}"
 fi

--- a/dist/scripts/service-ctrl.sh
+++ b/dist/scripts/service-ctrl.sh
@@ -183,7 +183,10 @@ run() {
 
     export CLASSPATH
 
-    (cd "\${RUN_DIR}" && java \${JAVA_OPTS} \$APPLICATION_CLASS --config "\${CONFIG_FILE}" \${TASK_LIST})
+    CWD=`pwd`
+    cd "\${RUN_DIR}"
+    java \${JAVA_OPTS} \$APPLICATION_CLASS --config "\${CONFIG_FILE}" &
+    cd "\${CWD}"
 }
 
 start() {
@@ -208,8 +211,11 @@ start() {
 
     export CLASSPATH
 
-    (cd "\${RUN_DIR}" && java \${JAVA_OPTS} \$APPLICATION_CLASS --config "\${CONFIG_FILE}") &
+    CWD=`pwd`
+    cd "\${RUN_DIR}"
+    java \${JAVA_OPTS} \$APPLICATION_CLASS --config "\${CONFIG_FILE}" &
     PID=\$!
+    cd "\${CWD}"
 
     # Before recording the PID, wait to make sure the service doesn't crash on startup
     # Not a fail-safe guarantee, but will catch e.g. missing or invalid config files

--- a/dist/scripts/service-ctrl.sh
+++ b/dist/scripts/service-ctrl.sh
@@ -194,7 +194,7 @@ run() {
 
     CWD=`pwd`
     cd "\${RUN_DIR}"
-    java \${JAVA_OPTS} \$APPLICATION_CLASS --config "\${CONFIG_FILE}" &
+    java \${JAVA_OPTS} \$APPLICATION_CLASS --config "\${CONFIG_FILE}" \${TASK_LIST}
     cd "\${CWD}"
 }
 

--- a/dist/scripts/service-ctrl.sh
+++ b/dist/scripts/service-ctrl.sh
@@ -181,20 +181,11 @@ run() {
     echo "Config file: [\${CONFIG_FILE}]"
     echo
 
-    if [ \$# -gt 0 ]; then
-        TASK_LIST=""
-        for TASK in \$@; do
-            echo "Task: \$TASK"
-            TASK_LIST="\${TASK_LIST} --task \"\${TASK}\""
-        done
-        echo
-    fi
-
     export CLASSPATH
 
     CWD=`pwd`
     cd "\${RUN_DIR}"
-    java \${JAVA_OPTS} \$APPLICATION_CLASS --config "\${CONFIG_FILE}" \${TASK_LIST}
+    java \${JAVA_OPTS} \$APPLICATION_CLASS --config "\${CONFIG_FILE}" \$@
     cd "\${CWD}"
 }
 
@@ -222,7 +213,7 @@ start() {
 
     CWD=`pwd`
     cd "\${RUN_DIR}"
-    java \${JAVA_OPTS} \$APPLICATION_CLASS --config "\${CONFIG_FILE}" &
+    java \${JAVA_OPTS} \$APPLICATION_CLASS --config "\${CONFIG_FILE}" \$@ &
     PID=\$!
     cd "\${CWD}"
 
@@ -358,7 +349,8 @@ case "\$1" in
        run \$@
        ;;
     start)
-       start
+       shift
+       start \$@
        ;;
     stop)
        stop

--- a/dist/scripts/service-ctrl.sh
+++ b/dist/scripts/service-ctrl.sh
@@ -80,7 +80,11 @@ PID_FILE="\${PID_DIR}/${applicationName}.pid"
 
 # If CONFIG_FILE is relative, look in the config folder
 if [ "\${CONFIG_FILE}" != "" ] && [ "\${CONFIG_FILE:0:1}" != "/" ]; then
-    CONFIG_FILE="\${CONFIG_DIR}/\${CONFIG_FILE}"
+    if [ "\${CONFIG_FILE:0:4}" == "etc/" ]; then
+        CONFIG_FILE="\${APP_HOME}/\${CONFIG_FILE}"
+    else
+        CONFIG_FILE="\${CONFIG_DIR}/\${CONFIG_FILE}"
+    fi
 fi
 
 

--- a/dist/scripts/service-ctrl.sh
+++ b/dist/scripts/service-ctrl.sh
@@ -145,6 +145,11 @@ CORE_JAVA_OPTS=\$(cat <<-JAVA_OPTS_END
 ${defaultJvmOpts.replace("'", "").replace(' "-', '\n"-').replace('"', '')}
 JAVA_OPTS_END)
 
+# Set java properties used for logging
+
+CORE_JAVA_OPTS="\${CORE_JAVA_OPTS} -DLOG_DIR=\${LOG_DIR}"
+CORE_JAVA_OPTS="\${CORE_JAVA_OPTS} -DLOG_NAME=\${APPLICATION_NAME}"
+
 # Add core Java opts to opts supplied from the environment or env.sh
 
 JAVA_OPTS="\${CORE_JAVA_OPTS} \${JAVA_OPTS}"

--- a/dist/template/etc/trac-gateway-example.yaml
+++ b/dist/template/etc/trac-gateway-example.yaml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#config:
-#  logging: trac-logging-example.xml
+config:
+  logging: trac-logging-example.xml
 
 
 port: 8080

--- a/dist/template/etc/trac-logging-example.xml
+++ b/dist/template/etc/trac-logging-example.xml
@@ -20,22 +20,16 @@
 
     <Appenders>
 
-        <!-- The STDOUT appender is recommended for containers and interactive sessions -->
-        <Appender name="STDOUT" type="Console">
-            <Layout type="PatternLayout" disableAnsi="false">
-                <Pattern>
-                    %d{yyyy-MM-dd HH:mm:ss.SSS} %highlight{%-5level} [%-16t] %cyan{%c{1.}} - %msg%n
-                </Pattern>
-            </Layout>
-        </Appender>
-
         <!-- The LOCAL_FILES appender is recommended for deployments on physical machines and VMs -->
-        <!-- The LOG_DIR and APPLICATION_NAME variables are set by the service startup script -->
-        <!-- <Appender
+
+        <!-- The LOG_DIR and LOG_NAME variables are set up as Java properties by the start-up script -->
+        <!-- Use JAVA_OPTS to define additional properties if needed -->
+
+        <Appender
                 name="LOCAL_FILES"
                 type="RollingFile"
-                fileName="${LOG_DIR}/${APPLICATION_NAME}.log"
-                filePatter="${LOG_DIR}/${APPLICATION_NAME}-%d{yyyy-MM-dd}.log.gz">
+                fileName="${sys:LOG_DIR}/${sys:LOG_NAME}.log"
+                filePattern="${sys:LOG_DIR}/${sys:LOG_NAME}-%d{yyyy-MM-dd}.log.gz">
 
             <Layout type="PatternLayout" disableAnsi="true">
                 <Pattern>
@@ -43,14 +37,27 @@
                 </Pattern>
             </Layout>
 
+            <Policies>
+            </Policies>
+
+        </Appender>
+
+        <!-- The STDOUT appender is recommended for containers and interactive sessions -->
+
+        <!-- <Appender name="STDOUT" type="Console">
+            <Layout type="PatternLayout" disableAnsi="true">
+                <Pattern>
+                    %d{yyyy-MM-dd HH:mm:ss.SSS} %highlight{%-5level} [%-16t] %cyan{%c{1.}} - %msg%n
+                </Pattern>
+            </Layout>
         </Appender> -->
 
     </Appenders>
 
     <Loggers>
         <Root level="info">
-            <AppenderRef ref="STDOUT"/>
-            <!-- <AppenderRef ref="LOCAL_FILES"/> -->
+            <AppenderRef ref="LOCAL_FILES"/>
+            <!-- <AppenderRef ref="STDOUT"/> -->
         </Root>
     </Loggers>
 

--- a/dist/template/etc/trac-logging-example.xml
+++ b/dist/template/etc/trac-logging-example.xml
@@ -52,6 +52,16 @@
             </Layout>
         </Appender> -->
 
+        <!-- An alternative STDOUT appender with ANSI color-coding enabled -->
+
+        <!-- <Appender type="Console" name="STDOUT">
+            <Layout type="PatternLayout" disableAnsi="false">
+                <Pattern>
+                    %d{yyyy-MM-dd HH:mm:ss.SSS} %highlight{%-5level} [%-16t] %cyan{%c{1.}} - %msg%n
+                </Pattern>
+            </Layout>
+        </Appender> -->
+
     </Appenders>
 
     <Loggers>

--- a/dist/template/etc/trac-logging-example.xml
+++ b/dist/template/etc/trac-logging-example.xml
@@ -47,7 +47,7 @@
         <!-- <Appender name="STDOUT" type="Console">
             <Layout type="PatternLayout" disableAnsi="true">
                 <Pattern>
-                    %d{yyyy-MM-dd HH:mm:ss.SSS} %highlight{%-5level} [%-16t] %cyan{%c{1.}} - %msg%n
+                    %d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%-16t] %c{1.} - %msg%n
                 </Pattern>
             </Layout>
         </Appender> -->

--- a/dist/template/etc/trac-platform-example.yaml
+++ b/dist/template/etc/trac-platform-example.yaml
@@ -14,8 +14,6 @@
 
 config:
   logging: trac-logging-example.xml
-  keystore.type: PKCS12
-  keystore.url: trac-keystore.pfx
 
 
 instances:

--- a/etc/trac-logging.xml
+++ b/etc/trac-logging.xml
@@ -28,11 +28,30 @@
             </Layout>
         </Appender>
 
+        <!-- Example appender for logging to files -->
+        <!-- <Appender
+                name="LOCAL_FILES"
+                type="RollingFile"
+                fileName="build/log/tracdap-svc-meta.log"
+                filePattern="build/log/tracdap-svc-meta-%d{yyyy-MM-dd}.log.gz">
+
+            <Layout type="PatternLayout" disableAnsi="true">
+                <Pattern>
+                    %d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%-16t] %c{1.} - %msg%n
+                </Pattern>
+            </Layout>
+
+            <Policies>
+            </Policies>
+
+        </Appender> -->
+
     </Appenders>
 
     <Loggers>
         <Root level="info">
             <AppenderRef ref="STDOUT"/>
+            <!--<AppenderRef ref="LOCAL_FILES"/>-->
         </Root>
     </Loggers>
 

--- a/tracdap-libs/tracdap-lib-common/src/main/java/org/finos/tracdap/common/startup/StandardArgsProcessor.java
+++ b/tracdap-libs/tracdap-lib-common/src/main/java/org/finos/tracdap/common/startup/StandardArgsProcessor.java
@@ -190,14 +190,24 @@ public class StandardArgsProcessor {
 
     private static Options standardOptions(boolean usingTasks) {
 
-        var options = helpOptions(usingTasks);
+        return buildOOptions(usingTasks, false);
+    }
+
+    private static Options helpOptions(boolean usingTasks) {
+
+        return buildOOptions(usingTasks, true);
+    }
+
+    private static Options buildOOptions(boolean usingTasks, boolean buildingHelp) {
+
+        var options = new Options();
 
         options.addOption(Option.builder()
                 .desc("Location of the service config file")
                 .longOpt("config")
                 .hasArg()
                 .argName("config_file")
-                .required()
+                .required(!buildingHelp)
                 .build());
 
         options.addOption(Option.builder()
@@ -205,6 +215,11 @@ public class StandardArgsProcessor {
                 .longOpt("keystore-key")
                 .hasArg()
                 .argName("keystore_key")
+                .build());
+
+        options.addOption(Option.builder()
+                .desc("Display this help and then quit")
+                .longOpt("help")
                 .build());
 
         if (usingTasks) {
@@ -215,23 +230,8 @@ public class StandardArgsProcessor {
                     .hasArgs()
                     .argName("task")
                     .valueSeparator(':')
-                    .required()
+                    .required(!buildingHelp)
                     .build());
-        }
-
-        return options;
-    }
-
-    private static Options helpOptions(boolean usingTasks) {
-
-        var options = new Options();
-
-        options.addOption(Option.builder()
-                .desc("Display this help and then quit")
-                .longOpt("help")
-                .build());
-
-        if (usingTasks) {
 
             options.addOption(Option.builder()
                     .desc("Display the list of available tasks and then quit")

--- a/tracdap-libs/tracdap-lib-common/src/main/java/org/finos/tracdap/common/startup/StartupSequence.java
+++ b/tracdap-libs/tracdap-lib-common/src/main/java/org/finos/tracdap/common/startup/StartupSequence.java
@@ -16,6 +16,7 @@
 
 package org.finos.tracdap.common.startup;
 
+import org.apache.logging.log4j.LogManager;
 import org.finos.tracdap.common.config.ConfigKeys;
 import org.finos.tracdap.common.config.ConfigManager;
 import org.finos.tracdap.common.exception.EStartup;
@@ -165,6 +166,10 @@ public class StartupSequence {
             try (var configStream = new ByteArrayInputStream(loggingConfig.getBytes())) {
 
                 var configSource = new ConfigurationSource(configStream);
+
+                log.info("Initialize logging...");
+
+                LogManager.shutdown();
                 Configurator.initialize(getClass().getClassLoader(), configSource);
 
                 // Invalid logging configuration cause the startup sequence to bomb out
@@ -177,11 +182,9 @@ public class StartupSequence {
         }
         else {
 
-            log.info("Using default logging config");
+            log.info("No logging config provided, using default...");
+            Configurator.reconfigure();
         }
-
-        log.info("Initialize logging...");
-        Configurator.reconfigure();
     }
 
     private String lookupLoggingConfigUrl(Map<?, ?> rootConfigMap) {

--- a/tracdap-libs/tracdap-lib-common/src/main/resources/log4j2.xml
+++ b/tracdap-libs/tracdap-lib-common/src/main/resources/log4j2.xml
@@ -21,9 +21,9 @@
     <Appenders>
 
         <Appender type="Console" name="STDOUT">
-            <Layout type="PatternLayout" disableAnsi="false">
+            <Layout type="PatternLayout" disableAnsi="true">
                 <Pattern>
-                    %d{yyyy-MM-dd HH:mm:ss.SSS} %highlight{%-5level} [%-16t] %cyan{%c{1.}} - %msg%n
+                    %d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%-16t] %c{1.} - %msg%n
                 </Pattern>
             </Layout>
         </Appender>


### PR DESCRIPTION
Various fixes to the logging system
Default logging options handled correctly
System properties available for logging config
Rolling file loggers are now the default in the platform packages
Startup logger always logs to console, until the logging config is processed