### PR TITLE
Fix / Controllled model path attr

### DIFF
--- a/tracdap-api/tracdap-metadata/src/main/proto/tracdap/metadata/model.proto
+++ b/tracdap-api/tracdap-metadata/src/main/proto/tracdap/metadata/model.proto
@@ -85,7 +85,7 @@ message ModelDefinition {
 
     string entryPoint = 5;
 
-    string path = 3;
+    optional string path = 3;
 
     map<string, ModelParameter> parameters = 7;
     map<string, ModelInputSchema> inputs = 8;

--- a/tracdap-libs/tracdap-lib-common/src/main/java/org/finos/tracdap/common/metadata/MetadataConstants.java
+++ b/tracdap-libs/tracdap-lib-common/src/main/java/org/finos/tracdap/common/metadata/MetadataConstants.java
@@ -86,4 +86,5 @@ public class MetadataConstants {
     public static final String TRAC_MODEL_PACKAGE = "trac_model_package";
     public static final String TRAC_MODEL_VERSION = "trac_model_version";
     public static final String TRAC_MODEL_ENTRY_POINT = "trac_model_entry_point";
+    public static final String TRAC_MODEL_PATH = "trac_model_path";
 }

--- a/tracdap-services/tracdap-svc-orch/src/main/java/org/finos/tracdap/svc/orch/jobs/ImportModelJob.java
+++ b/tracdap-services/tracdap-svc-orch/src/main/java/org/finos/tracdap/svc/orch/jobs/ImportModelJob.java
@@ -188,6 +188,14 @@ public class ImportModelJob implements IJobLogic {
                 .setValue(encodeValue(modelDef.getEntryPoint()))
                 .build());
 
+        if (modelDef.hasPath()) {
+
+            modelReq.addTagUpdates(TagUpdate.newBuilder()
+                    .setAttrName(TRAC_MODEL_PATH)
+                    .setValue(encodeValue(modelDef.getPath()))
+                    .build());
+        }
+
         return List.of(modelReq.build());
     }
 }


### PR DESCRIPTION
model path is only available for some repo types
make path optional in model definition and add a controlled attr to models only when it is present