### PR TITLE
Logging configuration correction - RollingFile appender configured.

### DIFF
--- a/dev/config/trac-logging.xml
+++ b/dev/config/trac-logging.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 
-<Configuration strict="true" name="TRAC console logging configuration">
+<Configuration strict="true" name="TRAC file and console logging configuration">
 
     <Appenders>
 
@@ -29,11 +29,16 @@
         </Appender>
 
         <!-- Example appender for logging to files -->
-        <!-- <Appender
+        <!-- It is set up for development and testing purposes: files are changed every 2 minutes
+        ("modulated", that is at 00, 02, 04 and so on after every full hour) and they are deleted
+        on rolling if older than 5 minutes.-->
+
+        <Appender
                 name="LOCAL_FILES"
                 type="RollingFile"
                 fileName="build/log/tracdap-svc-meta.log"
-                filePattern="build/log/tracdap-svc-meta-%d{yyyy-MM-dd}.log.gz">
+                filePattern="build/log/tracdap-svc-meta-%d{yyyy-MM-dd-HH-mm}.log.gz"
+                append="true">
 
             <Layout type="PatternLayout" disableAnsi="true">
                 <Pattern>
@@ -41,17 +46,23 @@
                 </Pattern>
             </Layout>
 
-            <Policies>
-            </Policies>
+            <TimeBasedTriggeringPolicy interval="2" modulate="true"/>
 
-        </Appender> -->
+            <DefaultRolloverStrategy>
+                <Delete basePath="build/log/" maxDepth="1">
+                    <IfFileName glob="*.log*" />
+                    <IfLastModified age="5m" />
+                </Delete>
+            </DefaultRolloverStrategy>
+
+        </Appender>
 
     </Appenders>
 
     <Loggers>
         <Root level="info">
             <AppenderRef ref="STDOUT"/>
-            <!--<AppenderRef ref="LOCAL_FILES"/>-->
+            <AppenderRef ref="LOCAL_FILES"/>
         </Root>
     </Loggers>
 

--- a/dist/template/etc/trac-logging.xml
+++ b/dist/template/etc/trac-logging.xml
@@ -29,7 +29,8 @@
                 name="LOCAL_FILES"
                 type="RollingFile"
                 fileName="${sys:LOG_DIR}/${sys:LOG_NAME}.log"
-                filePattern="${sys:LOG_DIR}/${sys:LOG_NAME}-%d{yyyy-MM-dd}.log.gz">
+                filePattern="${sys:LOG_DIR}/${sys:LOG_NAME}-%d{yyyy-MM-dd}.log.gz"
+                append="true">
 
             <Layout type="PatternLayout" disableAnsi="true">
                 <Pattern>
@@ -37,8 +38,14 @@
                 </Pattern>
             </Layout>
 
-            <Policies>
-            </Policies>
+            <TimeBasedTriggeringPolicy />
+
+            <DefaultRolloverStrategy>
+                <Delete basePath="${sys:LOG_DIR}" maxDepth="1">
+                    <IfFileName glob="*.log*" />
+                    <IfLastModified age="30d" />
+                </Delete>
+            </DefaultRolloverStrategy>
 
         </Appender>
 


### PR DESCRIPTION
RollingFile has been configured to change current log file once every defined time interval. Rolled log files are also deleted on regular basis - when they get old enough. In addition the log files are not deleted on service restart (thanks to append="true" option for the appender). 

There are 2 optional configuration files:
- for testing and development purposes with 2 minute long rolling time interval and 5 minute threshold for old files deletion
- for distribution purposes with 1 day long rolling time interval and 30 days threshold for old files deletion

Additional comment:
It was not necessary to modify the code. During the problem analysis there was some confusion about reading of the log4j configuration files - it came from the fact, that I was analyzing the configuration obtained with the following code:
        LoggerContext context = (LoggerContext) LogManager.getContext();
        Configuration configuration = context.getConfiguration();
As I learned, this was wrong. I should have looked at the configuration of the logger returned by LoggerFactory, which is different. After noticing this mistake the rest of the configuration was rather straightforward. 