### PR TITLE
Feature / Runtime guardrails

### DIFF
--- a/tracdap-runtime/python/src/tracdap/rt/_exec/functions.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_exec/functions.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import datetime
 import abc
-import pathlib
 import random
 import dataclasses as dc  # noqa
 
@@ -517,6 +516,7 @@ class RunModelFunc(NodeFunction[Bundle[_data.DataView]]):
         self.node = node
         self.model_class = model_class
         self.checkout_directory = checkout_directory
+
     def _execute(self, ctx: NodeContext) -> Bundle[_data.DataView]:
 
         model_def = self.node.model_def

--- a/tracdap-runtime/python/src/tracdap/rt/_exec/runtime.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_exec/runtime.py
@@ -35,6 +35,7 @@ import tracdap.rt._impl.util as _util  # noqa
 import tracdap.rt._impl.models as _models  # noqa
 import tracdap.rt._impl.storage as _storage  # noqa
 import tracdap.rt._impl.static_api as _static_api  # noqa
+import tracdap.rt._impl.guard_rails as _guard  # noqa
 import tracdap.rt._version as _version
 
 
@@ -125,6 +126,7 @@ class TracRuntime:
 
             _plugins.PluginManager.register_core_plugins()
             _static_api.StaticApiImpl.register_impl()
+            _guard.PythonGuardRails.protect_dangerous_functions()
 
             # Load sys config (or use embedded), config errors are detected before start()
             # Job config can also be checked before start() by using load_job_config()

--- a/tracdap-runtime/python/src/tracdap/rt/_impl/guard_rails.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_impl/guard_rails.py
@@ -1,0 +1,65 @@
+#  Copyright 2023 Accenture Global Solutions Limited
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import inspect
+import pathlib
+
+import tracdap.rt.api as api
+import tracdap.rt.exceptions as ex
+
+
+class PythonGuardRails:
+
+    # TODO: Do not block these calls running in the debugger
+
+    # breakpoint, globals
+    DANGEROUS_BUILTIN_FUNCTIONS = ["exec", "eval", "compile", "open", "input", "memoryview"]
+
+    @classmethod
+    def protect_dangerous_functions(cls):
+
+        for func_name in cls.DANGEROUS_BUILTIN_FUNCTIONS:
+            raw_func = __builtins__[func_name]  # noqa
+            __builtins__[func_name] = cls.protect_function(func_name, raw_func)  # noqa
+
+    @classmethod
+    def protect_function(cls, func_name, func):
+
+        if hasattr(func, "__trac_protection__") and func.__trac_protection__:
+            return func
+
+        def protected_function(*args, **kwargs):
+            model_code_details = cls.check_for_model_code()
+            if model_code_details is not None:
+                raise ex.EModelValidation(f"Calling {func_name}() is not allowed in model code ({model_code_details})")
+            else:
+                return func(*args, **kwargs)
+
+        setattr(protected_function,  "__trac_protection__", True)
+
+        return protected_function
+
+    @classmethod
+    def check_for_model_code(cls):
+
+        stack = inspect.stack()
+
+        for frame in stack:
+            if frame.function is not None and frame.function == "run_model":
+                for param_name, param in frame.frame.f_locals.items():
+                    if isinstance(param, api.TracModel):
+                        filename = pathlib.Path(frame.filename).name
+                        return f"{filename} line {frame.lineno}"
+
+        return None

--- a/tracdap-runtime/python/src/tracdap/rt/_impl/guard_rails.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_impl/guard_rails.py
@@ -150,10 +150,10 @@ class PythonGuardRails:
 
             frame_path = pathlib.Path(frame.filename)
 
-            if frame_path.is_relative_to(cls.SITE_PACKAGE_PATH):
+            if cls.path_is_in_dir(frame_path, cls.SITE_PACKAGE_PATH):
                 return None
 
-            if frame_path.is_relative_to(cls.TRAC_PACKAGE_PATH):
+            if cls.path_is_in_dir(frame_path, cls.TRAC_PACKAGE_PATH):
                 return None
 
             last_model_frame = frame
@@ -165,6 +165,14 @@ class PythonGuardRails:
         snippet = trace[-(cls.PROTECTED_FUNC_STACK_DEPTH + 1)].line
 
         return f"{filename} line {last_model_frame.lineno}, {snippet}"
+
+    @classmethod
+    def path_is_in_dir(cls, path: pathlib.Path, directory: pathlib.Path):
+
+        # path.is_relative_to() only appears in Python 3.9
+        # We are still supporting 3.7 +
+
+        return directory in path.parents
 
     @classmethod
     def is_debug(cls):

--- a/tracdap-runtime/python/src/tracdap/rt/_impl/guard_rails.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_impl/guard_rails.py
@@ -54,7 +54,7 @@ class PythonGuardRails:
     ]
 
     REQUIRED_DEBUG_FUNCTIONS = ["exec", "eval", "compile"]
-    REQUIRED_IMPORT_FUNCTIONS = ["exec", "memoryview"]
+    REQUIRED_IMPORT_FUNCTIONS = ["compile", "exec", "memoryview"]
 
     MODEL_IMPORT_ENTRY_POINT = "trac_model_code_import"
     MODEL_ENTRY_POINTS = _get_model_entry_points() + [MODEL_IMPORT_ENTRY_POINT]

--- a/tracdap-runtime/python/src/tracdap/rt/_impl/guard_rails.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_impl/guard_rails.py
@@ -22,6 +22,17 @@ import tracdap.rt.api as api
 import tracdap.rt.exceptions as ex
 
 
+def _get_model_entry_points():
+
+    entry_points = []
+
+    for member_name, member in api.TracModel.__dict__.items():
+        if callable(member):
+            entry_points.append(member_name)
+
+    return entry_points
+
+
 def _get_package_path(module_name):
 
     importlib.import_module(module_name)
@@ -44,7 +55,7 @@ class PythonGuardRails:
 
     REQUIRED_DEBUG_FUNCTIONS = ["exec", "eval", "compile"]
 
-    MODEL_ENTRY_POINTS = ["run_model", "scan_model"]
+    MODEL_ENTRY_POINTS = _get_model_entry_points()
     TRAC_PACKAGE_PATH: pathlib.Path = _get_package_path("tracdap.rt")
     SITE_PACKAGE_PATH: pathlib.Path = _get_package_path("pyarrow")
 

--- a/tracdap-runtime/python/test/tracdap_test/rt/impl/test_guard_rails.py
+++ b/tracdap-runtime/python/test/tracdap_test/rt/impl/test_guard_rails.py
@@ -18,6 +18,7 @@ import tracdap.rt._impl.guard_rails as guard  # noqa
 
 import typing as tp
 import unittest
+import sys
 
 from tracdap.rt.api import TracContext
 from tracdap.rt_gen.domain.tracdap.metadata import ModelOutputSchema, ModelInputSchema, ModelParameter
@@ -59,3 +60,10 @@ class PythonGuardRailsTest(unittest.TestCase):
 
         exec("print('Hello world')")
         self.assertTrue(True)
+
+    def test_sys_exit_inside_model(self):
+
+        test_model_class = create_model(lambda: sys.exit(-1))
+        test_model = test_model_class()
+
+        self.assertRaises(ex.EModelValidation, lambda: test_model.run_model(None))  # noqa

--- a/tracdap-runtime/python/test/tracdap_test/rt/impl/test_guard_rails.py
+++ b/tracdap-runtime/python/test/tracdap_test/rt/impl/test_guard_rails.py
@@ -1,0 +1,61 @@
+#  Copyright 2023 Accenture Global Solutions Limited
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import tracdap.rt.api as trac
+import tracdap.rt.exceptions as ex
+import tracdap.rt._impl.guard_rails as guard  # noqa
+
+import typing as tp
+import unittest
+
+from tracdap.rt.api import TracContext
+from tracdap.rt_gen.domain.tracdap.metadata import ModelOutputSchema, ModelInputSchema, ModelParameter
+
+
+def create_model(logic_func):
+
+    class TestModel(trac.TracModel):
+
+        def define_parameters(self) -> tp.Dict[str, ModelParameter]:
+            pass
+
+        def define_inputs(self) -> tp.Dict[str, ModelInputSchema]:
+            pass
+
+        def define_outputs(self) -> tp.Dict[str, ModelOutputSchema]:
+            pass
+
+        def run_model(self, ctx: TracContext):
+            logic_func()
+
+    return TestModel
+
+
+class PythonGuardRailsTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        guard.PythonGuardRails.protect_dangerous_functions()
+
+    def test_builtin_from_model(self):
+
+        test_model_class = create_model(lambda: exec("print('Hello world')"))
+        test_model = test_model_class()
+
+        self.assertRaises(ex.EModelValidation, lambda: test_model.run_model(None))  # noqa
+
+    def test_builtin_outside_model(self):
+
+        exec("print('Hello world')")
+        self.assertTrue(True)

--- a/tracdap-runtime/python/test/tracdap_test/rt/impl/test_shim_loader.py
+++ b/tracdap-runtime/python/test/tracdap_test/rt/impl/test_shim_loader.py
@@ -17,6 +17,7 @@ import unittest
 
 import tracdap.rt._impl.shim as shim
 import tracdap.rt._impl.util as util
+import tracdap.rt._impl.guard_rails as guard
 import tracdap.rt.exceptions as _ex
 
 _SHIM_TEST_DIR = pathlib.Path(__file__).parent \
@@ -34,6 +35,7 @@ class TestShimLoader(unittest.TestCase):
     def setUpClass(cls) -> None:
         util.configure_logging(enable_debug=True)
         cls._shim = cls._shim_loader.create_shim(_SHIM_TEST_DIR)
+        guard.PythonGuardRails.protect_dangerous_functions()
 
     def setUp(self):
         self._shim_loader.activate_shim(self._shim)

--- a/tracdap-services/tracdap-gateway/src/main/java/org/finos/tracdap/gateway/ProtocolNegotiator.java
+++ b/tracdap-services/tracdap-gateway/src/main/java/org/finos/tracdap/gateway/ProtocolNegotiator.java
@@ -392,7 +392,7 @@ public class ProtocolNegotiator extends ChannelInitializer<SocketChannel> {
 
             pipeline.addAfter(HTTP_1_AUTH, WS_FRAME_CODEC, new WebSocketServerProtocolHandler(wsConfig));
 
-            // Ådd the main handler - this should be the WebTransportRouter when the full service is running
+            // Add the main handler - this should be the WebTransportRouter when the full service is running
             pipeline.addLast(webSocketsHandler.create(connId.getAndIncrement()));
 
             pipeline.remove(this);


### PR DESCRIPTION
Prevent calling exec(), eval(), sys.exit() and other dangerous functions from model code