### PR TITLE
Feature / Web API transport enhancements

### DIFF
--- a/examples/apps/javascript/package-lock.json
+++ b/examples/apps/javascript/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "apache-arrow": "^10.0.1",
+        "node-fetch": "^3.3.0",
         "tracdap-web-api": "file:../../../tracdap-api/packages/web",
         "ws": "^8.11.0",
         "xhr2": "^0.2.1"
@@ -165,6 +166,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
+      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -179,6 +188,28 @@
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/find-replace": {
@@ -196,6 +227,17 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-2.0.4.tgz",
       "integrity": "sha512-4rUFVDPjSoP0tOII34oQf+72NKU7E088U5oX7kwICahft0UB2kOQ9wUzzCp+OHxByERIfxRDCgX5mP8Pjkfl0g=="
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/has-flag": {
       "version": "3.0.0",
@@ -217,6 +259,41 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.0.tgz",
+      "integrity": "sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
     },
     "node_modules/pad-left": {
       "version": "2.1.0",
@@ -301,6 +378,14 @@
       "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/wordwrapjs": {

--- a/examples/apps/javascript/package.json
+++ b/examples/apps/javascript/package.json
@@ -20,9 +20,10 @@
   "type": "module",
   "dependencies": {
     "apache-arrow": "^10.0.1",
+    "node-fetch": "^3.3.0",
     "tracdap-web-api": "file:../../../tracdap-api/packages/web",
-    "xhr2": "^0.2.1",
-    "ws": "^8.11.0"
+    "ws": "^8.11.0",
+    "xhr2": "^0.2.1"
   },
   "scripts": {
     "examples": "node --experimental-specifier-resolution=node run_examples.js"

--- a/examples/apps/javascript/run_examples.js
+++ b/examples/apps/javascript/run_examples.js
@@ -17,8 +17,10 @@
 
 // To run these examples outside of a browser, XMLHttpRequest is required
 import xhr2 from 'xhr2';
+import fetch from "node-fetch";
 import WebSocket from "ws";
 global.XMLHttpRequest = xhr2.XMLHttpRequest;
+global.fetch = fetch;
 global.WebSocket = WebSocket;
 
 

--- a/tracdap-api/packages/web/wrapper.js
+++ b/tracdap-api/packages/web/wrapper.js
@@ -103,6 +103,11 @@
         GoogleTransport.prototype._grpcWebUnary = function(method, descriptor, request, callback) {
 
             this.grpcWeb.rpcCall(method.name, request, this.rpcMetadata, descriptor, callback);
+
+            // For stream.on("metadata") and stream.on("status")
+            // If status == OK, call _processResponseMetadata()
+            // This will update cookies and session info sent by TRAC
+            // Share implementation with TRAC transport
         }
 
         GoogleTransport.prototype._grpcWebServerStreaming = function(method, descriptor, request, callback) {
@@ -113,10 +118,10 @@
             stream.on("end", () => callback(null, null));
             stream.on("error", err => callback(err, null));
 
-            // TODO: Do we need to do anything with these two messages?
-
-            stream.on("metadata", metadata => console.log("gRPC Metadata: " + JSON.stringify(metadata)));
-            stream.on("status", status => console.log("gRPC Status: " + JSON.stringify(status)));
+            // For stream.on("metadata") and stream.on("status")
+            // If status == OK, call _processResponseMetadata()
+            // This will update cookies and session info sent by TRAC
+            // Share implementation with TRAC transport
         }
 
         return GoogleTransport;

--- a/tracdap-services/tracdap-gateway/src/main/java/org/finos/tracdap/gateway/ProtocolNegotiator.java
+++ b/tracdap-services/tracdap-gateway/src/main/java/org/finos/tracdap/gateway/ProtocolNegotiator.java
@@ -349,9 +349,15 @@ public class ProtocolNegotiator extends ChannelInitializer<SocketChannel> {
             pipeline.addAfter(HTTP_1_CODEC, WS_COMPRESSION, new WebSocketServerCompressionHandler());
 
             // Configure the WS protocol handler - path must match the URI in the upgrade request
+
+            // Do not auto-reply to close frames as this can lead to protocol errors
+            // Chrome in particular is very fussy and will fail a whole request if the close sequence is wrong
+            // The close sequence is managed with the client explicitly in WebSocketsRouter
+
             var wsConfig = webSocketsHandler.config()
                     .toBuilder()
                     .websocketPath(req.uri())
+                    .handleCloseFrames(false)
                     .build();
 
             pipeline.addAfter(WS_COMPRESSION, WS_FRAME_CODEC, new WebSocketServerProtocolHandler(wsConfig));

--- a/tracdap-services/tracdap-gateway/src/main/java/org/finos/tracdap/gateway/proxy/grpc/WebSocketsTranslator.java
+++ b/tracdap-services/tracdap-gateway/src/main/java/org/finos/tracdap/gateway/proxy/grpc/WebSocketsTranslator.java
@@ -307,7 +307,7 @@ public class WebSocketsTranslator extends Http2ChannelDuplexHandler {
 
             if (eos) {
 
-                var closeFrame = new CloseWebSocketFrame(WebSocketCloseStatus.NORMAL_CLOSURE);
+                var closeFrame = new CloseWebSocketFrame(WebSocketCloseStatus.NORMAL_CLOSURE, "request complete");
                 ctx.fireChannelRead(closeFrame);
                 ctx.flush();
             }


### PR DESCRIPTION
Various small fixes, enchantments and simplifications in the web API transport classes, primarily for web sockets although some are shared.

Two transports are available, "google" and "trac", available as options in the setup method. "google" supports unary and server streaming calls, "trac" also supports client streaming. The "google" transport is preferred unless client streaming is required.

A future PR will add an "optimal" transport, which wraps the existing two and automatically selects "trac" for client streaming uploads.