### PR TITLE
Fix / Type coercion for default model parameters

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -20,7 +20,7 @@ ext {
 
     // Core platform technologies
     netty_version = '4.1.86.Final'
-    guava_version = '31.1-jre'
+    guava_version = '32.0.0-jre'
     proto_version = '3.21.10'
     grpc_version = '1.49.0'
     gapi_version = '2.9.2'

--- a/tracdap-runtime/python/src/tracdap/rt/_impl/static_api.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_impl/static_api.py
@@ -82,7 +82,11 @@ class StaticApiImpl(_StaticApiHook):
             param_type_descriptor = _meta.TypeDescriptor(param_type, None, None)
 
         if default_value is not None and not isinstance(default_value, _meta.Value):
-            default_value = _type_system.MetadataCodec.encode_value(default_value)
+            try:
+                default_value = _type_system.MetadataCodec.convert_value(default_value, param_type_descriptor)
+            except _ex.ETrac as e:
+                msg = f"Default value for parameter [{param_name}] does not match the declared type"
+                raise _ex.EModelValidation(msg) from e
 
         return _Named(param_name, _meta.ModelParameter(param_type_descriptor, label, default_value))
 

--- a/tracdap-runtime/python/src/tracdap/rt/api/static_api.py
+++ b/tracdap-runtime/python/src/tracdap/rt/api/static_api.py
@@ -125,7 +125,8 @@ def define_parameter(
     If a default value is specified, the model parameter becomes optional. It is ok to omit optional parameters
     when running models or setting up jobs, in which case the default value will be used. If no default is
     specified then the model parameter becomes mandatory, a value must always be supplied in order to execute
-    the model.
+    the model. TRAC will apply type coercion where possible to ensure the default value matches the parameter type,
+    if the default value cannot be coerced to match the parameter type then model validation will fail.
 
     Once defined model parameters can be passed to :py:func:`define_parameters`,
     either as a list or as individual arguments, to create the set of parameters for a model.

--- a/tracdap-runtime/python/test/tracdap_test/rt/exec/test_context.py
+++ b/tracdap-runtime/python/test/tracdap_test/rt/exec/test_context.py
@@ -40,27 +40,27 @@ class _TestModel(_api.TracModel):
 
             _api.P("integer_param", _api.BasicType.INTEGER,
                    label="An integer param",
-                   default_value=False),
+                   default_value=1),
 
             _api.P("float_param", _api.BasicType.FLOAT,
                    label="A float param",
-                   default_value=False),
+                   default_value=1.0),
 
             _api.P("decimal_param", _api.BasicType.DECIMAL,
                    label="A decimal param",
-                   default_value=False),
+                   default_value=1.0),
 
             _api.P("string_param", _api.BasicType.STRING,
                    label="A string param",
-                   default_value=False),
+                   default_value="hello"),
 
             _api.P("date_param", _api.BasicType.DATE,
                    label="A date param",
-                   default_value=False),
+                   default_value="2000-01-01"),  # type coercion string -> date
 
             _api.P("datetime_param", _api.BasicType.DATETIME,
                    label="A datetime param",
-                   default_value=False))
+                   default_value=datetime.datetime.now()))  # Using Python datetime values also works
 
     def define_inputs(self) -> tp.Dict[str, _api.ModelInputSchema]:
 

--- a/tracdap-runtime/python/test/tracdap_test/rt/impl/test_models.py
+++ b/tracdap-runtime/python/test/tracdap_test/rt/impl/test_models.py
@@ -33,7 +33,8 @@ class SampleModel(api.TracModel):
 
         return api.declare_parameters(
             api.P("param1", api.INTEGER, label="A first parameter"),
-            api.P("param2", api.STRING, label="A second parameter"))
+            api.P("param2", api.STRING, label="A second parameter"),
+            api.P("param3", api.FLOAT, label="Param 3, test default type coercion", default_value=1))
 
     def define_inputs(self) -> tp.Dict[str, api.ModelInputSchema]:
 
@@ -183,9 +184,12 @@ class ImportModelTest(unittest.TestCase):
         self.assertIsInstance(model_def, meta.ModelDefinition)
 
         self.assertIsInstance(model_def.parameters, dict)
-        self.assertEqual({"param1", "param2"}, set(model_def.parameters.keys()))
+        self.assertEqual({"param1", "param2", "param3"}, set(model_def.parameters.keys()))
         self.assertEqual(_td(meta.BasicType.INTEGER), model_def.parameters["param1"].paramType, )
         self.assertEqual(_td(meta.BasicType.STRING), model_def.parameters["param2"].paramType)
+        self.assertEqual(_td(meta.BasicType.FLOAT), model_def.parameters["param3"].paramType)
+        # Check type coercion is correctly applied to the default parameter
+        self.assertEqual(_td(meta.BasicType.FLOAT), model_def.parameters["param3"].defaultValue.type)
 
         self.assertIsInstance(model_def.inputs, dict)
         self.assertEqual({"input_table_1"}, set(model_def.inputs.keys()))


### PR DESCRIPTION
* Apply type coercion where possible for default model parameters
* If type coercion is not possible, raise errors in the runtime rather than waiting for platform validation