### PR TITLE
Feature / Remove non-batch methods from IMetadataDal

### DIFF
--- a/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/dal/IMetadataDal.java
+++ b/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/dal/IMetadataDal.java
@@ -26,15 +26,9 @@ public interface IMetadataDal {
 
     List<TenantInfo> listTenants();
 
-    void saveNewObject(String tenant, Tag tag);
-
     void saveNewObjects(String tenant, List<Tag> tags);
 
-    void saveNewVersion(String tenant, Tag tag);
-
     void saveNewVersions(String tenant, List<Tag> tags);
-
-    void saveNewTag(String tenant, Tag tag);
 
     void saveNewTags(String tenant, List<Tag> tags);
 

--- a/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/dal/jdbc/JdbcMetadataDal.java
+++ b/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/dal/jdbc/JdbcMetadataDal.java
@@ -98,10 +98,6 @@ public class JdbcMetadataDal extends JdbcBaseDal implements IMetadataDal {
     public void saveNewObjects(String tenant, List<Tag> tags) {
 
         var parts = separateParts(tags);
-        saveNewObjects(tenant, parts);
-    }
-
-    private void saveNewObjects(String tenant, ObjectParts parts) {
 
         wrapTransaction(conn -> {
 
@@ -121,10 +117,6 @@ public class JdbcMetadataDal extends JdbcBaseDal implements IMetadataDal {
     public void saveNewVersions(String tenant, List<Tag> tags) {
 
         var parts = separateParts(tags);
-        saveNewVersions(tenant, parts);
-    }
-
-    private void saveNewVersions(String tenant, ObjectParts parts) {
 
         wrapTransaction(conn -> {
 
@@ -148,10 +140,6 @@ public class JdbcMetadataDal extends JdbcBaseDal implements IMetadataDal {
     public void saveNewTags(String tenant, List<Tag> tags) {
 
         var parts = separateParts(tags);
-        saveNewTags(tenant, parts);
-    }
-
-    private void saveNewTags(String tenant, ObjectParts parts) {
 
         wrapTransaction(conn -> {
 

--- a/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/dal/jdbc/JdbcMetadataDal.java
+++ b/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/dal/jdbc/JdbcMetadataDal.java
@@ -94,14 +94,6 @@ public class JdbcMetadataDal extends JdbcBaseDal implements IMetadataDal {
     // So, use the same implementation for save one and save many
     // I.e. no special optimisation for saving a single item, even though this is the common case
 
-
-    @Override
-    public void saveNewObject(String tenant, Tag tag) {
-
-        var parts = separateParts(tag);
-        saveNewObjects(tenant, parts);
-    }
-
     @Override
     public void saveNewObjects(String tenant, List<Tag> tags) {
 
@@ -123,13 +115,6 @@ public class JdbcMetadataDal extends JdbcBaseDal implements IMetadataDal {
             writeBatch.writeTagAttrs(conn, tenantId, tagPk, parts);
         },
         (error, code) ->  JdbcError.handleDuplicateObjectId(error, code, parts));
-    }
-
-    @Override
-    public void saveNewVersion(String tenant, Tag tag) {
-
-        var parts = separateParts(tag);
-        saveNewVersions(tenant, parts);
     }
 
     @Override
@@ -157,13 +142,6 @@ public class JdbcMetadataDal extends JdbcBaseDal implements IMetadataDal {
         (error, code) -> JdbcError.handleMissingItem(error, code, parts),
         (error, code) ->  JdbcError.handleDuplicateObjectId(error, code, parts),
         (error, code) ->  JdbcError.newVersion_WrongType(error, code, parts));
-    }
-
-    @Override
-    public void saveNewTag(String tenant, Tag tag) {
-
-        var parts = separateParts(tag);
-        saveNewTags(tenant, parts);
     }
 
     @Override

--- a/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/services/MetadataWriteService.java
+++ b/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/services/MetadataWriteService.java
@@ -29,6 +29,7 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -53,7 +54,7 @@ public class MetadataWriteService {
 
         var newTag = prepareCreateObject(UUID.randomUUID(), definition, tagUpdates);
 
-        dal.saveNewObject(tenant, newTag);
+        dal.saveNewObjects(tenant, Collections.singletonList(newTag));
 
         return newTag.getHeader();
     }
@@ -121,7 +122,7 @@ public class MetadataWriteService {
 
         var newTag = prepareUpdateObject(userInfo, priorTag, definition, tagUpdates);
 
-        dal.saveNewVersion(tenant, newTag);
+        dal.saveNewVersions(tenant, Collections.singletonList(newTag));
 
         return newTag.getHeader();
     }
@@ -195,7 +196,7 @@ public class MetadataWriteService {
 
         var newTag = prepareUpdateTag(priorTag, tagUpdates);
 
-        dal.saveNewTag(tenant, newTag);
+        dal.saveNewTags(tenant, Collections.singletonList(newTag));
 
         return newTag.getHeader();
     }

--- a/tracdap-services/tracdap-svc-meta/src/test/java/org/finos/tracdap/svc/meta/dal/MetadataDalEncodingTest.java
+++ b/tracdap-services/tracdap-svc-meta/src/test/java/org/finos/tracdap/svc/meta/dal/MetadataDalEncodingTest.java
@@ -22,6 +22,7 @@ import org.finos.tracdap.common.metadata.MetadataCodec;
 
 import java.math.BigDecimal;
 import java.time.*;
+import java.util.Collections;
 import java.util.UUID;
 
 import org.finos.tracdap.test.meta.IDalTestable;
@@ -63,7 +64,7 @@ abstract class MetadataDalEncodingTest implements IDalTestable {
         var origTag = dummyTag(origDef, INCLUDE_HEADER);
         var origId = UUID.fromString(origTag.getHeader().getObjectId());
 
-        dal.saveNewObject(TEST_TENANT, origTag);
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(origTag));
         var result = dal.loadTag(TEST_TENANT, ObjectType.DATA, origId, 1, 1);
 
         assertEquals(origTag, result);
@@ -77,7 +78,7 @@ abstract class MetadataDalEncodingTest implements IDalTestable {
         var origTag = dummyTagForObjectType(objectType);
         var origId = UUID.fromString(origTag.getHeader().getObjectId());
 
-        dal.saveNewObject(TEST_TENANT, origTag);
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(origTag));
         var result = dal.loadTag(TEST_TENANT, objectType, origId, 1, 1);
 
         assertEquals(origTag, result);
@@ -99,7 +100,7 @@ abstract class MetadataDalEncodingTest implements IDalTestable {
                 .putAttrs(attrName, MetadataCodec.encodeNativeObject(attrValue))
                 .build();
 
-        dal.saveNewObject(TEST_TENANT, testTag);
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(testTag));
         var result = dal.loadTag(TEST_TENANT, ObjectType.DATA, origId, 1, 1);
 
         assertEquals(testTag, result);

--- a/tracdap-services/tracdap-svc-meta/src/test/java/org/finos/tracdap/svc/meta/dal/MetadataDalReadTest.java
+++ b/tracdap-services/tracdap-svc-meta/src/test/java/org/finos/tracdap/svc/meta/dal/MetadataDalReadTest.java
@@ -22,6 +22,7 @@ import org.finos.tracdap.common.metadata.MetadataCodec;
 import org.finos.tracdap.common.exception.EMetadataNotFound;
 import org.finos.tracdap.common.exception.EMetadataWrongType;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -63,9 +64,9 @@ abstract class MetadataDalReadTest implements IDalTestable {
         var origId = UUID.fromString(origTag.getHeader().getObjectId());
 
         // Save v1 t1, v2 t1, v2 t2
-        dal.saveNewObject(TEST_TENANT, origTag);
-        dal.saveNewVersion(TEST_TENANT, nextDefTag1);
-        dal.saveNewTag(TEST_TENANT, nextDefTag2);
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(origTag));
+        dal.saveNewVersions(TEST_TENANT, Collections.singletonList(nextDefTag1));
+        dal.saveNewTags(TEST_TENANT, Collections.singletonList(nextDefTag2));
 
         var selector = TagSelector.newBuilder()
                 .setObjectType(ObjectType.DATA)
@@ -95,9 +96,9 @@ abstract class MetadataDalReadTest implements IDalTestable {
         var origId = UUID.fromString(origTag.getHeader().getObjectId());
 
         // Save v1 t1, v2 t1, v2 t2
-        dal.saveNewObject(TEST_TENANT, origTag);
-        dal.saveNewVersion(TEST_TENANT, nextDefTag1);
-        dal.saveNewTag(TEST_TENANT, nextDefTag2);
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(origTag));
+        dal.saveNewVersions(TEST_TENANT, Collections.singletonList(nextDefTag1));
+        dal.saveNewTags(TEST_TENANT, Collections.singletonList(nextDefTag2));
 
         var selector = TagSelector.newBuilder()
                 .setObjectType(ObjectType.DATA)
@@ -130,9 +131,9 @@ abstract class MetadataDalReadTest implements IDalTestable {
         Thread.sleep(1);
         var nextDefTag2 = nextTag(nextDefTag1, UPDATE_TAG_VERSION);
 
-        dal.saveNewObject(TEST_TENANT, origTag);
-        dal.saveNewVersion(TEST_TENANT, nextDefTag1);
-        dal.saveNewTag(TEST_TENANT, nextDefTag2);
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(origTag));
+        dal.saveNewVersions(TEST_TENANT, Collections.singletonList(nextDefTag1));
+        dal.saveNewTags(TEST_TENANT, Collections.singletonList(nextDefTag2));
 
         var origId = UUID.fromString(origTag.getHeader().getObjectId());
         var v1t1AsOf = MetadataCodec.decodeDatetime(origTag.getHeader().getTagTimestamp()).plusNanos(500000);
@@ -180,9 +181,9 @@ abstract class MetadataDalReadTest implements IDalTestable {
         Thread.sleep(1);
         var nextDefTag2 = nextTag(nextDefTag1, UPDATE_TAG_VERSION);
 
-        dal.saveNewObject(TEST_TENANT, origTag);
-        dal.saveNewVersion(TEST_TENANT, nextDefTag1);
-        dal.saveNewTag(TEST_TENANT, nextDefTag2);
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(origTag));
+        dal.saveNewVersions(TEST_TENANT, Collections.singletonList(nextDefTag1));
+        dal.saveNewTags(TEST_TENANT, Collections.singletonList(nextDefTag2));
 
         var origId = UUID.fromString(origTag.getHeader().getObjectId());
         var v1t1AsOf = MetadataCodec.decodeDatetime(origTag.getHeader().getTagTimestamp()).plusNanos(500000);
@@ -236,13 +237,13 @@ abstract class MetadataDalReadTest implements IDalTestable {
                 .setLatestTag(true)
                 .build();
 
-        dal.saveNewObject(TEST_TENANT, origTag);
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(origTag));
         var v1t1 = dal.loadObject(TEST_TENANT, selector);
 
-        dal.saveNewVersion(TEST_TENANT, nextDefTag1);
+        dal.saveNewVersions(TEST_TENANT, Collections.singletonList(nextDefTag1));
         var v2t1 = dal.loadObject(TEST_TENANT, selector);
-        
-        dal.saveNewTag(TEST_TENANT, nextDefTag2);
+
+        dal.saveNewTags(TEST_TENANT, Collections.singletonList(nextDefTag2));
         var v2t2 = dal.loadObject(TEST_TENANT, selector);
 
         assertEquals(origTag, v1t1);
@@ -258,7 +259,7 @@ abstract class MetadataDalReadTest implements IDalTestable {
         var extraTag = dummyTag(extraDef, INCLUDE_HEADER);
         var extraId = UUID.fromString(extraTag.getHeader().getObjectId());
 
-        dal.saveNewObject(TEST_TENANT, extraTag);
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(extraTag));
 
         var extraSelector = TagSelector.newBuilder()
                 .setObjectType(ObjectType.DATA)
@@ -280,15 +281,15 @@ abstract class MetadataDalReadTest implements IDalTestable {
                 .setLatestTag(true)
                 .build();
 
-        dal.saveNewObject(TEST_TENANT, origTag);
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(origTag));
         var v1t1Batch = dal.loadObjects(TEST_TENANT, List.of(selector, extraSelector));
         var v1t1 = v1t1Batch.get(0);
 
-        dal.saveNewVersion(TEST_TENANT, nextDefTag1);
+        dal.saveNewVersions(TEST_TENANT, Collections.singletonList(nextDefTag1));
         var v2t1Batch = dal.loadObjects(TEST_TENANT, List.of(selector, extraSelector));
         var v2t1 = v2t1Batch.get(0);
 
-        dal.saveNewTag(TEST_TENANT, nextDefTag2);
+        dal.saveNewTags(TEST_TENANT, Collections.singletonList(nextDefTag2));
         var v2t2Batch = dal.loadObjects(TEST_TENANT, List.of(selector, extraSelector));
         var v2t2 = v2t2Batch.get(0);
 
@@ -312,10 +313,10 @@ abstract class MetadataDalReadTest implements IDalTestable {
         Thread.sleep(1);
         var v3t1Tag = tagForNextObject(v2t1Tag, nextDataDef(v2t1Tag.getDefinition()), INCLUDE_HEADER);
 
-        dal.saveNewObject(TEST_TENANT, v1Tag);
-        dal.saveNewVersion(TEST_TENANT, v2t1Tag);
-        dal.saveNewTag(TEST_TENANT, v2t2Tag);
-        dal.saveNewVersion(TEST_TENANT, v3t1Tag);
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(v1Tag));
+        dal.saveNewVersions(TEST_TENANT, Collections.singletonList(v2t1Tag));
+        dal.saveNewTags(TEST_TENANT, Collections.singletonList(v2t2Tag));
+        dal.saveNewVersions(TEST_TENANT, Collections.singletonList(v3t1Tag));
 
         var origId = UUID.fromString(v1Tag.getHeader().getObjectId());
         var v2t1AsOf = MetadataCodec.decodeDatetime(v2t1Tag.getHeader().getTagTimestamp()).plusNanos(500000);
@@ -368,10 +369,10 @@ abstract class MetadataDalReadTest implements IDalTestable {
         Thread.sleep(1);
         var v3t1Tag = tagForNextObject(v2t1Tag, nextDataDef(v2t1Tag.getDefinition()), INCLUDE_HEADER);
 
-        dal.saveNewObject(TEST_TENANT, v1Tag);
-        dal.saveNewVersion(TEST_TENANT, v2t1Tag);
-        dal.saveNewTag(TEST_TENANT, v2t2Tag);
-        dal.saveNewVersion(TEST_TENANT, v3t1Tag);
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(v1Tag));
+        dal.saveNewVersions(TEST_TENANT, Collections.singletonList(v2t1Tag));
+        dal.saveNewTags(TEST_TENANT, Collections.singletonList(v2t2Tag));
+        dal.saveNewVersions(TEST_TENANT, Collections.singletonList(v3t1Tag));
 
         var origId = UUID.fromString(v1Tag.getHeader().getObjectId());
         var v2t1AsOf = MetadataCodec.decodeDatetime(v2t1Tag.getHeader().getTagTimestamp()).plusNanos(500000);
@@ -420,7 +421,7 @@ abstract class MetadataDalReadTest implements IDalTestable {
         var origTag = addMultiValuedAttr(dummyTag(origDef, INCLUDE_HEADER));
         var origId = UUID.fromString(origTag.getHeader().getObjectId());
 
-        dal.saveNewObject(TEST_TENANT, origTag);
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(origTag));
 
         var selector = TagSelector.newBuilder()
                 .setObjectType(ObjectType.DATA)
@@ -481,9 +482,9 @@ abstract class MetadataDalReadTest implements IDalTestable {
         Thread.sleep(10);
         var t2Tag = nextTag(v2Tag, UPDATE_TAG_VERSION);
 
-        dal.saveNewObject(TEST_TENANT, v1Tag);
-        dal.saveNewVersion(TEST_TENANT, v2Tag);
-        dal.saveNewTag(TEST_TENANT, t2Tag);
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(v1Tag));
+        dal.saveNewVersions(TEST_TENANT, Collections.singletonList(v2Tag));
+        dal.saveNewTags(TEST_TENANT, Collections.singletonList(t2Tag));
 
         var origId = UUID.fromString(v1Tag.getHeader().getObjectId());
 
@@ -525,9 +526,9 @@ abstract class MetadataDalReadTest implements IDalTestable {
         Thread.sleep(10);
         var t2Tag = nextTag(v2Tag, UPDATE_TAG_VERSION);
 
-        dal.saveNewObject(TEST_TENANT, v1Tag);
-        dal.saveNewVersion(TEST_TENANT, v2Tag);
-        dal.saveNewTag(TEST_TENANT, t2Tag);
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(v1Tag));
+        dal.saveNewVersions(TEST_TENANT, Collections.singletonList(v2Tag));
+        dal.saveNewTags(TEST_TENANT, Collections.singletonList(t2Tag));
 
         var origId = UUID.fromString(v1Tag.getHeader().getObjectId());
 
@@ -586,7 +587,7 @@ abstract class MetadataDalReadTest implements IDalTestable {
         assertThrows(EMetadataNotFound.class, () -> dal.loadObject(TEST_TENANT, missing4));
 
         // Save an item
-        dal.saveNewObject(TEST_TENANT, origTag);
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(origTag));
 
         // No selectors should match
         assertThrows(EMetadataNotFound.class, () -> dal.loadObject(TEST_TENANT, missing1));
@@ -602,7 +603,7 @@ abstract class MetadataDalReadTest implements IDalTestable {
         var validTag = dummyTag(validDef, INCLUDE_HEADER);
         var validId = UUID.fromString(validTag.getHeader().getObjectId());
 
-        dal.saveNewObject(TEST_TENANT, validTag);
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(validTag));
 
         var validSelector = TagSelector.newBuilder()
                 .setObjectType(ObjectType.DATA)
@@ -634,7 +635,7 @@ abstract class MetadataDalReadTest implements IDalTestable {
         assertThrows(EMetadataNotFound.class, () -> dal.loadObjects(TEST_TENANT, List.of(validSelector, missing4)));
 
         // Save an item
-        dal.saveNewObject(TEST_TENANT, origTag);
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(origTag));
 
         // No selectors should match
         assertThrows(EMetadataNotFound.class, () -> dal.loadObjects(TEST_TENANT, List.of(validSelector, missing1)));
@@ -650,7 +651,7 @@ abstract class MetadataDalReadTest implements IDalTestable {
         var origTag = dummyTag(origDef, INCLUDE_HEADER);
         var origId = UUID.fromString(origTag.getHeader().getObjectId());
 
-        dal.saveNewObject(TEST_TENANT, origTag);
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(origTag));
 
         var selector = TagSelector.newBuilder()
                 .setObjectType(ObjectType.MODEL)

--- a/tracdap-services/tracdap-svc-meta/src/test/java/org/finos/tracdap/svc/meta/dal/MetadataDalSearchTest.java
+++ b/tracdap-services/tracdap-svc-meta/src/test/java/org/finos/tracdap/svc/meta/dal/MetadataDalSearchTest.java
@@ -34,6 +34,7 @@ import java.lang.Object;
 import java.math.BigDecimal;
 import java.time.*;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -85,8 +86,8 @@ abstract class MetadataDalSearchTest implements IDalTestable {
                 .build();
 
 
-        dal.saveNewObject(TestData.TEST_TENANT, tag1);
-        dal.saveNewObject(TestData.TEST_TENANT, tag2);
+        dal.saveNewObjects(TestData.TEST_TENANT, Collections.singletonList(tag1));
+        dal.saveNewObjects(TestData.TEST_TENANT, Collections.singletonList(tag2));
 
         var searchParams = SearchParameters.newBuilder()
                 .setObjectType(ObjectType.DATA)
@@ -649,7 +650,7 @@ abstract class MetadataDalSearchTest implements IDalTestable {
                 .putAttrs(attrToLookFor, MetadataCodec.encodeArrayValue(attrValues, TypeSystem.descriptor(basicType)))
                 .build();
 
-        dal.saveNewObject(TestData.TEST_TENANT, tag);
+        dal.saveNewObjects(TestData.TEST_TENANT, Collections.singletonList(tag));
 
         var inequalities = Set.of(
                 SearchOperator.GT,
@@ -1234,10 +1235,10 @@ abstract class MetadataDalSearchTest implements IDalTestable {
         var tagV2T1 = tagForNextObject(tagV1T2, defV2, INCLUDE_HEADER);
         var tagV2T2 = TestData.nextTag(tagV2T1, UPDATE_TAG_VERSION);
 
-        dal.saveNewObject(TEST_TENANT, tagV1T1);
-        dal.saveNewTag(TEST_TENANT, tagV1T2);
-        dal.saveNewVersion(TEST_TENANT, tagV2T1);
-        dal.saveNewTag(TEST_TENANT, tagV2T2);
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(tagV1T1));
+        dal.saveNewTags(TEST_TENANT, Collections.singletonList(tagV1T2));
+        dal.saveNewVersions(TEST_TENANT, Collections.singletonList(tagV2T1));
+        dal.saveNewTags(TEST_TENANT, Collections.singletonList(tagV2T2));
 
         // A regular search with one EQ search term
         // This should bring back only the latest version / tag if no other behaviour is specified
@@ -1302,9 +1303,9 @@ abstract class MetadataDalSearchTest implements IDalTestable {
                 .putAttrs("dal_prior_version_attr", MetadataCodec.encodeValue("not_the_droids_you_are_looking_for"))
                 .build();
 
-        dal.saveNewObject(TEST_TENANT, v1Tag);
-        dal.saveNewVersion(TEST_TENANT, v2Tag);
-        dal.saveNewVersion(TEST_TENANT, v3Tag);
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(v1Tag));
+        dal.saveNewVersions(TEST_TENANT, Collections.singletonList(v2Tag));
+        dal.saveNewVersions(TEST_TENANT, Collections.singletonList(v3Tag));
 
         var searchExpr = SearchExpression.newBuilder()
                 .setTerm(SearchTerm.newBuilder()
@@ -1352,9 +1353,9 @@ abstract class MetadataDalSearchTest implements IDalTestable {
                 .putAttrs("dal_prior_tag_attr", MetadataCodec.encodeValue("not_the_droids_you_are_looking_for"))
                 .build();
 
-        dal.saveNewObject(TEST_TENANT, t1Tag);
-        dal.saveNewTag(TEST_TENANT, t2Tag);
-        dal.saveNewTag(TEST_TENANT, t3Tag);
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(t1Tag));
+        dal.saveNewTags(TEST_TENANT, Collections.singletonList(t2Tag));
+        dal.saveNewTags(TEST_TENANT, Collections.singletonList(t3Tag));
 
         var searchExpr = SearchExpression.newBuilder()
                 .setTerm(SearchTerm.newBuilder()
@@ -1398,7 +1399,7 @@ abstract class MetadataDalSearchTest implements IDalTestable {
                 .putAttrs("dal_as_of_attr_1", MetadataCodec.encodeValue("initial_value"))
                 .build();
 
-        dal.saveNewObject(TEST_TENANT, unchangedTag);
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(unchangedTag));
 
         // Ensure unchanged tag has a creation timestamp that is before the versioned object
         Thread.sleep(10);
@@ -1411,7 +1412,7 @@ abstract class MetadataDalSearchTest implements IDalTestable {
                 .putAttrs("dal_as_of_attr_1", MetadataCodec.encodeValue("initial_value"))
                 .build();
 
-        dal.saveNewObject(TEST_TENANT, v1Tag);
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(v1Tag));
 
         // Use a search timestamp after both objects have been created, but before either is updated
         var v1SearchTime = MetadataCodec.decodeDatetime(v1Tag.getHeader().getTagTimestamp()).plusNanos(5000);
@@ -1428,7 +1429,7 @@ abstract class MetadataDalSearchTest implements IDalTestable {
                 .putAttrs("dal_as_of_attr_1", MetadataCodec.encodeValue("updated_value"))
                 .build();
 
-        dal.saveNewVersion(TEST_TENANT, v2Tag);
+        dal.saveNewVersions(TEST_TENANT, Collections.singletonList(v2Tag));
 
         // Search without specifying as-of, should return only the extra object that has the original tag
 
@@ -1488,10 +1489,10 @@ abstract class MetadataDalSearchTest implements IDalTestable {
         Thread.sleep(10);
         var v2t2Tag = nextTag(v2t1Tag, UPDATE_TAG_VERSION);
 
-        dal.saveNewObject(TEST_TENANT, v1t1Tag);
-        dal.saveNewTag(TEST_TENANT, v1t2Tag);
-        dal.saveNewVersion(TEST_TENANT, v2t1Tag);
-        dal.saveNewTag(TEST_TENANT, v2t2Tag);
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(v1t1Tag));
+        dal.saveNewTags(TEST_TENANT, Collections.singletonList(v1t2Tag));
+        dal.saveNewVersions(TEST_TENANT, Collections.singletonList(v2t1Tag));
+        dal.saveNewTags(TEST_TENANT, Collections.singletonList(v2t2Tag));
 
         var preCreateTime = MetadataCodec.decodeDatetime(v1t1Tag.getHeader().getTagTimestamp()).minusNanos(5000);
         var v1t1Time = MetadataCodec.decodeDatetime(v1t1Tag.getHeader().getTagTimestamp()).plusNanos(5000);
@@ -1586,8 +1587,8 @@ abstract class MetadataDalSearchTest implements IDalTestable {
                 .putAttrs("dal_as_of_attr_4", MetadataCodec.encodeValue("the_droids_you_are_looking_for"))
                 .build();
 
-        dal.saveNewObject(TEST_TENANT, obj1t1Tag);
-        dal.saveNewObject(TEST_TENANT, obj2t1Tag);
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(obj1t1Tag));
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(obj2t1Tag));
 
         var t1Time = MetadataCodec.decodeDatetime(obj2t1Tag.getHeader().getTagTimestamp()).plusNanos(5000);
 
@@ -1603,8 +1604,8 @@ abstract class MetadataDalSearchTest implements IDalTestable {
                 .putAttrs("dal_as_of_attr_4", MetadataCodec.encodeValue("not_the_droids_you_are_looking_for"))
                 .build();
 
-        dal.saveNewTag(TEST_TENANT, obj1t2Tag);
-        dal.saveNewTag(TEST_TENANT, obj2t2Tag);
+        dal.saveNewTags(TEST_TENANT, Collections.singletonList(obj1t2Tag));
+        dal.saveNewTags(TEST_TENANT, Collections.singletonList(obj2t2Tag));
 
         var searchExpr = SearchExpression.newBuilder()
                 .setLogical(LogicalExpression.newBuilder()
@@ -1708,12 +1709,12 @@ abstract class MetadataDalSearchTest implements IDalTestable {
 
         // Save everything
 
-        dal.saveNewObject(TEST_TENANT, v1t1);
-        dal.saveNewTag(TEST_TENANT, v1t2);
-        dal.saveNewTag(TEST_TENANT, v1t3);
-        dal.saveNewVersion(TEST_TENANT, v2t1);
-        dal.saveNewTag(TEST_TENANT, v1t4);
-        dal.saveNewVersion(TEST_TENANT, v3t1);
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(v1t1));
+        dal.saveNewTags(TEST_TENANT, Collections.singletonList(v1t2));
+        dal.saveNewTags(TEST_TENANT, Collections.singletonList(v1t3));
+        dal.saveNewVersions(TEST_TENANT, Collections.singletonList(v2t1));
+        dal.saveNewTags(TEST_TENANT, Collections.singletonList(v1t4));
+        dal.saveNewVersions(TEST_TENANT, Collections.singletonList(v3t1));
 
         var searchExpr = SearchExpression.newBuilder()
                 .setLogical(LogicalExpression.newBuilder()
@@ -1769,8 +1770,8 @@ abstract class MetadataDalSearchTest implements IDalTestable {
 
         // Save objects in the wrong order to try to confuse the DAL
 
-        dal.saveNewObject(TEST_TENANT, obj2Tag);
-        dal.saveNewObject(TEST_TENANT, obj1Tag);
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(obj2Tag));
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(obj1Tag));
 
         var searchParams = SearchParameters.newBuilder()
                 .setObjectType(ObjectType.DATA)

--- a/tracdap-services/tracdap-svc-meta/src/test/java/org/finos/tracdap/svc/meta/dal/MetadataDalWriteTest.java
+++ b/tracdap-services/tracdap-svc-meta/src/test/java/org/finos/tracdap/svc/meta/dal/MetadataDalWriteTest.java
@@ -21,6 +21,7 @@ import org.finos.tracdap.common.exception.EMetadataDuplicate;
 import org.finos.tracdap.common.exception.EMetadataNotFound;
 import org.finos.tracdap.common.exception.EMetadataWrongType;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -61,7 +62,7 @@ abstract class MetadataDalWriteTest implements IDalTestable {
         var origTag = dummyTag(origDef, INCLUDE_HEADER);
         var origId = UUID.fromString(origTag.getHeader().getObjectId());
 
-        dal.saveNewObject(TEST_TENANT, origTag);
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(origTag));
         var result = dal.loadTag(TEST_TENANT, ObjectType.DATA, origId, 1, 1);
 
         assertEquals(origTag, result);
@@ -87,7 +88,7 @@ abstract class MetadataDalWriteTest implements IDalTestable {
         var origTag = addMultiValuedAttr(dummyTag(origDef, INCLUDE_HEADER));
         var origId = UUID.fromString(origTag.getHeader().getObjectId());
 
-        dal.saveNewObject(TEST_TENANT, origTag);
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(origTag));
         var result = dal.loadTag(TEST_TENANT, ObjectType.DATA, origId, 1, 1);
 
         assertEquals(origTag, result);
@@ -116,9 +117,9 @@ abstract class MetadataDalWriteTest implements IDalTestable {
         assertThrows(EMetadataNotFound.class, () -> dal.loadTag(TEST_TENANT, ObjectType.DATA, origId, 1, 1));
 
         // First insert should succeed if they are run one by one
-        assertDoesNotThrow(() -> dal.saveNewObject(TEST_TENANT, origTag));
+        assertDoesNotThrow(() -> dal.saveNewObjects(TEST_TENANT, Collections.singletonList(origTag)));
         assertDoesNotThrow(() -> dal.loadTag(TEST_TENANT, ObjectType.DATA, origId, 1, 1));
-        assertThrows(EMetadataDuplicate.class, () -> dal.saveNewObject(TEST_TENANT, origTag));
+        assertThrows(EMetadataDuplicate.class, () -> dal.saveNewObjects(TEST_TENANT, Collections.singletonList(origTag)));
     }
 
     @Test
@@ -132,8 +133,8 @@ abstract class MetadataDalWriteTest implements IDalTestable {
         var nextDef = nextDataDef(origDef);
         var nextTag = tagForNextObject(origTag, nextDef, INCLUDE_HEADER);
 
-        dal.saveNewObject(TEST_TENANT, origTag);
-        dal.saveNewVersion(TEST_TENANT, nextTag);
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(origTag));
+        dal.saveNewVersions(TEST_TENANT, Collections.singletonList(nextTag));
         var result = dal.loadTag(TEST_TENANT, ObjectType.DATA, origId, 2, 1);
 
         assertEquals(nextTag, result);
@@ -166,8 +167,8 @@ abstract class MetadataDalWriteTest implements IDalTestable {
         var nextDef = nextDataDef(origDef);
         var nextTag = addMultiValuedAttr(tagForNextObject(origTag, nextDef, INCLUDE_HEADER));
 
-        dal.saveNewObject(TEST_TENANT, origTag);
-        dal.saveNewVersion(TEST_TENANT, nextTag);
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(origTag));
+        dal.saveNewVersions(TEST_TENANT, Collections.singletonList(nextTag));
         var result = dal.loadTag(TEST_TENANT, ObjectType.DATA, origId, 2, 1);
 
         assertEquals(nextTag, result);
@@ -199,14 +200,14 @@ abstract class MetadataDalWriteTest implements IDalTestable {
         var nextDef = nextDataDef(origDef);
         var nextTag = tagForNextObject(origTag, nextDef, INCLUDE_HEADER);
 
-        dal.saveNewObject(TEST_TENANT, origTag);
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(origTag));
 
         assertThrows(EMetadataDuplicate.class, () -> dal.saveNewVersions(TEST_TENANT, List.of(nextTag, nextTag)));
         assertThrows(EMetadataNotFound.class, () -> dal.loadTag(TEST_TENANT, ObjectType.DATA, origId, 2, 1));
 
         // First insert should succeed if they are run one by one
-        dal.saveNewVersion(TEST_TENANT, nextTag);
-        assertThrows(EMetadataDuplicate.class, () -> dal.saveNewVersion(TEST_TENANT, nextTag));
+        dal.saveNewVersions(TEST_TENANT, Collections.singletonList(nextTag));
+        assertThrows(EMetadataDuplicate.class, () -> dal.saveNewVersions(TEST_TENANT, Collections.singletonList(nextTag)));
 
         var loadDup2 = dal.loadTag(TEST_TENANT, ObjectType.DATA, origId, 2, 1);
         assertEquals(nextTag, loadDup2);
@@ -221,13 +222,13 @@ abstract class MetadataDalWriteTest implements IDalTestable {
         var nextTag = tagForNextObject(origTag, nextDef, INCLUDE_HEADER);
 
         // Save next version, single, without saving original
-        assertThrows(EMetadataNotFound.class, () -> dal.saveNewVersion(TEST_TENANT, nextTag));
+        assertThrows(EMetadataNotFound.class, () -> dal.saveNewVersions(TEST_TENANT, Collections.singletonList(nextTag)));
 
         var modelTag = dummyTagForObjectType(ObjectType.MODEL);
         var nextModelTag = tagForNextObject(modelTag, nextModelDef(modelTag.getDefinition()), INCLUDE_HEADER);
 
         // Save next, multiple, one item does not have original
-        dal.saveNewObject(TEST_TENANT, origTag);
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(origTag));
 
         assertThrows(EMetadataNotFound.class, () -> dal.saveNewVersions(TEST_TENANT, List.of(nextTag, nextModelTag)));
     }
@@ -247,9 +248,9 @@ abstract class MetadataDalWriteTest implements IDalTestable {
                 .build();
 
         // Save next version, single, without saving original
-        dal.saveNewObject(TEST_TENANT, dataTag);
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(dataTag));
 
-        assertThrows(EMetadataWrongType.class, () -> dal.saveNewVersion(TEST_TENANT, nextModelTag));
+        assertThrows(EMetadataWrongType.class, () -> dal.saveNewVersions(TEST_TENANT, Collections.singletonList(nextModelTag)));
         assertThrows(EMetadataWrongType.class, () -> dal.saveNewVersions(TEST_TENANT, List.of(nextDataTag, nextModelTag)));
     }
 
@@ -263,9 +264,9 @@ abstract class MetadataDalWriteTest implements IDalTestable {
         var origId = UUID.fromString(origTag.getHeader().getObjectId());
 
         // Test saving tag v2 against object v2
-        dal.saveNewObject(TEST_TENANT, origTag);
-        dal.saveNewVersion(TEST_TENANT, nextDefTag1);
-        dal.saveNewTag(TEST_TENANT, nextDefTag2);
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(origTag));
+        dal.saveNewVersions(TEST_TENANT, Collections.singletonList(nextDefTag1));
+        dal.saveNewTags(TEST_TENANT, Collections.singletonList(nextDefTag2));
         var result = dal.loadTag(TEST_TENANT, ObjectType.DATA, origId, 2, 2);
 
         assertEquals(nextDefTag2, result);
@@ -297,9 +298,9 @@ abstract class MetadataDalWriteTest implements IDalTestable {
         var origId = UUID.fromString(origTag.getHeader().getObjectId());
 
         // Test saving tag v2 against object v2
-        dal.saveNewObject(TEST_TENANT, origTag);
-        dal.saveNewVersion(TEST_TENANT, nextDefTag1);
-        dal.saveNewTag(TEST_TENANT, nextDefTag2);
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(origTag));
+        dal.saveNewVersions(TEST_TENANT, Collections.singletonList(nextDefTag1));
+        dal.saveNewTags(TEST_TENANT, Collections.singletonList(nextDefTag2));
         var result = dal.loadTag(TEST_TENANT, ObjectType.DATA, origId, 2, 2);
 
         assertEquals(nextDefTag2, result);
@@ -329,14 +330,14 @@ abstract class MetadataDalWriteTest implements IDalTestable {
         var nextTag = nextTag(origTag, UPDATE_TAG_VERSION);
         var origId = UUID.fromString(origTag.getHeader().getObjectId());
 
-        dal.saveNewObject(TEST_TENANT, origTag);
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(origTag));
 
         assertThrows(EMetadataDuplicate.class, () -> dal.saveNewTags(TEST_TENANT, List.of(nextTag, nextTag)));
         assertThrows(EMetadataNotFound.class, () -> dal.loadTag(TEST_TENANT, ObjectType.DATA, origId, 1, 2));
 
         // First insert should succeed if they are run one by one
-        dal.saveNewTag(TEST_TENANT, nextTag);
-        assertThrows(EMetadataDuplicate.class, () -> dal.saveNewTag(TEST_TENANT, nextTag));
+        dal.saveNewTags(TEST_TENANT, Collections.singletonList(nextTag));
+        assertThrows(EMetadataDuplicate.class, () -> dal.saveNewTags(TEST_TENANT, Collections.singletonList(nextTag)));
 
         var loadDup2 = dal.loadTag(TEST_TENANT, ObjectType.DATA, origId, 1, 2);
         assertEquals(nextTag, loadDup2);
@@ -350,13 +351,13 @@ abstract class MetadataDalWriteTest implements IDalTestable {
         var nextTag = nextTag(origTag, UPDATE_TAG_VERSION);
 
         // Save next tag, single, without saving object
-        assertThrows(EMetadataNotFound.class, () -> dal.saveNewTag(TEST_TENANT, nextTag));
+        assertThrows(EMetadataNotFound.class, () -> dal.saveNewTags(TEST_TENANT, Collections.singletonList(nextTag)));
 
         var modelTag = dummyTagForObjectType(ObjectType.MODEL);
         var nextModelTag = tagForNextObject(modelTag, nextModelDef(modelTag.getDefinition()), INCLUDE_HEADER);
 
         // Save next tag, multiple, one item does not have an object
-        dal.saveNewObject(TEST_TENANT, origTag);
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(origTag));
 
         assertThrows(EMetadataNotFound.class, () -> dal.saveNewTags(TEST_TENANT, List.of(nextTag, nextModelTag)));
     }
@@ -373,23 +374,23 @@ abstract class MetadataDalWriteTest implements IDalTestable {
         // Save next tag (single) on an unknown object version
         // This is an error, even for tag v1
         // saveNewVersion must be called first
-        dal.saveNewObject(TEST_TENANT, origTag);
-        assertThrows(EMetadataNotFound.class, () -> dal.saveNewTag(TEST_TENANT, nextDefTag1));
-        assertThrows(EMetadataNotFound.class, () -> dal.saveNewTag(TEST_TENANT, nextDefTag2));
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(origTag));
+        assertThrows(EMetadataNotFound.class, () -> dal.saveNewTags(TEST_TENANT, Collections.singletonList(nextDefTag1)));
+        assertThrows(EMetadataNotFound.class, () -> dal.saveNewTags(TEST_TENANT, Collections.singletonList(nextDefTag2)));
 
         var modelTag = dummyTagForObjectType(ObjectType.MODEL);
         var nextModelTag = tagForNextObject(modelTag, nextModelDef(modelTag.getDefinition()), INCLUDE_HEADER);
         var nextModelTag2 = nextTag(nextModelTag, UPDATE_TAG_VERSION);
 
         // Save object 1 version 2, and object 2 version 1
-        dal.saveNewVersion(TEST_TENANT, nextDefTag1);
-        dal.saveNewObject(TEST_TENANT, modelTag);
+        dal.saveNewVersions(TEST_TENANT, Collections.singletonList(nextDefTag1));
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(modelTag));
 
         // Save next tag (multiple), second item is missing the required object version
         assertThrows(EMetadataNotFound.class, () -> dal.saveNewTags(TEST_TENANT, List.of(nextDefTag2, nextModelTag2)));
 
         // Saving the valid tag by itself should not throw
-        Assertions.assertDoesNotThrow(() -> dal.saveNewTag(TEST_TENANT, nextDefTag2));
+        Assertions.assertDoesNotThrow(() -> dal.saveNewTags(TEST_TENANT, Collections.singletonList(nextDefTag2)));
     }
 
     @Test
@@ -412,9 +413,9 @@ abstract class MetadataDalWriteTest implements IDalTestable {
                 .setDefinition(nextDef)
                 .build();
 
-        dal.saveNewObject(TEST_TENANT, origTag);
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(origTag));
 
-        assertThrows(EMetadataWrongType.class, () -> dal.saveNewTag(TEST_TENANT, nextTag));
+        assertThrows(EMetadataWrongType.class, () -> dal.saveNewTags(TEST_TENANT, Collections.singletonList(nextTag)));
         assertThrows(EMetadataNotFound.class, () -> dal.loadTag(TEST_TENANT, ObjectType.DATA, origId, 1, 2));
 
         var origDef2 = dummyModelDef();
@@ -423,7 +424,7 @@ abstract class MetadataDalWriteTest implements IDalTestable {
 
         var nextTag2 = nextTag(origTag2, UPDATE_TAG_VERSION);
 
-        dal.saveNewObject(TEST_TENANT, origTag2);
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(origTag2));
 
         assertThrows(EMetadataWrongType.class, () -> dal.saveNewTags(TEST_TENANT, List.of(nextTag, nextTag2)));
         assertThrows(EMetadataNotFound.class, () -> dal.loadTags(TEST_TENANT,
@@ -478,7 +479,7 @@ abstract class MetadataDalWriteTest implements IDalTestable {
         var id2 = UUID.fromString(obj2.getHeader().getObjectId());
         var id3 = UUID.randomUUID();
 
-        dal.saveNewObject(TEST_TENANT, obj2);
+        dal.saveNewObjects(TEST_TENANT, Collections.singletonList(obj2));
         assertThrows(EMetadataDuplicate.class,
                 () -> dal.preallocateObjectIds(TEST_TENANT,
                         List.of(ObjectType.MODEL, ObjectType.MODEL),


### PR DESCRIPTION
Remove from `IMetadataDal`:

* `saveNewTag`
* `saveNewVersion`
* `saveNewObject`

They are replaced with calls to batch versions (like `saveNewTags`).