### PR TITLE
Run configuration correction - Deploy Meta DB.

### DIFF
--- a/dev/ide/idea/runConfigurations/Tools__Deploy_Meta_DB.xml
+++ b/dev/ide/idea/runConfigurations/Tools__Deploy_Meta_DB.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="Tools: Deploy Meta DB" type="Application" factoryName="Application">
     <option name="MAIN_CLASS_NAME" value="org.finos.tracdap.tools.deploy.metadb.DeployMetaDB" />
     <module name="tracdap.deploy-metadb.main" />
-    <option name="PROGRAM_PARAMETERS" value="--config dev/config/trac-devlocal.yaml --secret-key devlocal_key --task deploy_schema --task add_tenant ACME_CORP 'ACME Corp.'" />
+    <option name="PROGRAM_PARAMETERS" value="--config dev/config/trac-devlocal.yaml --secret-key devlocal_key --task deploy_schema --task add_tenant ACME_CORP &quot;ACME Corp&quot;" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>


### PR DESCRIPTION
A cosmetic change, which was needed to fix an error occurring when running "Deploy Meta DB" RunConfiguration in IntelliJ.  