### PR TITLE
Fix / SECRET_KEY from environment in the start scripts

### DIFF
--- a/dist/scripts/service-ctrl.bat
+++ b/dist/scripts/service-ctrl.bat
@@ -180,7 +180,11 @@ goto :main
 
     set CWD=%cd%
     cd "%RUN_DIR%"
-    "%JAVA_CMD%" %JAVA_OPTS% %APPLICATION_CLASS% --config "%CONFIG_FILE%" %*
+    if "%SECRET_KEY%" == "" (
+        "%JAVA_CMD%" %JAVA_OPTS% %APPLICATION_CLASS% --config "%CONFIG_FILE%" %*
+    ) else (
+        "%JAVA_CMD%" %JAVA_OPTS% %APPLICATION_CLASS% --config "%CONFIG_FILE%" --secret-key "%SECRET_KEY%" %*
+    )
     set RESULT=%errorlevel%
     cd "%CWD%"
 
@@ -207,7 +211,11 @@ exit /b %RESULT%
     echo Config file: [%CONFIG_FILE%]
     echo.
 
-    start "%APPLICATION_NAME%" /D "%RUN_DIR%" /B "%JAVA_CMD%" %JAVA_OPTS% %APPLICATION_CLASS% --config "%CONFIG_FILE%" %*
+    if "%SECRET_KEY%" == "" (
+        start "%APPLICATION_NAME%" /D "%RUN_DIR%" /B "%JAVA_CMD%" %JAVA_OPTS% %APPLICATION_CLASS% --config "%CONFIG_FILE%" %*
+    ) else (
+        start "%APPLICATION_NAME%" /D "%RUN_DIR%" /B "%JAVA_CMD%" %JAVA_OPTS% %APPLICATION_CLASS% --config "%CONFIG_FILE%" --secret-key "%SECRET_KEY%" %*
+    )
 
     @rem Look up PID using WMIC, name='java.exe' stops wmic from finding itself
     @rem findstr filters out blank lines, which are included in the output

--- a/dist/scripts/service-ctrl.sh
+++ b/dist/scripts/service-ctrl.sh
@@ -195,7 +195,11 @@ run() {
 
     CWD=`pwd`
     cd "\${RUN_DIR}"
-    "\${JAVA_CMD}" \${JAVA_OPTS} \$APPLICATION_CLASS --config "\${CONFIG_FILE}" \$@
+    if [ "\${SECRET_KEY}" = "" ]; then
+        "\${JAVA_CMD}" \${JAVA_OPTS} \$APPLICATION_CLASS --config "\${CONFIG_FILE}" \$@
+    else
+        "\${JAVA_CMD}" \${JAVA_OPTS} \$APPLICATION_CLASS --config "\${CONFIG_FILE}" --secret-key "\${SECRET_KEY}" \$@
+    fi
     cd "\${CWD}"
 }
 
@@ -223,7 +227,11 @@ start() {
 
     CWD=`pwd`
     cd "\${RUN_DIR}"
-    "\${JAVA_CMD}" \${JAVA_OPTS} \$APPLICATION_CLASS --config "\${CONFIG_FILE}" \$@ &
+    if [ "\${SECRET_KEY}" = "" ]; then
+        "\${JAVA_CMD}" \${JAVA_OPTS} \$APPLICATION_CLASS --config "\${CONFIG_FILE}" \$@ &
+    else
+        "\${JAVA_CMD}" \${JAVA_OPTS} \$APPLICATION_CLASS --config "\${CONFIG_FILE}" --secret-key "\${SECRET_KEY}" \$@ &
+    fi
     PID=\$!
     cd "\${CWD}"
 

--- a/dist/template/etc/env.bat
+++ b/dist/template/etc/env.bat
@@ -28,6 +28,7 @@
 @rem PLUGINS_ENABLED - Whether to load plugins from PLUGIN_DIR, defaults to true
 @rem PLUGINS_EXT_DIR - Location for external plugins, JARs in this folder will be added to the classpath
 @rem PLUGINS_EXT_ENABLED - Whether to load plugins from PLUGIN_EXT_DIR, defaults to false
+@rem SECRET_KEY - Location of the JKS secret key
 
 @rem JAVA_HOME - Use a specific JVM
 @rem JAVA_OPTS - Java options passed to the JVM on startup

--- a/dist/template/etc/env.sh
+++ b/dist/template/etc/env.sh
@@ -23,6 +23,7 @@
 # PLUGINS_ENABLED - Whether to load plugins from PLUGIN_DIR, defaults to true
 # PLUGINS_EXT_DIR - Location for external plugins, JARs in this folder will be added to the classpath
 # PLUGINS_EXT_ENABLED - Whether to load plugins from PLUGIN_EXT_DIR, defaults to false
+# SECRET_KEY - Location of the JKS secret key
 
 # JAVA_HOME - Use a specific JVM
 # JAVA_OPTS - Java options passed to the JVM on startup


### PR DESCRIPTION
Fixes #201 

Support `SECRET_KEY` env variable in start scripts