### PR TITLE
Feature / Remove non-batch preallocate methods from IMetadataDal

### DIFF
--- a/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/dal/IMetadataDal.java
+++ b/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/dal/IMetadataDal.java
@@ -32,11 +32,7 @@ public interface IMetadataDal {
 
     void saveNewTags(String tenant, List<Tag> tags);
 
-    void preallocateObjectId(String tenant, ObjectType objectType, UUID objectId);
-
     void preallocateObjectIds(String tenant, List<ObjectType> objectTypes, List<UUID> objectIds);
-
-    void savePreallocatedObject(String tenant, Tag tag);
 
     void savePreallocatedObjects(String tenant, List<Tag> tags);
 

--- a/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/dal/jdbc/JdbcMetadataDal.java
+++ b/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/dal/jdbc/JdbcMetadataDal.java
@@ -160,20 +160,9 @@ public class JdbcMetadataDal extends JdbcBaseDal implements IMetadataDal {
     }
 
     @Override
-    public void preallocateObjectId(String tenant, ObjectType objectType, UUID objectId) {
-
-        var parts = separateParts(objectType, objectId);
-        preallocateObjectIds(tenant, parts);
-    }
-
-    @Override
     public void preallocateObjectIds(String tenant, List<ObjectType> objectTypes, List<UUID> objectIds) {
 
         var parts = separateParts(objectTypes, objectIds);
-        preallocateObjectIds(tenant, parts);
-    }
-
-    private void preallocateObjectIds(String tenant, ObjectParts parts) {
 
         wrapTransaction(conn -> {
 
@@ -187,20 +176,9 @@ public class JdbcMetadataDal extends JdbcBaseDal implements IMetadataDal {
     }
 
     @Override
-    public void savePreallocatedObject(String tenant, Tag tag) {
-
-        var parts = separateParts(tag);
-        savePreallocatedObjects(tenant, parts);
-    }
-
-    @Override
     public void savePreallocatedObjects(String tenant, List<Tag> tags) {
 
         var parts = separateParts(tags);
-        savePreallocatedObjects(tenant, parts);
-    }
-
-    private void savePreallocatedObjects(String tenant, ObjectParts parts) {
 
         wrapTransaction(conn -> {
 
@@ -429,28 +407,6 @@ public class JdbcMetadataDal extends JdbcBaseDal implements IMetadataDal {
         TagSelector[] selector;
     }
 
-    private ObjectParts separateParts(Tag tag) {
-
-        var header = tag.getHeader();
-
-        var parts = new ObjectParts();
-        parts.objectType = new ObjectType[] {header.getObjectType()};
-        parts.objectId = new UUID[] {UUID.fromString(header.getObjectId())};
-        parts.objectVersion = new int[] {header.getObjectVersion()};
-        parts.tagVersion = new int[] {header.getTagVersion()};
-
-        var objectTimestamp = MetadataCodec.decodeDatetime(header.getObjectTimestamp()).toInstant();
-        var tagTimestamp = MetadataCodec.decodeDatetime(header.getTagTimestamp()).toInstant();
-
-        parts.objectTimestamp = new Instant[] {objectTimestamp};
-        parts.tagTimestamp = new Instant[] {tagTimestamp};
-
-        parts.tag = new Tag[] {tag};
-        parts.definition = new ObjectDefinition[] {tag.getDefinition()};
-
-        return parts;
-    }
-
     private ObjectParts separateParts(List<Tag> tags) {
 
         var headers = tags.stream().map(Tag::getHeader).toArray(TagHeader[]::new);
@@ -475,15 +431,6 @@ public class JdbcMetadataDal extends JdbcBaseDal implements IMetadataDal {
 
         parts.tag = tags.toArray(Tag[]::new);
         parts.definition = tags.stream().map(Tag::getDefinition).toArray(ObjectDefinition[]::new);
-
-        return parts;
-    }
-
-    private ObjectParts separateParts(ObjectType objectType, UUID objectId) {
-
-        var parts = new ObjectParts();
-        parts.objectType = new ObjectType[] {objectType};
-        parts.objectId = new UUID[] {objectId};
 
         return parts;
     }

--- a/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/services/MetadataWriteService.java
+++ b/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/services/MetadataWriteService.java
@@ -246,20 +246,7 @@ public class MetadataWriteService {
     }
 
     public TagHeader preallocateId(String tenant, ObjectType objectType) {
-
-        // New random ID
-        var objectId = UUID.randomUUID();
-
-        // Header for preallocated IDs does not include an object or tag version
-        var preallocatedHeader = TagHeader.newBuilder()
-                .setObjectType(objectType)
-                .setObjectId(objectId.toString())
-                .build();
-
-        // Save as a preallocated ID in the DAL
-        dal.preallocateObjectId(tenant, objectType, objectId);
-
-        return preallocatedHeader;
+        return preallocateIdBatch(tenant, Collections.singletonList(objectType)).get(0);
     }
 
     public List<TagHeader> preallocateIdBatch(String tenant, List<ObjectType> objectTypes) {
@@ -292,7 +279,7 @@ public class MetadataWriteService {
                 tagUpdates
         );
 
-        dal.savePreallocatedObject(tenant, newTag);
+        dal.savePreallocatedObjects(tenant, Collections.singletonList(newTag));
 
         return newTag.getHeader();
     }

--- a/tracdap-services/tracdap-svc-meta/src/test/java/org/finos/tracdap/svc/meta/dal/MetadataDalWriteTest.java
+++ b/tracdap-services/tracdap-svc-meta/src/test/java/org/finos/tracdap/svc/meta/dal/MetadataDalWriteTest.java
@@ -442,8 +442,12 @@ abstract class MetadataDalWriteTest implements IDalTestable {
         var origTag = dummyTag(origDef, INCLUDE_HEADER);
         var origId = UUID.fromString(origTag.getHeader().getObjectId());
 
-        dal.preallocateObjectId(TEST_TENANT, ObjectType.DATA, origId);
-        dal.savePreallocatedObject(TEST_TENANT, origTag);
+        dal.preallocateObjectIds(
+                TEST_TENANT,
+                Collections.singletonList(ObjectType.DATA),
+                Collections.singletonList(origId)
+        );
+        dal.savePreallocatedObjects(TEST_TENANT, Collections.singletonList(origTag));
         var result = dal.loadTag(TEST_TENANT, ObjectType.DATA, origId, 1, 1);
 
         assertEquals(origTag, result);
@@ -471,9 +475,17 @@ abstract class MetadataDalWriteTest implements IDalTestable {
 
         var id1 = UUID.randomUUID();
 
-        dal.preallocateObjectId(TEST_TENANT, ObjectType.DATA, id1);
+        dal.preallocateObjectIds(
+                TEST_TENANT,
+                Collections.singletonList(ObjectType.DATA),
+                Collections.singletonList(id1)
+        );
         assertThrows(EMetadataDuplicate.class,
-                () -> dal.preallocateObjectId(TEST_TENANT, ObjectType.DATA, id1));
+                () -> dal.preallocateObjectIds(
+                        TEST_TENANT,
+                        Collections.singletonList(ObjectType.DATA),
+                        Collections.singletonList(id1)
+                ));
 
         var obj2 = dummyTagForObjectType(ObjectType.MODEL);
         var id2 = UUID.fromString(obj2.getHeader().getObjectId());
@@ -492,12 +504,16 @@ abstract class MetadataDalWriteTest implements IDalTestable {
         var obj1 = dummyTagForObjectType(ObjectType.MODEL);
 
         assertThrows(EMetadataNotFound.class,
-                () -> dal.savePreallocatedObject(TEST_TENANT, obj1));
+                () -> dal.savePreallocatedObjects(TEST_TENANT, Collections.singletonList(obj1)));
 
         var obj2 = dummyTagForObjectType(ObjectType.DATA);
         var id2 = UUID.fromString(obj2.getHeader().getObjectId());
 
-        dal.preallocateObjectId(TEST_TENANT, ObjectType.DATA, id2);
+        dal.preallocateObjectIds(
+                TEST_TENANT,
+                Collections.singletonList(ObjectType.DATA),
+                Collections.singletonList(id2)
+        );
 
         assertThrows(EMetadataNotFound.class,
                 () -> dal.savePreallocatedObjects(TEST_TENANT, List.of(obj1, obj2)));
@@ -509,15 +525,23 @@ abstract class MetadataDalWriteTest implements IDalTestable {
         var obj1 = dummyTagForObjectType(ObjectType.MODEL);
         var id1 = UUID.fromString(obj1.getHeader().getObjectId());
 
-        dal.preallocateObjectId(TEST_TENANT, ObjectType.DATA, id1);
+        dal.preallocateObjectIds(
+                TEST_TENANT,
+                Collections.singletonList(ObjectType.DATA),
+                Collections.singletonList(id1)
+        );
 
         assertThrows(EMetadataWrongType.class,
-                () -> dal.savePreallocatedObject(TEST_TENANT, obj1));
+                () -> dal.savePreallocatedObjects(TEST_TENANT, Collections.singletonList(obj1)));
 
         var obj2 = dummyTagForObjectType(ObjectType.DATA);
         var id2 = UUID.fromString(obj2.getHeader().getObjectId());
 
-        dal.preallocateObjectId(TEST_TENANT, ObjectType.DATA, id2);
+        dal.preallocateObjectIds(
+                TEST_TENANT,
+                Collections.singletonList(ObjectType.DATA),
+                Collections.singletonList(id2)
+        );
 
         assertThrows(EMetadataWrongType.class,
                 () -> dal.savePreallocatedObjects(TEST_TENANT, List.of(obj1, obj2)));


### PR DESCRIPTION
Remove from `IMetadataDal`:

* `savePreallocatedObject`
* `preallocateObjectId`

Refactor `MetadataWriteService`.