### PR TITLE
Feature / Batch operations for metadata

### DIFF
--- a/dist/scripts/service-ctrl.sh
+++ b/dist/scripts/service-ctrl.sh
@@ -196,9 +196,9 @@ run() {
     CWD=`pwd`
     cd "\${RUN_DIR}"
     if [ "\${SECRET_KEY}" = "" ]; then
-        "\${JAVA_CMD}" \${JAVA_OPTS} \$APPLICATION_CLASS --config "\${CONFIG_FILE}" \$@
+        "\${JAVA_CMD}" \${JAVA_OPTS} \$APPLICATION_CLASS --config "\${CONFIG_FILE}" "\$@"
     else
-        "\${JAVA_CMD}" \${JAVA_OPTS} \$APPLICATION_CLASS --config "\${CONFIG_FILE}" --secret-key "\${SECRET_KEY}" \$@
+        "\${JAVA_CMD}" \${JAVA_OPTS} \$APPLICATION_CLASS --config "\${CONFIG_FILE}" --secret-key "\${SECRET_KEY}" "\$@"
     fi
     cd "\${CWD}"
 }
@@ -228,9 +228,9 @@ start() {
     CWD=`pwd`
     cd "\${RUN_DIR}"
     if [ "\${SECRET_KEY}" = "" ]; then
-        "\${JAVA_CMD}" \${JAVA_OPTS} \$APPLICATION_CLASS --config "\${CONFIG_FILE}" \$@ &
+        "\${JAVA_CMD}" \${JAVA_OPTS} \$APPLICATION_CLASS --config "\${CONFIG_FILE}" "\$@" &
     else
-        "\${JAVA_CMD}" \${JAVA_OPTS} \$APPLICATION_CLASS --config "\${CONFIG_FILE}" --secret-key "\${SECRET_KEY}" \$@ &
+        "\${JAVA_CMD}" \${JAVA_OPTS} \$APPLICATION_CLASS --config "\${CONFIG_FILE}" --secret-key "\${SECRET_KEY}" "\$@" &
     fi
     PID=\$!
     cd "\${CWD}"
@@ -360,11 +360,11 @@ kill_all() {
 case "\$1" in
     run)
        shift
-       run \$@
+       run "\$@"
        ;;
     start)
        shift
-       start \$@
+       start "\$@"
        ;;
     stop)
        stop

--- a/tracdap-api/tracdap-services/src/main/proto/tracdap/api/metadata.proto
+++ b/tracdap-api/tracdap-services/src/main/proto/tracdap/api/metadata.proto
@@ -616,6 +616,7 @@ message MetadataBatchResponse {
  * @see TracMetadataApi
  */
 message MetadataWriteBatchResponse {
+
     repeated metadata.TagHeader ids = 1;
 };
 

--- a/tracdap-api/tracdap-services/src/main/proto/tracdap/api/metadata.proto
+++ b/tracdap-api/tracdap-services/src/main/proto/tracdap/api/metadata.proto
@@ -150,6 +150,39 @@ service TracMetadataApi {
     }
 
     /**
+     * Create new objects in the TRAC metadata store.
+     *
+     * To create an object, supply a metadata write request with the tenant code,
+     * object type and a definition for the item you want to save. The tag should contain
+     * all the attributes you want to set and the object definition, without an
+     * object header. TRAC will create a header when it assigns and ID for the new
+     * object. Only FLOW and CUSTOM objects can be created by this API call.
+     *
+     * Validation is performed on new objects before they are saved. Objects can
+     * fail validation because they are semantically invalid (e.g. missing
+     * required fields or inconsistencies within the object definition) or due to
+     * consistency errors (referring to other metadata items that don't exist or
+     * don't meet certain requirements).
+     *
+     * NOTE: Validation is only partially implemented in the current release.
+     *
+     * The call returns an ID responses to indicate the IDs of the newly created
+     * objects, as well as the objects and tag versions (which will always be 1).
+     *
+     * Error conditions include: Invalid request, unknown tenant, object type does
+     * not match the supplied definition, validation failure.
+     *
+     * @see tracdap.metadata.ObjectDefinition
+     * @see tracdap.metadata.TagUpdate
+     */
+    rpc createBatch (MetadataWriteBatchRequest) returns (MetadataWriteBatchResponse) {
+        option (google.api.http) = {
+            post: "/{tenant}/create-batch"
+            body: "*"
+        };
+    }
+
+    /**
      * Update an existing object in the TRAC metadata store.
      *
      * To save a new version, supply a metadata write request with the tenant code,
@@ -188,6 +221,43 @@ service TracMetadataApi {
     }
 
     /**
+     * Update existing objects in the TRAC metadata store.
+     *
+     * To save a new version, supply a metadata write request with the tenant code,
+     * object type and a tag for the item you want to save. The tag should contain
+     * all the attributes you want to set and the updated object definition, which
+     * must be supplied with the header from the *previous* version of the object.
+     * TRAC will apply the new version number when it creates the new version of
+     * the object. Only the latest version of an object can be updated and only
+     * CUSTOM objects can be updated by this API call.
+     *
+     * Validation is performed on new objects before they are saved. Objects can
+     * fail validation because they are semantically invalid (e.g. missing
+     * required fields or inconsistencies within the object definition) or due to
+     * consistency errors (referring to other metadata items that don't exist or
+     * don't meet certain requirements). For new versions, validation also covers
+     * checking for compatibility with the previous version of the object.
+     *
+     * NOTE: Validation is only partially implemented in the current release.
+     *
+     * The call returns an ID response with the ID object and the newly assigned
+     * version number, as well as the tag version (which will always be 1).
+     *
+     * Error conditions include: Invalid request, unknown tenant, unknown object
+     * ID or version, wrong object type (not the same as the prior version), object
+     * version is superseded.
+     *
+     * @see tracdap.metadata.ObjectDefinition
+     * @see tracdap.metadata.TagUpdate
+     */
+    rpc updateBatch (MetadataWriteBatchRequest) returns (MetadataWriteBatchResponse) {
+        option (google.api.http) = {
+            post: "/{tenant}/update-batch"
+            body: "*"
+        };
+    }
+
+    /**
      * Update the tag for an existing object in the TRAC metadata store.
      *
      * To save a new tag, supply a metadata write request with the tenant code,
@@ -215,6 +285,33 @@ service TracMetadataApi {
         };
     }
 
+    /**
+     * Update tags for existing objects in the TRAC metadata store.
+     *
+     * To save a new tag, supply a metadata write request with the tenant code,
+     * object type and a tag for the item you want to save. The tag should contain
+     * all the attributes you want to include in the new tag, even if they have
+     * not been changed. The object definition must be supplied with a header only,
+     * supplying an object body is an invalid request. Tags for any type of object
+     * can be updated by this API call. Only the latest version of a tag can be
+     * updated.
+     *
+     * The call returns an ID response with the ID and version of the object and
+     * the newly assigned tag number.
+     *
+     * Error conditions include: Invalid request, unknown tenant, unknown object
+     * ID, object version or tag version, wrong object type (does not match what
+     * is stored in TRAC), tag version is superseded.
+     *
+     * @see tracdap.metadata.ObjectDefinition
+     * @see tracdap.metadata.TagUpdate
+     */
+    rpc updateBatchTag (MetadataWriteBatchRequest) returns (MetadataWriteBatchResponse) {
+        option (google.api.http) = {
+            post: "/{tenant}/update-batch-tag"
+            body: "*"
+        };
+    }
 
     /**
      * Read a single object from the TRAC metadata store using a tag selector.
@@ -488,6 +585,21 @@ message MetadataBatchRequest {
 
 
 /**
+ * Request to create or update a batch of objects in the TRAC metadata store.
+ *
+ * @see TracMetadataApi
+ */
+message MetadataWriteBatchRequest {
+
+    string tenant = 1;
+
+    repeated MetadataWriteRequest requests = 2;
+
+    repeated metadata.TagUpdate batchTagUpdates = 3;
+};
+
+
+/**
  * Response to reading a batch of objects from the TRAC metadata store.
  *
  * @see TracMetadataApi
@@ -495,6 +607,16 @@ message MetadataBatchRequest {
 message MetadataBatchResponse {
 
     repeated metadata.Tag tag = 1;
+};
+
+
+/**
+ * Response to creating or updating a batch of objects in the TRAC metadata store.
+ *
+ * @see TracMetadataApi
+ */
+message MetadataWriteBatchResponse {
+    repeated metadata.TagHeader ids = 1;
 };
 
 

--- a/tracdap-api/tracdap-services/src/main/proto/tracdap/api/metadata_trusted.proto
+++ b/tracdap-api/tracdap-services/src/main/proto/tracdap/api/metadata_trusted.proto
@@ -62,6 +62,21 @@ service TrustedMetadataApi {
   }
 
   /**
+   * Create new objects in the TRAC metadata store.
+   *
+   * This call behaves identically to the equivalent public API call, without the
+   * restriction on which types of object can be saved.
+   *
+   * @see TracMetadataApi.createBatch()
+   */
+  rpc createBatch (MetadataWriteBatchRequest) returns (MetadataWriteBatchResponse) {
+    option (google.api.http) = {
+      post: "/{tenant}/trusted/create-batch"
+      body: "*"
+    };
+  }
+
+  /**
    * Update an existing object in the TRAC metadata store.
    *
    * This call behaves identically to the equivalent public API call, however it
@@ -73,6 +88,22 @@ service TrustedMetadataApi {
   rpc updateObject (MetadataWriteRequest) returns (metadata.TagHeader) {
     option (google.api.http) = {
       post: "/{tenant}/trusted/update-object"
+      body: "*"
+    };
+  }
+
+  /**
+   * Update existing objects in the TRAC metadata store.
+   *
+   * This call behaves identically to the equivalent public API call, however it
+   * can be used with any type of object that supports versioning (currently DATA
+   * and CUSTOM).
+   *
+   * @see TracMetadataApi.updateBatch()
+   */
+  rpc updateBatch (MetadataWriteBatchRequest) returns (MetadataWriteBatchResponse) {
+    option (google.api.http) = {
+      post: "/{tenant}/trusted/update-batch"
       body: "*"
     };
   }
@@ -91,6 +122,21 @@ service TrustedMetadataApi {
     };
   }
 
+  /**
+   * Update tags for existing objects in the TRAC metadata store.
+   *
+   * This call behaves identically to the equivalent public API call, however it
+   * can be used with any type of object that supports versioning (currently DATA
+   * and CUSTOM).
+   *
+   * @see TracMetadataApi.updateBatchTag()
+   */
+  rpc updateBatchTag (MetadataWriteBatchRequest) returns (MetadataWriteBatchResponse) {
+    option (google.api.http) = {
+      post: "/{tenant}/trusted/update-batch-tag"
+      body: "*"
+    };
+  }
 
   /**
    * Preallocate an object ID for an object that will be created later.

--- a/tracdap-libs/tracdap-lib-validation/src/main/java/org/finos/tracdap/common/validation/api/MetadataApiValidator.java
+++ b/tracdap-libs/tracdap-lib-validation/src/main/java/org/finos/tracdap/common/validation/api/MetadataApiValidator.java
@@ -49,6 +49,11 @@ public class MetadataApiValidator {
     private static final Descriptors.FieldDescriptor BRR_TENANT;
     private static final Descriptors.FieldDescriptor BRR_SELECTORS;
 
+    private static final Descriptors.Descriptor BATCH_WRITE_REQUEST;
+    private static final Descriptors.FieldDescriptor BWR_TENANT;
+    private static final Descriptors.FieldDescriptor BWR_REQUESTS;
+    private static final Descriptors.FieldDescriptor BWR_BATCH_TAG_UPDATES;
+
     private static final Descriptors.Descriptor METADATA_SEARCH_REQUEST;
     private static final Descriptors.FieldDescriptor MSR_TENANT;
     private static final Descriptors.FieldDescriptor MSR_SEARCH_PARAMS;
@@ -77,6 +82,11 @@ public class MetadataApiValidator {
         BRR_TENANT = field(BATCH_READ_REQUEST, MetadataBatchRequest.TENANT_FIELD_NUMBER);
         BRR_SELECTORS = field(BATCH_READ_REQUEST, MetadataBatchRequest.SELECTOR_FIELD_NUMBER);
 
+        BATCH_WRITE_REQUEST = MetadataWriteBatchRequest.getDescriptor();
+        BWR_TENANT = field(BATCH_WRITE_REQUEST, MetadataWriteBatchRequest.TENANT_FIELD_NUMBER);
+        BWR_REQUESTS = field(BATCH_WRITE_REQUEST, MetadataWriteBatchRequest.REQUESTS_FIELD_NUMBER);
+        BWR_BATCH_TAG_UPDATES = field(BATCH_WRITE_REQUEST, MetadataWriteBatchRequest.BATCHTAGUPDATES_FIELD_NUMBER);
+
         METADATA_SEARCH_REQUEST = MetadataSearchRequest.getDescriptor();
         MSR_TENANT = field(METADATA_SEARCH_REQUEST, MetadataSearchRequest.TENANT_FIELD_NUMBER);
         MSR_SEARCH_PARAMS = field(METADATA_SEARCH_REQUEST, MetadataSearchRequest.SEARCHPARAMS_FIELD_NUMBER);
@@ -92,12 +102,12 @@ public class MetadataApiValidator {
     @Validator(method = "createObject")
     public static ValidationContext createObject(MetadataWriteRequest msg, ValidationContext ctx) {
 
-        return createObject(msg, ctx, PUBLIC_API);
+        return createObject(msg, ctx, PUBLIC_API, true);
     }
 
-    static ValidationContext createObject(MetadataWriteRequest msg, ValidationContext ctx, boolean apiTrust) {
+    static ValidationContext createObject(MetadataWriteRequest msg, ValidationContext ctx, boolean apiTrust, boolean tenantRequired) {
 
-        ctx = createOrUpdate(ctx, false, apiTrust);
+        ctx = createOrUpdate(ctx, false, apiTrust, tenantRequired);
 
         ctx = ctx.push(MWR_PRIOR_VERSION)
                 .apply(CommonValidators::omitted)
@@ -112,6 +122,33 @@ public class MetadataApiValidator {
         return ctx;
     }
 
+    @Validator(method = "createBatch")
+    public static ValidationContext createBatch(MetadataWriteBatchRequest msg, ValidationContext ctx) {
+
+        return createBatch(msg, ctx, PUBLIC_API);
+    }
+
+    static ValidationContext createBatch(MetadataWriteBatchRequest msg, ValidationContext ctx, boolean apiTrust) {
+        ctx = ctx.push(BWR_TENANT)
+                .apply(CommonValidators::required)
+                .apply(CommonValidators::identifier)
+                .pop();
+
+        ctx = ctx.pushRepeated(BWR_REQUESTS)
+                .apply(CommonValidators::listNotEmpty)
+                .applyRepeated((MetadataWriteRequest r, ValidationContext c) ->
+                        MetadataApiValidator.createObject(r, c, apiTrust, false), MetadataWriteRequest.class)
+                .pop();
+
+        ctx = ctx.pushRepeated(BWR_BATCH_TAG_UPDATES)
+                .applyRepeated(TagUpdateValidator::tagUpdate, TagUpdate.class)
+                // Only allow reserved attrs for requests on the trusted API
+                .applyRepeated(TagUpdateValidator::reservedAttrs, TagUpdate.class, (apiTrust == TRUSTED_API))
+                .pop();
+
+        return ctx;
+    }
+
     @Validator(method = "updateObject")
     public static ValidationContext updateObject(MetadataWriteRequest msg, ValidationContext ctx) {
 
@@ -120,7 +157,7 @@ public class MetadataApiValidator {
 
     static ValidationContext updateObject(MetadataWriteRequest msg, ValidationContext ctx, boolean apiTrust) {
 
-        ctx = createOrUpdate(ctx, true, apiTrust);
+        ctx = createOrUpdate(ctx, true, apiTrust, true);
 
         ctx = ctx.push(MWR_PRIOR_VERSION)
                 .apply(CommonValidators::required)
@@ -146,7 +183,7 @@ public class MetadataApiValidator {
 
     static ValidationContext updateTag(MetadataWriteRequest msg, ValidationContext ctx, boolean apiTrust) {
 
-        ctx = createOrUpdate(ctx, false, apiTrust);
+        ctx = createOrUpdate(ctx, false, apiTrust, true);
 
         ctx = ctx.push(MWR_PRIOR_VERSION)
                 .apply(CommonValidators::required)
@@ -165,7 +202,7 @@ public class MetadataApiValidator {
 
     static ValidationContext preallocateId(MetadataWriteRequest msg, ValidationContext ctx) {
 
-        ctx = createOrUpdate(ctx, false, TRUSTED_API);
+        ctx = createOrUpdate(ctx, false, TRUSTED_API, true);
 
         ctx = ctx.push(MWR_PRIOR_VERSION)
                 .apply(CommonValidators::omitted)
@@ -180,7 +217,7 @@ public class MetadataApiValidator {
 
     static ValidationContext createPreallocatedObject(MetadataWriteRequest msg, ValidationContext ctx) {
 
-        ctx = createOrUpdate(ctx, false, TRUSTED_API);
+        ctx = createOrUpdate(ctx, false, TRUSTED_API, true);
 
         // Do not use the regular tag selector validator (ObjectIdValidator::tagSelector)
         // The regular validator will enforce object and tag version > 0
@@ -202,12 +239,18 @@ public class MetadataApiValidator {
         return ctx;
     }
 
-    private static ValidationContext createOrUpdate(ValidationContext ctx, boolean isVersioned, boolean apiTrust) {
+    private static ValidationContext createOrUpdate(ValidationContext ctx, boolean isVersioned, boolean apiTrust, boolean tenantRequired) {
 
-        ctx = ctx.push(MWR_TENANT)
-                .apply(CommonValidators::required)
-                .apply(CommonValidators::identifier)
-                .pop();
+        if (tenantRequired) {
+            ctx = ctx.push(MWR_TENANT)
+                    .apply(CommonValidators::required)
+                    .apply(CommonValidators::identifier)
+                    .pop();
+        } else {
+            ctx = ctx.push(MWR_TENANT)
+                    .apply(CommonValidators::omitted)
+                    .pop();
+        }
 
         ctx = ctx.push(MWR_OBJECT_TYPE)
                 .apply(CommonValidators::required)

--- a/tracdap-libs/tracdap-lib-validation/src/main/java/org/finos/tracdap/common/validation/api/MetadataTrustedApiValidator.java
+++ b/tracdap-libs/tracdap-lib-validation/src/main/java/org/finos/tracdap/common/validation/api/MetadataTrustedApiValidator.java
@@ -56,7 +56,12 @@ public class MetadataTrustedApiValidator {
 
     @Validator(method = "updateTag")
     public static ValidationContext updateTag(MetadataWriteRequest msg, ValidationContext ctx) {
-        return MetadataApiValidator.updateTag(msg, ctx, MetadataApiValidator.TRUSTED_API);
+        return MetadataApiValidator.updateTag(msg, ctx, MetadataApiValidator.TRUSTED_API, true);
+    }
+
+    @Validator(method = "updateBatchTag")
+    public static ValidationContext updateBatchTag(MetadataWriteBatchRequest msg, ValidationContext ctx) {
+        return MetadataApiValidator.updateBatchTag(msg, ctx, MetadataApiValidator.TRUSTED_API);
     }
 
     @Validator(method = "preallocateId")

--- a/tracdap-libs/tracdap-lib-validation/src/main/java/org/finos/tracdap/common/validation/api/MetadataTrustedApiValidator.java
+++ b/tracdap-libs/tracdap-lib-validation/src/main/java/org/finos/tracdap/common/validation/api/MetadataTrustedApiValidator.java
@@ -20,7 +20,6 @@ import org.finos.tracdap.api.*;
 import org.finos.tracdap.common.validation.core.ValidationContext;
 import org.finos.tracdap.common.validation.core.ValidationType;
 import org.finos.tracdap.common.validation.core.Validator;
-import org.finos.tracdap.common.validation.static_.CommonValidators;
 
 
 @Validator(type = ValidationType.STATIC, serviceFile = MetadataTrusted.class, serviceName = TrustedMetadataApiGrpc.SERVICE_NAME)
@@ -37,7 +36,12 @@ public class MetadataTrustedApiValidator {
 
     @Validator(method = "createObject")
     public static ValidationContext createObject(MetadataWriteRequest msg, ValidationContext ctx) {
-        return MetadataApiValidator.createObject(msg, ctx, MetadataApiValidator.TRUSTED_API);
+        return MetadataApiValidator.createObject(msg, ctx, MetadataApiValidator.TRUSTED_API, true);
+    }
+
+    @Validator(method = "createBatch")
+    public static ValidationContext createBatch(MetadataWriteBatchRequest msg, ValidationContext ctx) {
+        return MetadataApiValidator.createBatch(msg, ctx, MetadataApiValidator.TRUSTED_API);
     }
 
     @Validator(method = "updateObject")

--- a/tracdap-libs/tracdap-lib-validation/src/main/java/org/finos/tracdap/common/validation/api/MetadataTrustedApiValidator.java
+++ b/tracdap-libs/tracdap-lib-validation/src/main/java/org/finos/tracdap/common/validation/api/MetadataTrustedApiValidator.java
@@ -46,7 +46,12 @@ public class MetadataTrustedApiValidator {
 
     @Validator(method = "updateObject")
     public static ValidationContext updateObject(MetadataWriteRequest msg, ValidationContext ctx) {
-        return MetadataApiValidator.updateObject(msg, ctx, MetadataApiValidator.TRUSTED_API);
+        return MetadataApiValidator.updateObject(msg, ctx, MetadataApiValidator.TRUSTED_API, true);
+    }
+
+    @Validator(method = "updateBatch")
+    public static ValidationContext updateBatch(MetadataWriteBatchRequest msg, ValidationContext ctx) {
+        return MetadataApiValidator.updateBatch(msg, ctx, MetadataApiValidator.TRUSTED_API);
     }
 
     @Validator(method = "updateTag")

--- a/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/api/MetadataApiImpl.java
+++ b/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/api/MetadataApiImpl.java
@@ -125,7 +125,20 @@ public class MetadataApiImpl {
 
         validateRequest(UPDATE_BATCH_METHOD, request);
 
-        return runWriteBatch(request, MetadataApiImpl::updateObject);
+        List<MetadataWriteRequest> requestsList = request.getRequestsList();
+
+        for (MetadataWriteRequest rq : requestsList) {
+            validateObjectType(rq.getObjectType());
+        }
+
+        List<TagHeader> tagHeaders = writeService.updateObjects(
+                request.getTenant(),
+                requestsList,
+                request.getBatchTagUpdatesList()
+        );
+        return MetadataWriteBatchResponse.newBuilder()
+                .addAllIds(tagHeaders)
+                .build();
     }
 
     private void validateObjectType(ObjectType objectType) {

--- a/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/api/MetadataApiImpl.java
+++ b/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/api/MetadataApiImpl.java
@@ -94,6 +94,12 @@ public class MetadataApiImpl {
                 request.getTagUpdatesList());
     }
 
+    CompletableFuture<MetadataWriteBatchResponse> createBatch(MetadataWriteBatchRequest request) {
+        validateRequest(CREATE_BATCH_METHOD, request);
+
+        return null;  // TODO
+    }
+
     CompletableFuture<TagHeader> updateObject(MetadataWriteRequest request) {
 
         validateRequest(UPDATE_OBJECT_METHOD, request);
@@ -113,6 +119,12 @@ public class MetadataApiImpl {
                 request.getTagUpdatesList());
     }
 
+    CompletableFuture<MetadataWriteBatchResponse> updateBatch(MetadataWriteBatchRequest request) {
+        validateRequest(UPDATE_BATCH_METHOD, request);
+
+        return null;  // TODO
+    }
+
     CompletableFuture<TagHeader> updateTag(MetadataWriteRequest request) {
 
         validateRequest(UPDATE_TAG_METHOD, request);
@@ -121,6 +133,12 @@ public class MetadataApiImpl {
                 request.getTenant(),
                 request.getPriorVersion(),
                 request.getTagUpdatesList());
+    }
+
+    CompletableFuture<MetadataWriteBatchResponse> updateBatchTag(MetadataWriteBatchRequest request) {
+        validateRequest(UPDATE_BATCH_METHOD, request);
+
+        return null;  // TODO
     }
 
     CompletableFuture<TagHeader> preallocateId(MetadataWriteRequest request) {

--- a/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/api/TracMetadataApi.java
+++ b/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/api/TracMetadataApi.java
@@ -39,8 +39,11 @@ public class TracMetadataApi extends TracMetadataApiGrpc.TracMetadataApiImplBase
     static final MethodDescriptor<ListTenantsRequest, ListTenantsResponse> LIST_TENANTS_METHOD = TracMetadataApiGrpc.getListTenantsMethod();
 
     static final MethodDescriptor<MetadataWriteRequest, TagHeader> CREATE_OBJECT_METHOD = TracMetadataApiGrpc.getCreateObjectMethod();
+    static final MethodDescriptor<MetadataWriteBatchRequest, MetadataWriteBatchResponse> CREATE_BATCH_METHOD = TracMetadataApiGrpc.getCreateBatchMethod();
     static final MethodDescriptor<MetadataWriteRequest, TagHeader> UPDATE_OBJECT_METHOD = TracMetadataApiGrpc.getUpdateObjectMethod();
+    static final MethodDescriptor<MetadataWriteBatchRequest, MetadataWriteBatchResponse> UPDATE_BATCH_METHOD = TracMetadataApiGrpc.getUpdateBatchMethod();
     static final MethodDescriptor<MetadataWriteRequest, TagHeader> UPDATE_TAG_METHOD = TracMetadataApiGrpc.getUpdateTagMethod();
+    static final MethodDescriptor<MetadataWriteBatchRequest, MetadataWriteBatchResponse> UPDATE_BATCH_TAG_METHOD = TracMetadataApiGrpc.getUpdateBatchTagMethod();
 
     static final MethodDescriptor<MetadataReadRequest, Tag> READ_OBJECT_METHOD = TracMetadataApiGrpc.getReadObjectMethod();
     static final MethodDescriptor<MetadataBatchRequest, MetadataBatchResponse> READ_BATCH_METHOD = TracMetadataApiGrpc.getReadBatchMethod();
@@ -84,15 +87,33 @@ public class TracMetadataApi extends TracMetadataApiGrpc.TracMetadataApiImplBase
     }
 
     @Override
+    public void createBatch(MetadataWriteBatchRequest request, StreamObserver<MetadataWriteBatchResponse> response) {
+
+        grpcWrap.unaryCall(CREATE_BATCH_METHOD, request, response, apiImpl::createBatch);
+    }
+
+    @Override
     public void updateObject(MetadataWriteRequest request, StreamObserver<TagHeader> response) {
 
         grpcWrap.unaryCall(UPDATE_OBJECT_METHOD, request, response, apiImpl::updateObject);
     }
 
     @Override
+    public void updateBatch(MetadataWriteBatchRequest request, StreamObserver<MetadataWriteBatchResponse> response) {
+
+        grpcWrap.unaryCall(UPDATE_BATCH_METHOD, request, response, apiImpl::updateBatch);
+    }
+
+    @Override
     public void updateTag(MetadataWriteRequest request, StreamObserver<TagHeader> response) {
 
         grpcWrap.unaryCall(UPDATE_TAG_METHOD, request, response, apiImpl::updateTag);
+    }
+
+    @Override
+    public void updateBatchTag(MetadataWriteBatchRequest request, StreamObserver<MetadataWriteBatchResponse> response) {
+
+        grpcWrap.unaryCall(UPDATE_BATCH_TAG_METHOD, request, response, apiImpl::updateBatchTag);
     }
 
     @Override

--- a/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/api/TrustedMetadataApi.java
+++ b/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/api/TrustedMetadataApi.java
@@ -36,8 +36,11 @@ public class TrustedMetadataApi extends TrustedMetadataApiGrpc.TrustedMetadataAp
     private static final Descriptors.ServiceDescriptor TRUSTED_METADATA_SERVICE = MetadataTrusted.getDescriptor().findServiceByName(SERVICE_NAME);
 
     private static final MethodDescriptor<MetadataWriteRequest, TagHeader> CREATE_OBJECT_METHOD = TrustedMetadataApiGrpc.getCreateObjectMethod();
+    private static final MethodDescriptor<MetadataWriteBatchRequest, MetadataWriteBatchResponse> CREATE_BATCH_METHOD = TrustedMetadataApiGrpc.getCreateBatchMethod();
     private static final MethodDescriptor<MetadataWriteRequest, TagHeader> UPDATE_OBJECT_METHOD = TrustedMetadataApiGrpc.getUpdateObjectMethod();
+    private static final MethodDescriptor<MetadataWriteBatchRequest, MetadataWriteBatchResponse> UPDATE_BATCH_METHOD = TrustedMetadataApiGrpc.getUpdateBatchMethod();
     private static final MethodDescriptor<MetadataWriteRequest, TagHeader> UPDATE_TAG_METHOD = TrustedMetadataApiGrpc.getUpdateTagMethod();
+    private static final MethodDescriptor<MetadataWriteBatchRequest, MetadataWriteBatchResponse> UPDATE_BATCH_TAG_METHOD = TrustedMetadataApiGrpc.getUpdateBatchTagMethod();
     static final MethodDescriptor<MetadataWriteRequest, TagHeader> PREALLOCATE_ID_METHOD = TrustedMetadataApiGrpc.getPreallocateIdMethod();
     static final MethodDescriptor<MetadataWriteRequest, TagHeader> CREATE_PREALLOCATED_OBJECT_METHOD = TrustedMetadataApiGrpc.getCreatePreallocatedObjectMethod();
 
@@ -68,15 +71,33 @@ public class TrustedMetadataApi extends TrustedMetadataApiGrpc.TrustedMetadataAp
     }
 
     @Override
+    public void createBatch(MetadataWriteBatchRequest request, StreamObserver<MetadataWriteBatchResponse> response) {
+
+        grpcWrap.unaryCall(CREATE_BATCH_METHOD, request, response, apiImpl::createBatch);
+    }
+
+    @Override
     public void updateObject(MetadataWriteRequest request, StreamObserver<TagHeader> response) {
 
         grpcWrap.unaryCall(UPDATE_OBJECT_METHOD, request, response, apiImpl::updateObject);
     }
 
     @Override
+    public void updateBatch(MetadataWriteBatchRequest request, StreamObserver<MetadataWriteBatchResponse> response) {
+
+        grpcWrap.unaryCall(UPDATE_BATCH_METHOD, request, response, apiImpl::updateBatch);
+    }
+
+    @Override
     public void updateTag(MetadataWriteRequest request, StreamObserver<TagHeader> response) {
 
         grpcWrap.unaryCall(UPDATE_TAG_METHOD, request, response, apiImpl::updateTag);
+    }
+
+    @Override
+    public void updateBatchTag(MetadataWriteBatchRequest request, StreamObserver<MetadataWriteBatchResponse> response) {
+
+        grpcWrap.unaryCall(UPDATE_BATCH_TAG_METHOD, request, response, apiImpl::updateBatchTag);
     }
 
     @Override

--- a/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/services/MetadataWriteService.java
+++ b/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/services/MetadataWriteService.java
@@ -64,7 +64,7 @@ public class MetadataWriteService {
             List<TagUpdate> batchTagUpdates) {
         List<Tag> newTags = new ArrayList<>();
         for (MetadataWriteRequest request : requests) {
-            List<TagUpdate> tagUpdates = request.getTagUpdatesList();
+            List<TagUpdate> tagUpdates = new ArrayList<>(request.getTagUpdatesList());
             tagUpdates.addAll(batchTagUpdates);
 
             newTags.add(

--- a/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/services/MetadataWriteService.java
+++ b/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/services/MetadataWriteService.java
@@ -219,7 +219,7 @@ public class MetadataWriteService {
         List<Tag> newTags = new ArrayList<>();
         for (int i = 0; i < requests.size(); i++) {
             MetadataWriteRequest r = requests.get(i);
-            List<TagUpdate> tagUpdates = r.getTagUpdatesList();
+            List<TagUpdate> tagUpdates = new ArrayList<>(r.getTagUpdatesList());
             tagUpdates.addAll(batchTagUpdates);
 
             newTags.add(

--- a/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/services/MetadataWriteService.java
+++ b/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/services/MetadataWriteService.java
@@ -144,7 +144,7 @@ public class MetadataWriteService {
         List<Tag> newTags = new ArrayList<>();
         for (int i = 0; i < requests.size(); i++) {
             MetadataWriteRequest r = requests.get(i);
-            List<TagUpdate> tagUpdates = r.getTagUpdatesList();
+            List<TagUpdate> tagUpdates = new ArrayList<>(r.getTagUpdatesList());
             tagUpdates.addAll(batchTagUpdates);
 
             newTags.add(


### PR DESCRIPTION
Add batch operations to metadata (trusted and public API).

Operations:

- `createBatch`
- `updateBatch`
- `updateBatchTag`
