### PR TITLE
Do not allow integer categorical fields in the 0.6 release

### DIFF
--- a/tracdap-libs/tracdap-lib-validation/src/main/java/org/finos/tracdap/common/validation/static_/SchemaValidator.java
+++ b/tracdap-libs/tracdap-lib-validation/src/main/java/org/finos/tracdap/common/validation/static_/SchemaValidator.java
@@ -37,8 +37,7 @@ public class SchemaValidator {
     private static final List<BasicType> ALLOWED_BUSINESS_KEY_TYPES = List.of(
             BasicType.STRING, BasicType.INTEGER, BasicType.DATE);
 
-    // TODO: Integer categorical fields will not be allowed from 0.6 onward
-    private static final List<BasicType> ALLOWED_CATEGORICAL_TYPES = List.of(BasicType.STRING, BasicType.INTEGER);
+    private static final List<BasicType> ALLOWED_CATEGORICAL_TYPES = List.of(BasicType.STRING);
 
     private static final Descriptors.Descriptor SCHEMA_DEFINITION;
     private static final Descriptors.FieldDescriptor SD_SCHEMA_TYPE;


### PR DESCRIPTION
This is a solution to  the issue [#290](https://github.com/finos/tracdap/issues/290).