### PR TITLE
Backport / isLatestObject and isLatestTag flags in object_id (issue 345) (#349)

### DIFF
--- a/tracdap-api/tracdap-metadata/src/main/proto/tracdap/metadata/object_id.proto
+++ b/tracdap-api/tracdap-metadata/src/main/proto/tracdap/metadata/object_id.proto
@@ -82,6 +82,16 @@ message TagHeader {
    * Timestamp for when this version of the tag was created.
    */
   DatetimeValue tagTimestamp = 6;
+
+  /**
+   * isLatest flag for the object the tag is associated with.
+   */
+  bool isLatestObject = 7;
+
+  /**
+   * isLatest flag for the tag.
+   */
+  bool isLatestTag = 8;
 }
 
 

--- a/tracdap-libs/tracdap-lib-test/src/main/java/org/finos/tracdap/test/meta/TestData.java
+++ b/tracdap-libs/tracdap-lib-test/src/main/java/org/finos/tracdap/test/meta/TestData.java
@@ -104,6 +104,8 @@ public class TestData {
                 .setObjectId(UUID.randomUUID().toString())
                 .setObjectVersion(1)
                 .setTagVersion(1)
+                .setIsLatestObject(true)
+                .setIsLatestTag(true)
                 .setObjectTimestamp(MetadataCodec.encodeDatetime(timestamp))
                 .setTagTimestamp(MetadataCodec.encodeDatetime(timestamp))
                 .build();
@@ -115,6 +117,7 @@ public class TestData {
 
         return priorTagHeader.toBuilder()
                 .setTagVersion(priorTagHeader.getTagVersion() + 1)
+                .setIsLatestTag(true)
                 .setTagTimestamp(MetadataCodec.encodeDatetime(timestamp))
                 .build();
     }
@@ -444,6 +447,8 @@ public class TestData {
             var header = previous.getHeader().toBuilder()
                     .setObjectVersion(previous.getHeader().getObjectVersion() + 1)
                     .setTagVersion(1)
+                    .setIsLatestTag(true)
+                    .setIsLatestObject(true)
                     .setObjectTimestamp(MetadataCodec.encodeDatetime(timestamp))
                     .setTagTimestamp(MetadataCodec.encodeDatetime(timestamp))
                     .build();

--- a/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/dal/jdbc/JdbcBaseDal.java
+++ b/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/dal/jdbc/JdbcBaseDal.java
@@ -113,16 +113,18 @@ class JdbcBaseDal {
         final int version;
         final Instant timestamp;
         final TItem item;
+        final boolean isLatest;
 
-        KeyedItem(long key, int version, Instant timestamp, TItem item) {
+        KeyedItem(long key, int version, Instant timestamp, TItem item, boolean isLatest) {
             this.key = key;
             this.version = version;
             this.timestamp = timestamp;
             this.item = item;
+            this.isLatest = isLatest;
         }
 
         KeyedItem(long key, TItem item) {
-            this(key, 0, null, item);
+            this(key, 0, null, item, false);
         }
     }
 
@@ -132,20 +134,22 @@ class JdbcBaseDal {
         final int[] versions;
         final Instant[] timestamps;
         final TItem[] items;
+        final boolean[] isLatest;
 
-        KeyedItems(long[] keys, int[] versions, Instant[] timestamps, TItem[] items) {
+        KeyedItems(long[] keys, int[] versions, Instant[] timestamps, TItem[] items, boolean[] isLatest) {
             this.keys = keys;
             this.versions = versions;
             this.timestamps = timestamps;
             this.items = items;
+            this.isLatest = isLatest;
         }
 
         KeyedItems(long[] keys, int[] versions, TItem[] items) {
-            this(keys, versions, null, items);
+            this(keys, versions, null, items, null);
         }
 
         KeyedItems(long[] keys, TItem[] items) {
-            this(keys, null, null, items);
+            this(keys, null, null, items, null);
         }
     }
 }

--- a/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/dal/jdbc/JdbcMetadataDal.java
+++ b/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/dal/jdbc/JdbcMetadataDal.java
@@ -571,6 +571,8 @@ public class JdbcMetadataDal extends JdbcBaseDal implements IMetadataDal {
                 .setObjectId(objectId.toString())
                 .setObjectVersion(definition.version)
                 .setTagVersion(tagRecord.version)
+                .setIsLatestTag(tagRecord.isLatest)
+                .setIsLatestObject(definition.isLatest)
                 .setObjectTimestamp(MetadataCodec.encodeDatetime(objectTimestamp))
                 .setTagTimestamp(MetadataCodec.encodeDatetime(tagTimestamp));
 
@@ -598,6 +600,8 @@ public class JdbcMetadataDal extends JdbcBaseDal implements IMetadataDal {
                     .setObjectId(objectId[i].toString())
                     .setObjectVersion(definitions.versions[i])
                     .setTagVersion(tags.versions[i])
+                    .setIsLatestTag(tags.isLatest[i])
+                    .setIsLatestObject(definitions.isLatest[i])
                     .setObjectTimestamp(MetadataCodec.encodeDatetime(objectTimestamp))
                     .setTagTimestamp(MetadataCodec.encodeDatetime(tagTimestamp));
 

--- a/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/dal/jdbc/JdbcReadBatchImpl.java
+++ b/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/dal/jdbc/JdbcReadBatchImpl.java
@@ -107,7 +107,7 @@ class JdbcReadBatchImpl {
             throws SQLException {
 
         var query =
-                "select definition_pk, object_version, object_timestamp, definition\n" +
+                "select definition_pk, object_version, object_timestamp, definition, object_is_latest\n" +
                 "from object_definition def\n" +
                 "join key_mapping km\n" +
                 "  on def.definition_pk = km.pk\n" +
@@ -128,6 +128,7 @@ class JdbcReadBatchImpl {
                 int[] versions = new int[length];
                 Instant[] timestamps = new Instant[length];
                 ObjectDefinition[] defs = new ObjectDefinition[length];
+                boolean[] objectsIsLatest = new boolean[length];
 
                 for (var i = 0; i < length; i++) {
 
@@ -140,6 +141,7 @@ class JdbcReadBatchImpl {
                     var defTimestamp = sqlTimestamp.toInstant();
                     var defEncoded = rs.getBytes(4);
                     var defDecoded = ObjectDefinition.parseFrom(defEncoded);
+                    var objectIsLatest = rs.getBoolean(5);
 
                     // TODO: Encode / decode helper, type = protobuf | json ?
 
@@ -147,12 +149,13 @@ class JdbcReadBatchImpl {
                     versions[i] = defVersion;
                     timestamps[i] = defTimestamp;
                     defs[i] = defDecoded;
+                    objectsIsLatest[i] = objectIsLatest;
                 }
 
                 if (rs.next())
                     throw new JdbcException(JdbcErrorCode.TOO_MANY_ROWS);
 
-                return new JdbcBaseDal.KeyedItems<>(pks, versions, timestamps, defs);
+                return new JdbcBaseDal.KeyedItems<>(pks, versions, timestamps, defs, objectsIsLatest);
             }
             catch (InvalidProtocolBufferException e) {
                 throw new JdbcException(JdbcErrorCode.INVALID_OBJECT_DEFINITION);
@@ -193,7 +196,7 @@ class JdbcReadBatchImpl {
         // Note: Common attributes may be added to the tag table as search optimisations, but do not need to be read
 
         var query =
-                "select tag.tag_pk, tag.tag_version, tag.tag_timestamp\n" +
+                "select tag.tag_pk, tag.tag_version, tag.tag_timestamp, tag.tag_is_latest\n" +
                 "from tag\n" +
                 "join key_mapping km\n" +
                 "  on tag.tag_pk = km.pk\n" +
@@ -213,6 +216,7 @@ class JdbcReadBatchImpl {
                 long[] pks = new long[length];
                 int[] versions = new int[length];
                 Instant[] timestamps = new Instant[length];
+                boolean[] tagsIsLatest = new boolean[length];
 
                 for (var i = 0; i < length; i++) {
 
@@ -223,17 +227,19 @@ class JdbcReadBatchImpl {
                     var tagVersion = rs.getInt(2);
                     var sqlTimestamp = rs.getTimestamp(3);
                     var tagTimestamp = sqlTimestamp.toInstant();
+                    var tagIsLatest = rs.getBoolean(4);
 
                     pks[i] = tagPk;
                     versions[i] = tagVersion;
                     timestamps[i] = tagTimestamp;
+                    tagsIsLatest[i] = tagIsLatest;
                 }
 
                 if (rs.next())
                     throw new JdbcException(JdbcErrorCode.TOO_MANY_ROWS);
 
                 // Tag record requires only PK and version info
-                return new JdbcBaseDal.KeyedItems<>(pks, versions, timestamps, null);
+                return new JdbcBaseDal.KeyedItems<>(pks, versions, timestamps, null, tagsIsLatest);
             }
         }
     }
@@ -255,7 +261,8 @@ class JdbcReadBatchImpl {
                 "  obj.object_id_hi,\n" +
                 "  obj.object_id_lo,\n" +
                 "  def.object_version,\n" +
-                "  def.object_timestamp\n" +
+                "  def.object_timestamp,\n" +
+                "  def.object_is_latest\n"+
                 "from key_mapping km\n" +
                 "join object_definition def\n" +
                 "  on def.definition_pk = km.fk\n" +
@@ -290,6 +297,7 @@ class JdbcReadBatchImpl {
                     var objectVersion = rs.getInt(5);
                     var sqlTimestamp = rs.getTimestamp(6);
                     var objectTimestamp = sqlTimestamp.toInstant();
+                    var isLatestObject = rs.getBoolean(7);
 
                     var objectId = new UUID(objectIdHi, objectIdLo);
                     var objectType = ObjectType.valueOf(objectTypeCode);
@@ -298,6 +306,7 @@ class JdbcReadBatchImpl {
                             .setObjectType(objectType)
                             .setObjectId(objectId.toString())
                             .setObjectVersion(objectVersion)
+                            .setIsLatestObject(isLatestObject)
                             .setObjectTimestamp(MetadataCodec.encodeDatetime(objectTimestamp.atOffset(ZoneOffset.UTC)))
                             .build();
 
@@ -428,7 +437,7 @@ class JdbcReadBatchImpl {
                     .putAllAttrs(attrs[i]);
         }
 
-        return new JdbcBaseDal.KeyedItems<>(tagRecords.keys, tagRecords.versions, tagRecords.timestamps, tags);
+        return new JdbcBaseDal.KeyedItems<>(tagRecords.keys, tagRecords.versions, tagRecords.timestamps, tags, tagRecords.isLatest);
     }
 
     private JdbcBaseDal.KeyedItems<Tag.Builder>
@@ -445,6 +454,7 @@ class JdbcReadBatchImpl {
             var header = headers.items[i].toBuilder()
                     .setTagVersion(tagRecords.versions[i])
                     .setTagTimestamp(tagTimestamp)
+                    .setIsLatestTag(tagRecords.isLatest[i])
                     .build();
 
             tags[i] = Tag.newBuilder()
@@ -452,7 +462,7 @@ class JdbcReadBatchImpl {
                     .putAllAttrs(attrs[i]);
         }
 
-        return new JdbcBaseDal.KeyedItems<>(headers.keys, tagRecords.versions, tagRecords.timestamps, tags);
+        return new JdbcBaseDal.KeyedItems<>(headers.keys, tagRecords.versions, tagRecords.timestamps, tags, tagRecords.isLatest);
     }
 
 

--- a/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/services/MetadataWriteService.java
+++ b/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/services/MetadataWriteService.java
@@ -161,6 +161,8 @@ public class MetadataWriteService {
                 .setObjectTimestamp(MetadataCodec.encodeDatetime(timestamp))
                 .setTagVersion(TAG_FIRST_VERSION)
                 .setTagTimestamp(MetadataCodec.encodeDatetime(timestamp))
+                .setIsLatestTag(true)
+                .setIsLatestObject(true)
                 .build();
 
         var newTag = Tag.newBuilder()
@@ -240,6 +242,8 @@ public class MetadataWriteService {
                 .setObjectTimestamp(MetadataCodec.encodeDatetime(timestamp))
                 .setTagVersion(TAG_FIRST_VERSION)
                 .setTagTimestamp(MetadataCodec.encodeDatetime(timestamp))
+                .setIsLatestTag(true)
+                .setIsLatestObject(true)
                 .build();
 
         var newTag = priorTag.toBuilder()
@@ -307,6 +311,7 @@ public class MetadataWriteService {
         var newHeader = oldHeader.toBuilder()
                 .setTagVersion(oldHeader.getTagVersion() + 1)
                 .setTagTimestamp(MetadataCodec.encodeDatetime(timestamp))
+                .setIsLatestTag(true)
                 .build();
 
         var newTag = priorTag.toBuilder()

--- a/tracdap-services/tracdap-svc-meta/src/test/java/org/finos/tracdap/svc/meta/api/MetadataReadApiTest.java
+++ b/tracdap-services/tracdap-svc-meta/src/test/java/org/finos/tracdap/svc/meta/api/MetadataReadApiTest.java
@@ -279,7 +279,9 @@ abstract class MetadataReadApiTest {
         var t2TagSaved = readApi.readObject(t2MetadataReadRequest);
 
         var v1TagExpected = v1TagSaved.newBuilderForType()
-                .setHeader(v1Header)
+                .setHeader(v1Header.toBuilder()
+                        .setIsLatestTag(false)
+                        .setIsLatestObject(false))
                 .setDefinition(v1Obj)
                 .putAllAttrs(v1Attrs)
                 .build();
@@ -360,13 +362,17 @@ abstract class MetadataReadApiTest {
         var t2TagSaved = savedTags.getTag(2);
 
         var v1TagExpected = v1TagSaved.newBuilderForType()
-                .setHeader(v1Header)
+                .setHeader(v1Header.toBuilder()
+                        .setIsLatestTag(false)
+                        .setIsLatestObject(false))
                 .setDefinition(v1Obj)
                 .putAllAttrs(v1Attrs)
                 .build();
 
         var v2TagExpected = v2TagSaved.newBuilderForType()
-                .setHeader(v2Header)
+                .setHeader(v2Header.toBuilder()
+                        .setIsLatestTag(true)
+                        .setIsLatestObject(true))
                 .setDefinition(v2Obj)
                 .putAllAttrs(v1Attrs)
                 .build();
@@ -470,13 +476,17 @@ abstract class MetadataReadApiTest {
         var t2TagSaved = readApi.readObject(t2MetadataReadRequest);
 
         var v1TagExpected = v1TagSaved.newBuilderForType()
-                .setHeader(v1Header)
+                .setHeader(v1Header.toBuilder()
+                        .setIsLatestTag(false)
+                        .setIsLatestObject(false))
                 .setDefinition(v1Obj)
                 .putAllAttrs(v1Attrs)
                 .build();
 
         var v2TagExpected = v2TagSaved.newBuilderForType()
-                .setHeader(v2Header)
+                .setHeader(v2Header.toBuilder()
+                        .setIsLatestTag(true)
+                        .setIsLatestObject(true))
                 .setDefinition(v2Obj)
                 .putAllAttrs(v1Attrs)
                 .build();
@@ -579,13 +589,17 @@ abstract class MetadataReadApiTest {
         var t2TagSaved = savedTags.getTag(2);
 
         var v1TagExpected = v1TagSaved.newBuilderForType()
-                .setHeader(v1Header)
+                .setHeader(v1Header.toBuilder()
+                        .setIsLatestTag(false)
+                        .setIsLatestObject(false))
                 .setDefinition(v1Obj)
                 .putAllAttrs(v1Attrs)
                 .build();
 
         var v2TagExpected = v2TagSaved.newBuilderForType()
-                .setHeader(v2Header)
+                .setHeader(v2Header.toBuilder()
+                        .setIsLatestTag(true)
+                        .setIsLatestObject(true))
                 .setDefinition(v2Obj)
                 .putAllAttrs(v1Attrs)
                 .build();

--- a/tracdap-services/tracdap-svc-meta/src/test/java/org/finos/tracdap/svc/meta/api/MetadataSearchApiTest.java
+++ b/tracdap-services/tracdap-svc-meta/src/test/java/org/finos/tracdap/svc/meta/api/MetadataSearchApiTest.java
@@ -631,9 +631,14 @@ abstract class MetadataSearchApiTest {
         // The object for header2 was created last
         // So, that should be the first result
 
-        Assertions.assertEquals(2, asOfResult.getSearchResultCount());
-        Assertions.assertEquals(resultHeader1, header2);
-        Assertions.assertEquals(resultHeader2, header1);
+        header2 = header2.toBuilder()
+                    .setIsLatestTag(false)
+                    .setIsLatestObject(true)
+                .build();
+
+        assertEquals(2, asOfResult.getSearchResultCount());
+        assertEquals(resultHeader1, header2);
+        assertEquals(resultHeader2, header1);
     }
 
     @Test
@@ -692,9 +697,14 @@ abstract class MetadataSearchApiTest {
                 .build();
 
         var result = searchApi.search(searchRequest);
+        var resultFirstHeader = result.getSearchResult(0).getHeader();
+        v1t1Header = v1t1Header.toBuilder()
+                    .setIsLatestTag(false)
+                    .setIsLatestObject(false)
+                .build();
 
-        Assertions.assertEquals(1, result.getSearchResultCount());
-        Assertions.assertEquals(v1t1Header, result.getSearchResult(0).getHeader());
+        assertEquals(1, result.getSearchResultCount());
+        assertEquals(v1t1Header, resultFirstHeader);
     }
 
     @Test

--- a/tracdap-services/tracdap-svc-meta/src/test/java/org/finos/tracdap/svc/meta/dal/MetadataDalReadTest.java
+++ b/tracdap-services/tracdap-svc-meta/src/test/java/org/finos/tracdap/svc/meta/dal/MetadataDalReadTest.java
@@ -81,8 +81,19 @@ abstract class MetadataDalReadTest implements IDalTestable {
         var v2t1 = dal.loadObject(TEST_TENANT, selector2t1);
         var v2t2 = dal.loadObject(TEST_TENANT, selector2t2);
 
-        assertEquals(origTag, v1t1);
-        assertEquals(nextDefTag1, v2t1);
+        var expectedTag1 = origTag.toBuilder()
+                        .setHeader(origTag.getHeader().toBuilder()
+                                .setIsLatestObject(false)
+                                .setIsLatestTag(true))
+                        .build();
+        var expectedTag2 = nextDefTag1.toBuilder()
+                .setHeader(nextDefTag1.getHeader().toBuilder()
+                        .setIsLatestObject(true)
+                        .setIsLatestTag(false))
+                .build();
+
+        assertEquals(expectedTag1, v1t1);
+        assertEquals(expectedTag2, v2t1);
         assertEquals(nextDefTag2, v2t2);
     }
 
@@ -114,8 +125,19 @@ abstract class MetadataDalReadTest implements IDalTestable {
         var v2t1 = batch.get(1);
         var v2t2 = batch.get(2);
 
-        assertEquals(origTag, v1t1);
-        assertEquals(nextDefTag1, v2t1);
+        var expectedTag1 = origTag.toBuilder()
+                        .setHeader(origTag.getHeader().toBuilder()
+                                .setIsLatestTag(true)
+                                .setIsLatestObject(false))
+                        .build();
+        var expectedTag2 = nextDefTag1.toBuilder()
+                .setHeader(nextDefTag1.getHeader().toBuilder()
+                        .setIsLatestTag(false)
+                        .setIsLatestObject(true))
+                .build();
+
+        assertEquals(expectedTag1, v1t1);
+        assertEquals(expectedTag2, v2t1);
         assertEquals(nextDefTag2, v2t2);
     }
 
@@ -164,8 +186,19 @@ abstract class MetadataDalReadTest implements IDalTestable {
         var v2t1 = dal.loadObject(TEST_TENANT, selector2t1);
         var v2t2 = dal.loadObject(TEST_TENANT, selector2t2);
 
-        assertEquals(origTag, v1t1);
-        assertEquals(nextDefTag1, v2t1);
+        var expectedTag1 = origTag.toBuilder()
+                .setHeader(origTag.getHeader().toBuilder()
+                        .setIsLatestTag(true)
+                        .setIsLatestObject(false))
+                .build();
+        var expectedTag2 = nextDefTag1.toBuilder()
+                .setHeader(nextDefTag1.getHeader().toBuilder()
+                        .setIsLatestTag(false)
+                        .setIsLatestObject(true))
+                .build();
+
+        assertEquals(expectedTag1, v1t1);
+        assertEquals(expectedTag2, v2t1);
         assertEquals(nextDefTag2, v2t2);
     }
 
@@ -216,8 +249,19 @@ abstract class MetadataDalReadTest implements IDalTestable {
         var v2t1 = batch.get(1);
         var v2t2 = batch.get(2);
 
-        assertEquals(origTag, v1t1);
-        assertEquals(nextDefTag1, v2t1);
+        var expectedTag1 = origTag.toBuilder()
+                        .setHeader(origTag.getHeader().toBuilder()
+                                .setIsLatestObject(false)
+                                .setIsLatestTag(true))
+                        .build();
+        var expectedTag2 = nextDefTag1.toBuilder()
+                .setHeader(nextDefTag1.getHeader().toBuilder()
+                        .setIsLatestObject(true)
+                        .setIsLatestTag(false))
+                .build();
+
+        assertEquals(expectedTag1, v1t1);
+        assertEquals(expectedTag2, v2t1);
         assertEquals(nextDefTag2, v2t2);
     }
 
@@ -349,8 +393,19 @@ abstract class MetadataDalReadTest implements IDalTestable {
         var combo2 = dal.loadObject(TEST_TENANT, selectCombo2);
         var combo3 = dal.loadObject(TEST_TENANT, selectCombo3);
 
-        assertEquals(v2t2Tag, combo1);
-        assertEquals(v2t2Tag, combo2);
+        var expectedTag1 = v2t2Tag.toBuilder()
+                .setHeader(v2t2Tag.getHeader().toBuilder()
+                        .setIsLatestTag(true)
+                        .setIsLatestObject(false))
+                .build();
+        var expectedTag2 = v2t2Tag.toBuilder()
+                .setHeader(v2t2Tag.getHeader().toBuilder()
+                        .setIsLatestTag(true)
+                        .setIsLatestObject(false))
+                .build();
+
+        assertEquals(expectedTag1, combo1);
+        assertEquals(expectedTag2, combo2);
         assertEquals(v3t1Tag, combo3);
     }
 
@@ -409,8 +464,14 @@ abstract class MetadataDalReadTest implements IDalTestable {
         var combo2 = batch.get(1);
         var combo3 = batch.get(2);
 
-        assertEquals(v2t2Tag, combo1);
-        assertEquals(v2t2Tag, combo2);
+        var expectedTag = v2t2Tag.toBuilder()
+                .setHeader(v2t2Tag.getHeader().toBuilder()
+                        .setIsLatestTag(true)
+                        .setIsLatestObject(false))
+                .build();
+
+        assertEquals(expectedTag, combo1);
+        assertEquals(expectedTag, combo2);
         assertEquals(v3t1Tag, combo3);
     }
     
@@ -508,10 +569,21 @@ abstract class MetadataDalReadTest implements IDalTestable {
         var t2BoundaryTag = dal.loadObject(TEST_TENANT, t2BoundarySelector);
         var t2PriorTag = dal.loadObject(TEST_TENANT, t2PriorSelector);
 
-        assertEquals(v2Tag, v2BoundaryTag);
-        assertEquals(v1Tag, v2PriorTag);
+        var expectedTag1 = v2Tag.toBuilder()
+                .setHeader(v2Tag.getHeader().toBuilder()
+                        .setIsLatestTag(false)
+                        .setIsLatestObject(true))
+                .build();
+        var expectedTag2 = v1Tag.toBuilder()
+                .setHeader(v1Tag.getHeader().toBuilder()
+                        .setIsLatestTag(true)
+                        .setIsLatestObject(false))
+                .build();
+
+        assertEquals(expectedTag1, v2BoundaryTag);
+        assertEquals(expectedTag2, v2PriorTag);
         assertEquals(t2Tag, t2BoundaryTag);
-        assertEquals(v2Tag, t2PriorTag);
+        assertEquals(expectedTag1, t2PriorTag);
     }
 
     @Test
@@ -554,11 +626,26 @@ abstract class MetadataDalReadTest implements IDalTestable {
         var batch2 = dal.loadObjects(TEST_TENANT, List.of(t2BoundarySelector, t2PriorSelector));
         var t2BoundaryTag = batch2.get(0);
         var t2PriorTag = batch2.get(1);
+        var expextedv2Tag = v2Tag.toBuilder()
+                .setHeader(v2Tag.getHeader().toBuilder()
+                        .setIsLatestTag(false)
+                        .setIsLatestObject(true))
+                .build();
+        var expextedv1Tag = v1Tag.toBuilder()
+                .setHeader(v1Tag.getHeader().toBuilder()
+                        .setIsLatestTag(true)
+                        .setIsLatestObject(false))
+                .build();
+        var expextedt2Tag = t2Tag.toBuilder()
+                .setHeader(t2Tag.getHeader().toBuilder()
+                        .setIsLatestTag(true)
+                        .setIsLatestObject(true))
+                .build();
 
-        assertEquals(v2Tag, v2BoundaryTag);
-        assertEquals(v1Tag, v2PriorTag);
-        assertEquals(t2Tag, t2BoundaryTag);
-        assertEquals(v2Tag, t2PriorTag);
+        assertEquals(expextedv2Tag, v2BoundaryTag);
+        assertEquals(expextedv1Tag, v2PriorTag);
+        assertEquals(expextedt2Tag, t2BoundaryTag);
+        assertEquals(expextedv2Tag, t2PriorTag);
     }
 
     @Test

--- a/tracdap-services/tracdap-svc-meta/src/test/java/org/finos/tracdap/svc/meta/dal/MetadataDalSearchTest.java
+++ b/tracdap-services/tracdap-svc-meta/src/test/java/org/finos/tracdap/svc/meta/dal/MetadataDalSearchTest.java
@@ -19,11 +19,8 @@ package org.finos.tracdap.svc.meta.dal;
 import org.finos.tracdap.metadata.*;
 import org.finos.tracdap.common.metadata.TypeSystem;
 import org.finos.tracdap.common.metadata.MetadataCodec;
-import org.finos.tracdap.test.meta.IDalTestable;
-import org.finos.tracdap.test.meta.JdbcUnit;
-import org.finos.tracdap.test.meta.JdbcIntegration;
+import org.finos.tracdap.test.meta.*;
 
-import org.finos.tracdap.test.meta.TestData;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -1408,8 +1405,13 @@ abstract class MetadataDalSearchTest implements IDalTestable {
 
         var resultPriorVersions = dal.search(TEST_TENANT, searchPriorVersions);
 
-        Assertions.assertEquals(1, resultPriorVersions.size());
-        Assertions.assertEquals(v2Tag.getHeader(), resultPriorVersions.get(0).getHeader());
+        var expectedTagHeader = v2Tag.getHeader().toBuilder()
+                        .setIsLatestTag(true)
+                        .setIsLatestObject(false)
+                .build();
+
+        assertEquals(1, resultPriorVersions.size());
+        assertEquals(expectedTagHeader, resultPriorVersions.get(0).getHeader());
     }
 
     @Test
@@ -1459,8 +1461,13 @@ abstract class MetadataDalSearchTest implements IDalTestable {
 
         var resultPriorTags = dal.search(TEST_TENANT, searchPriorTags);
 
-        Assertions.assertEquals(1, resultPriorTags.size());
-        Assertions.assertEquals(t2Tag.getHeader(), resultPriorTags.get(0).getHeader());
+        var expectedTagHeader = t2Tag.getHeader().toBuilder()
+                        .setIsLatestObject(true)
+                        .setIsLatestTag(false)
+                .build();
+
+        assertEquals(1, resultPriorTags.size());
+        assertEquals(expectedTagHeader, resultPriorTags.get(0).getHeader());
     }
 
     @Test
@@ -1535,13 +1542,17 @@ abstract class MetadataDalSearchTest implements IDalTestable {
         var asOfResult = dal.search(TEST_TENANT, asOfSearch);
         var resultHeader1 = asOfResult.get(0).getHeader();
         var resultHeader2 = asOfResult.get(1).getHeader();
+        var expectedv1TagHeader = v1Tag.getHeader().toBuilder()
+                    .setIsLatestTag(true)
+                    .setIsLatestObject(false)
+                .build();
 
         // The versioned tag should be returned first in the list
         // This is because results are returned with the most recently updated first
 
-        Assertions.assertEquals(2, asOfResult.size());
-        Assertions.assertEquals(v1Tag.getHeader(), resultHeader1);
-        Assertions.assertEquals(unchangedTag.getHeader(), resultHeader2);
+        assertEquals(2, asOfResult.size());
+        assertEquals(expectedv1TagHeader, resultHeader1);
+        assertEquals(unchangedTag.getHeader(), resultHeader2);
     }
 
     @Test
@@ -1606,8 +1617,13 @@ abstract class MetadataDalSearchTest implements IDalTestable {
 
         var result2 = dal.search(TEST_TENANT, search2);
 
-        Assertions.assertEquals(1, result2.size());
-        Assertions.assertEquals(v2t1Tag.getHeader(), result2.get(0).getHeader());
+        var expectedTagHeader1 = v2t1Tag.getHeader().toBuilder()
+                        .setIsLatestTag(false)
+                        .setIsLatestObject(true)
+                .build();
+
+        assertEquals(1, result2.size());
+        assertEquals(expectedTagHeader1, result2.get(0).getHeader());
 
         var search3 = SearchParameters.newBuilder()
                 .setObjectType(ObjectType.DATA)
@@ -1617,8 +1633,13 @@ abstract class MetadataDalSearchTest implements IDalTestable {
 
         var result3 = dal.search(TEST_TENANT, search3);
 
-        Assertions.assertEquals(1, result3.size());
-        Assertions.assertEquals(v1t2Tag.getHeader(), result3.get(0).getHeader());
+        var expectedTagHeader2 = v1t2Tag.getHeader().toBuilder()
+                    .setIsLatestTag(true)
+                    .setIsLatestObject(false)
+                .build();
+
+        assertEquals(1, result3.size());
+        assertEquals(expectedTagHeader2, result3.get(0).getHeader());
 
         var search4 = SearchParameters.newBuilder()
                 .setObjectType(ObjectType.DATA)
@@ -1628,8 +1649,13 @@ abstract class MetadataDalSearchTest implements IDalTestable {
 
         var result4 = dal.search(TEST_TENANT, search4);
 
-        Assertions.assertEquals(1, result4.size());
-        Assertions.assertEquals(v1t1Tag.getHeader(), result4.get(0).getHeader());
+        var expectedTagHeader3 = v1t1Tag.getHeader().toBuilder()
+                    .setIsLatestTag(false)
+                    .setIsLatestObject(false)
+                .build();
+
+        assertEquals(1, result4.size());
+        assertEquals(expectedTagHeader3, result4.get(0).getHeader());
 
         // Stepping back before the object was created should give an empty search result
 
@@ -1725,8 +1751,13 @@ abstract class MetadataDalSearchTest implements IDalTestable {
 
         var result2 = dal.search(TEST_TENANT, search2);
 
-        Assertions.assertEquals(1, result2.size());
-        Assertions.assertEquals(obj2t1Tag.getHeader(), result2.get(0).getHeader());
+        var expectedTagHeader = obj2t1Tag.getHeader().toBuilder()
+                    .setIsLatestTag(false)
+                    .setIsLatestObject(true)
+                .build();
+
+        assertEquals(1, result2.size());
+        assertEquals(expectedTagHeader, result2.get(0).getHeader());
     }
 
     @Test
@@ -1823,9 +1854,14 @@ abstract class MetadataDalSearchTest implements IDalTestable {
                 .build();
 
         var result = dal.search(TEST_TENANT, searchParams);
+        var resultFirstTag = result.get(0);
+        var expectedHeader = v1t3.getHeader().toBuilder()
+                    .setIsLatestTag(false)
+                    .setIsLatestObject(false)
+                .build();
 
         assertEquals(1, result.size());
-        assertEquals(v1t3.getHeader(), result.get(0).getHeader());
+        assertEquals(expectedHeader, resultFirstTag.getHeader());
     }
 
     @Test


### PR DESCRIPTION
* WIP

* WIP

* WIP

* WIP

* New test for isLatestTag and isLatestObject flags.

* WIP

* Old test correction.

* Tests modification: setting expected isLatest(...) flags instead of checking them with assertTrue or assertFalse.

* Cosmetic changes for issue 345.