### PR TITLE
Feature / Batch preallocate operations for metadata

### DIFF
--- a/tracdap-api/tracdap-services/src/main/proto/tracdap/api/metadata_trusted.proto
+++ b/tracdap-api/tracdap-services/src/main/proto/tracdap/api/metadata_trusted.proto
@@ -160,6 +160,26 @@ service TrustedMetadataApi {
   }
 
   /**
+   * Preallocate object IDs in batch for objects that will be created later.
+   *
+   * This call is for use by TRAC components that need to reserve an ID before
+   * it is used, particularly if the object ID must be included in the definition
+   * of an object that has not been created yet. When creating an ID the tenant
+   * and object type must be specified, the object that is eventually saved must
+   * match these two conditions. Orphan IDs are expected - if a component request
+   * an ID and encounters an error before that ID is used, the orphan ID is just
+   * ignored.
+   *
+   * @see TrustedMetadataApi.preallocateId()
+   */
+  rpc preallocateIdBatch (MetadataWriteBatchRequest) returns (MetadataWriteBatchResponse) {
+    option (google.api.http) = {
+      post: "/{tenant}/trusted/preallocate-batch"
+      body: "*"
+    };
+  }
+
+  /**
    * Create an object using an ID that was previously preallocated.
    *
    * This call behaves essentially the same as saveNewObject(), with all the
@@ -174,6 +194,27 @@ service TrustedMetadataApi {
   rpc createPreallocatedObject (MetadataWriteRequest) returns (metadata.TagHeader) {
     option (google.api.http) = {
       post: "/{tenant}/trusted/create-preallocated"
+      body: "*"
+    };
+  }
+
+  /**
+   * Create objects in batch using IDs that were previously preallocated.
+   *
+   * This call behaves essentially the same as saveNewObject(), with all the
+   * same validation. The only difference is that the new definition must be
+   * supplied with an object header, including the object ID returned from a
+   * prior call to preallocateId().
+   *
+   * Error conditions include all the error conditions for saveNewObject().
+   * Using a preallocated ID twice, attempting to save to an unknown ID or the
+   * ID of another object that already exists are also errors.
+   *
+   * @see TrustedMetadataApi.createPreallocatedObject()
+   */
+  rpc createPreallocatedObjectBatch (MetadataWriteBatchRequest) returns (MetadataWriteBatchResponse) {
+    option (google.api.http) = {
+      post: "/{tenant}/trusted/create-preallocated-batch"
       body: "*"
     };
   }

--- a/tracdap-libs/tracdap-lib-validation/src/main/java/org/finos/tracdap/common/validation/api/MetadataTrustedApiValidator.java
+++ b/tracdap-libs/tracdap-lib-validation/src/main/java/org/finos/tracdap/common/validation/api/MetadataTrustedApiValidator.java
@@ -69,9 +69,19 @@ public class MetadataTrustedApiValidator {
         return MetadataApiValidator.preallocateId(msg, ctx);  // always a trusted call
     }
 
+    @Validator(method = "preallocateIdBatch")
+    public static ValidationContext preallocateIdBatch(MetadataWriteBatchRequest msg, ValidationContext ctx) {
+        return MetadataApiValidator.preallocateIdBatch(msg, ctx);  // always a trusted call
+    }
+
     @Validator(method = "createPreallocatedObject")
     public static ValidationContext createPreallocatedObject(MetadataWriteRequest msg, ValidationContext ctx) {
         return MetadataApiValidator.createPreallocatedObject(msg, ctx);  // always a trusted call
+    }
+
+    @Validator(method = "createPreallocatedObjectBatch")
+    public static ValidationContext createPreallocatedObjectBatch(MetadataWriteBatchRequest msg, ValidationContext ctx) {
+        return MetadataApiValidator.createPreallocatedObjectBatch(msg, ctx);  // always a trusted call
     }
 
     @Validator(method = "readObject")

--- a/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/api/MetadataApiImpl.java
+++ b/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/api/MetadataApiImpl.java
@@ -29,11 +29,14 @@ import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static org.finos.tracdap.common.metadata.MetadataConstants.PUBLIC_WRITABLE_OBJECT_TYPES;
 import static org.finos.tracdap.svc.meta.api.TracMetadataApi.*;
 import static org.finos.tracdap.svc.meta.api.TrustedMetadataApi.CREATE_PREALLOCATED_OBJECT_METHOD;
+import static org.finos.tracdap.svc.meta.api.TrustedMetadataApi.CREATE_PREALLOCATED_OBJECT_BATCH_METHOD;
 import static org.finos.tracdap.svc.meta.api.TrustedMetadataApi.PREALLOCATE_ID_METHOD;
+import static org.finos.tracdap.svc.meta.api.TrustedMetadataApi.PREALLOCATE_ID_BATCH_METHOD;
 import static org.finos.tracdap.svc.meta.services.MetadataConstants.PUBLIC_API;
 
 
@@ -182,6 +185,21 @@ public class MetadataApiImpl {
         return writeService.preallocateId(tenant, objectType);
     }
 
+    MetadataWriteBatchResponse preallocateIdBatch(MetadataWriteBatchRequest request) {
+
+        validateRequest(PREALLOCATE_ID_BATCH_METHOD, request);
+
+        var tenant = request.getTenant();
+        var objectTypes = request.getRequestsList().stream()
+                .map(MetadataWriteRequest::getObjectType)
+                .collect(Collectors.toList());
+
+        var tagHeaders = writeService.preallocateIdBatch(tenant, objectTypes);
+        return MetadataWriteBatchResponse.newBuilder()
+                .addAllHeaders(tagHeaders)
+                .build();
+    }
+
     TagHeader createPreallocatedObject(MetadataWriteRequest request) {
 
         validateRequest(CREATE_PREALLOCATED_OBJECT_METHOD, request);
@@ -191,6 +209,20 @@ public class MetadataApiImpl {
                 request.getPriorVersion(),
                 request.getDefinition(),
                 request.getTagUpdatesList());
+    }
+
+    MetadataWriteBatchResponse createPreallocatedObjectBatch(MetadataWriteBatchRequest request) {
+
+        validateRequest(CREATE_PREALLOCATED_OBJECT_BATCH_METHOD, request);
+
+        var tagHeaders = writeService.createPreallocatedObjectBatch(
+                request.getTenant(),
+                request.getRequestsList(),
+                request.getBatchAttrsList()
+        );
+        return MetadataWriteBatchResponse.newBuilder()
+                .addAllHeaders(tagHeaders)
+                .build();
     }
 
     Tag readObject(MetadataReadRequest request) {

--- a/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/api/TrustedMetadataApi.java
+++ b/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/api/TrustedMetadataApi.java
@@ -42,7 +42,9 @@ public class TrustedMetadataApi extends TrustedMetadataApiGrpc.TrustedMetadataAp
     private static final MethodDescriptor<MetadataWriteRequest, TagHeader> UPDATE_TAG_METHOD = TrustedMetadataApiGrpc.getUpdateTagMethod();
     private static final MethodDescriptor<MetadataWriteBatchRequest, MetadataWriteBatchResponse> UPDATE_TAG_BATCH_METHOD = TrustedMetadataApiGrpc.getUpdateTagBatchMethod();
     static final MethodDescriptor<MetadataWriteRequest, TagHeader> PREALLOCATE_ID_METHOD = TrustedMetadataApiGrpc.getPreallocateIdMethod();
+    static final MethodDescriptor<MetadataWriteBatchRequest, MetadataWriteBatchResponse> PREALLOCATE_ID_BATCH_METHOD = TrustedMetadataApiGrpc.getPreallocateIdBatchMethod();
     static final MethodDescriptor<MetadataWriteRequest, TagHeader> CREATE_PREALLOCATED_OBJECT_METHOD = TrustedMetadataApiGrpc.getCreatePreallocatedObjectMethod();
+    static final MethodDescriptor<MetadataWriteBatchRequest, MetadataWriteBatchResponse> CREATE_PREALLOCATED_OBJECT_BATCH_METHOD = TrustedMetadataApiGrpc.getCreatePreallocatedObjectBatchMethod();
 
     private static final MethodDescriptor<MetadataReadRequest, Tag> READ_OBJECT_METHOD = TrustedMetadataApiGrpc.getReadObjectMethod();
     private static final MethodDescriptor<MetadataBatchRequest, MetadataBatchResponse> READ_BATCH_METHOD = TrustedMetadataApiGrpc.getReadBatchMethod();
@@ -107,9 +109,21 @@ public class TrustedMetadataApi extends TrustedMetadataApiGrpc.TrustedMetadataAp
     }
 
     @Override
+    public void preallocateIdBatch(MetadataWriteBatchRequest request, StreamObserver<MetadataWriteBatchResponse> response) {
+
+        grpcWrap.unaryCall(PREALLOCATE_ID_BATCH_METHOD, request, response, apiImpl::preallocateIdBatch);
+    }
+
+    @Override
     public void createPreallocatedObject(MetadataWriteRequest request, StreamObserver<TagHeader> response) {
 
         grpcWrap.unaryCall(CREATE_PREALLOCATED_OBJECT_METHOD, request, response, apiImpl::createPreallocatedObject);
+    }
+
+    @Override
+    public void createPreallocatedObjectBatch(MetadataWriteBatchRequest request, StreamObserver<MetadataWriteBatchResponse> response) {
+
+        grpcWrap.unaryCall(CREATE_PREALLOCATED_OBJECT_BATCH_METHOD, request, response, apiImpl::createPreallocatedObjectBatch);
     }
 
     @Override


### PR DESCRIPTION
Add preallocate batch operations to metadata (trusted API).

Operations:

* `preallocateIdBatch`
* `createPreallocatedObjectBatch`
