### PR TITLE
Fix / Metadata in-place upgrade from 0.4 series

### DIFF
--- a/tracdap-services/tracdap-svc-meta/src/schema/h2/rollout/001__trac_metadata.ddl
+++ b/tracdap-services/tracdap-svc-meta/src/schema/h2/rollout/001__trac_metadata.ddl
@@ -1,16 +1,4 @@
---  Copyright 2022 Accenture Global Solutions Limited
---
---  Licensed under the Apache License, Version 2.0 (the "License");
---  you may not use this file except in compliance with the License.
---  You may obtain a copy of the License at
---
---      http://www.apache.org/licenses/LICENSE-2.0
---
---  Unless required by applicable law or agreed to in writing, software
---  distributed under the License is distributed on an "AS IS" BASIS,
---  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
---  See the License for the specific language governing permissions and
---  limitations under the License.
+--  Copyright 2020 Accenture Global Solutions Limited
 --
 --  Licensed under the Apache License, Version 2.0 (the "License");
 --  you may not use this file except in compliance with the License.

--- a/tracdap-services/tracdap-svc-meta/src/schema/mariadb/rollout/001__trac_metadata.ddl
+++ b/tracdap-services/tracdap-svc-meta/src/schema/mariadb/rollout/001__trac_metadata.ddl
@@ -1,16 +1,4 @@
---  Copyright 2022 Accenture Global Solutions Limited
---
---  Licensed under the Apache License, Version 2.0 (the "License");
---  you may not use this file except in compliance with the License.
---  You may obtain a copy of the License at
---
---      http://www.apache.org/licenses/LICENSE-2.0
---
---  Unless required by applicable law or agreed to in writing, software
---  distributed under the License is distributed on an "AS IS" BASIS,
---  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
---  See the License for the specific language governing permissions and
---  limitations under the License.
+--  Copyright 2020 Accenture Global Solutions Limited
 --
 --  Licensed under the Apache License, Version 2.0 (the "License");
 --  you may not use this file except in compliance with the License.

--- a/tracdap-services/tracdap-svc-meta/src/schema/mysql/rollout/001__trac_metadata.ddl
+++ b/tracdap-services/tracdap-svc-meta/src/schema/mysql/rollout/001__trac_metadata.ddl
@@ -1,16 +1,4 @@
---  Copyright 2022 Accenture Global Solutions Limited
---
---  Licensed under the Apache License, Version 2.0 (the "License");
---  you may not use this file except in compliance with the License.
---  You may obtain a copy of the License at
---
---      http://www.apache.org/licenses/LICENSE-2.0
---
---  Unless required by applicable law or agreed to in writing, software
---  distributed under the License is distributed on an "AS IS" BASIS,
---  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
---  See the License for the specific language governing permissions and
---  limitations under the License.
+--  Copyright 2020 Accenture Global Solutions Limited
 --
 --  Licensed under the Apache License, Version 2.0 (the "License");
 --  you may not use this file except in compliance with the License.

--- a/tracdap-services/tracdap-svc-meta/src/schema/postgresql/rollout/001__trac_metadata.ddl
+++ b/tracdap-services/tracdap-svc-meta/src/schema/postgresql/rollout/001__trac_metadata.ddl
@@ -1,16 +1,4 @@
---  Copyright 2022 Accenture Global Solutions Limited
---
---  Licensed under the Apache License, Version 2.0 (the "License");
---  you may not use this file except in compliance with the License.
---  You may obtain a copy of the License at
---
---      http://www.apache.org/licenses/LICENSE-2.0
---
---  Unless required by applicable law or agreed to in writing, software
---  distributed under the License is distributed on an "AS IS" BASIS,
---  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
---  See the License for the specific language governing permissions and
---  limitations under the License.
+--  Copyright 2020 Accenture Global Solutions Limited
 --
 --  Licensed under the Apache License, Version 2.0 (the "License");
 --  you may not use this file except in compliance with the License.

--- a/tracdap-services/tracdap-svc-meta/src/schema/sqlserver/rollout/001__trac_metadata.ddl
+++ b/tracdap-services/tracdap-svc-meta/src/schema/sqlserver/rollout/001__trac_metadata.ddl
@@ -1,16 +1,4 @@
---  Copyright 2022 Accenture Global Solutions Limited
---
---  Licensed under the Apache License, Version 2.0 (the "License");
---  you may not use this file except in compliance with the License.
---  You may obtain a copy of the License at
---
---      http://www.apache.org/licenses/LICENSE-2.0
---
---  Unless required by applicable law or agreed to in writing, software
---  distributed under the License is distributed on an "AS IS" BASIS,
---  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
---  See the License for the specific language governing permissions and
---  limitations under the License.
+--  Copyright 2020 Accenture Global Solutions Limited
 --
 --  Licensed under the Apache License, Version 2.0 (the "License");
 --  you may not use this file except in compliance with the License.


### PR DESCRIPTION
Flyway requires that v001 scripts are not altered (file checksum) from the previous version before applying v002