### PR TITLE
Feature / Add fsspec implementation for GCP storage in the runtime

### DIFF
--- a/tracdap-runtime/python/requirements_plugins.txt
+++ b/tracdap-runtime/python/requirements_plugins.txt
@@ -14,23 +14,40 @@
 # AWS
 # ----------------------------------------------------------------------------------------------------------------------
 
-botocore == 1.29.133
-boto3 == 1.26.133
+# AWS client libraries
 
+botocore == 1.29.156
+boto3 == 1.26.156
+
+# S3 FS Spec implementation depends on aiobotocore
+# This is a separate library that depends on a very old version of botocore
+# It is not really possible to use them together and maintain compliance
 
 # ----------------------------------------------------------------------------------------------------------------------
 # GCP
 # ----------------------------------------------------------------------------------------------------------------------
 
-# Currently GCP is entirely supported using Arrow's native storage implementation
-# No need for extra libs at present
+# GCP client libraries
+
+google-auth == 2.20.0
+google-cloud-core == 2.3.2
+google-cloud-storage == 2.9.0
+
+# GCS implementation of FS Spec
+
+gcsfs == 2023.6.0
 
 
 # ----------------------------------------------------------------------------------------------------------------------
 # Azure
 # ----------------------------------------------------------------------------------------------------------------------
 
+# AWS client libraries
+
 azure-core == 1.26.4
 azure-identity == 1.13.0
 azure-storage-blob == 12.16.0
+
+# Asure implementation of FS Spec
+
 adlfs == 2023.4.0

--- a/tracdap-runtime/python/setup.cfg
+++ b/tracdap-runtime/python/setup.cfg
@@ -75,8 +75,14 @@ spark =
     pyspark >= 3.0.0, < 3.5.0
 
 aws =
-    botocore == 1.29.133
-    boto3 == 1.26.133
+    botocore == 1.29.156
+    boto3 == 1.26.156
+
+gcp =
+    google-auth == 2.20.0
+    google-cloud-core == 2.3.2
+    google-cloud-storage == 2.9.0
+    gcsfs == 2023.6.0
 
 azure =
     azure-core == 1.26.4

--- a/tracdap-runtime/python/src/tracdap/rt/_impl/storage.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_impl/storage.py
@@ -205,7 +205,6 @@ class CommonFileStorage(IFileStorage):
 
     FILE_SEMANTICS_FS_TYPES = ["local"]
     BUCKET_SEMANTICS_FS_TYPES = ["s3", "gcs", "abfs"]
-    EXPLICIT_DIR_FS_TYPES = ["abfs"]
 
     def __init__(self, storage_key: str, storage_config: _cfg.PluginConfig, fs: pa_fs.SubTreeFileSystem):
 
@@ -223,13 +222,13 @@ class CommonFileStorage(IFileStorage):
         if isinstance(base_fs, pa_fs.PyFileSystem):
             handler = base_fs.handler
             if isinstance(handler, pa_fs.FSSpecHandler):
-                fs_type = handler.fs.protocol
+                fs_type = handler.fs.protocol[0] if isinstance(handler.fs.protocol, tuple) else handler.fs.protocol
                 fs_impl = "fsspec"
 
         # Some optimization is possible if the underlying storage semantics are known
         self._file_semantics = True if fs_type in self.FILE_SEMANTICS_FS_TYPES else False
         self._bucket_semantics = True if fs_type in self.BUCKET_SEMANTICS_FS_TYPES else False
-        self._explicit_dir_semantics = True if fs_type in self.EXPLICIT_DIR_FS_TYPES else False
+        self._explicit_dir_semantics = True if self._bucket_semantics and fs_impl == "fsspec" else False
 
         self._log.info(
             f"INIT [{self._key}]: Common file storage, " +

--- a/tracdap-runtime/python/src/tracdap/rt/_impl/storage.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_impl/storage.py
@@ -331,7 +331,8 @@ class CommonFileStorage(IFileStorage):
 
         # Otherwise do a normal directory listing
         else:
-            selector = pa_fs.FileSelector(resolved_path, recursive=recursive)  # noqa
+            # A trailing slash prevents some implementations including the directory in its own listing
+            selector = pa_fs.FileSelector(resolved_path + "/", recursive=recursive)  # noqa
             file_infos = self._fs.get_file_info(selector)
             file_infos = filter(lambda fi: not fi.path.endswith(self._TRAC_DIR_MARKER), file_infos)
             return list(map(self._info_to_stat, file_infos))

--- a/tracdap-runtime/python/src/tracdap/rt/_plugins/storage_aws.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_plugins/storage_aws.py
@@ -325,7 +325,7 @@ class S3ObjectStorage(IFileStorage):
         data = self.read_bytes(storage_path)
         return io.BytesIO(data)
 
-    def _read_impl(self, storage_path: str) -> botocore.response.StreamingBody:
+    def _read_impl(self, storage_path: str):
 
         try:
 

--- a/tracdap-runtime/python/src/tracdap/rt/_plugins/storage_local.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_plugins/storage_local.py
@@ -35,8 +35,12 @@ from . import _helpers
 class LocalStorageProvider(IStorageProvider):
 
     ROOT_PATH_PROPERTY = "rootPath"
-    ARROW_NATIVE_FS_PROPERTY = "arrowNativeFs"
-    ARROW_NATIVE_FS_DEFAULT = False
+
+    RUNTIME_FS_PROPERTY = "runtimeFs"
+    RUNTIME_FS_AUTO = "auto"
+    RUNTIME_FS_ARROW = "arrow"
+    RUNTIME_FS_PYTHON = "python"
+    RUNTIME_FS_DEFAULT = RUNTIME_FS_AUTO
 
     def __init__(self, properties: tp.Dict[str, str]):
 
@@ -45,14 +49,15 @@ class LocalStorageProvider(IStorageProvider):
 
         self._root_path = self.check_root_path(self._properties, self._log)
 
-        self._arrow_native = _helpers.get_plugin_property_boolean(
-            properties, self.ARROW_NATIVE_FS_PROPERTY, self.ARROW_NATIVE_FS_DEFAULT)
+        self._runtime_fs = _helpers.get_plugin_property(
+            properties, self.RUNTIME_FS_PROPERTY) \
+            or self.RUNTIME_FS_DEFAULT
 
     def has_arrow_native(self) -> bool:
-        return True if self._arrow_native else False
+        return self._runtime_fs in [self.RUNTIME_FS_ARROW, self.RUNTIME_FS_AUTO]
 
     def has_file_storage(self) -> bool:
-        return False if self._arrow_native else True
+        return self._runtime_fs == self.RUNTIME_FS_PYTHON
 
     def get_arrow_native(self) -> afs.SubTreeFileSystem:
         root_fs = afs.LocalFileSystem()

--- a/tracdap-runtime/python/src/tracdap/rt/ext/storage.py
+++ b/tracdap-runtime/python/src/tracdap/rt/ext/storage.py
@@ -84,12 +84,12 @@ class IFileStorage:
         pass
 
     @_abc.abstractmethod
-    def read_byte_stream(self, storage_path: str) -> _tp.BinaryIO:
+    def read_byte_stream(self, storage_path: str) -> _tp.ContextManager[_tp.BinaryIO]:
         """The read_byte_stream method only works for existing files"""
         pass
 
     @_abc.abstractmethod
-    def write_byte_stream(self, storage_path: str) -> _tp.BinaryIO:
+    def write_byte_stream(self, storage_path: str) -> _tp.ContextManager[_tp.BinaryIO]:
         """The write_byte_stream method will always overwrite an existing file if it exists"""
         pass
 

--- a/tracdap-runtime/python/test/tracdap_test/rt/impl/test_storage_local.py
+++ b/tracdap-runtime/python/test/tracdap_test/rt/impl/test_storage_local.py
@@ -34,7 +34,7 @@ _plugins.PluginManager.register_core_plugins()
 # ----------------------------------------------------------------------------------------------------------------------
 
 
-class LocalFileStorageTest(unittest.TestCase, FileOperationsTestSuite, FileReadWriteTestSuite):
+class LocalArrowImplStorageTest(unittest.TestCase, FileOperationsTestSuite, FileReadWriteTestSuite):
 
     storage_root: tempfile.TemporaryDirectory
     test_number: int
@@ -50,11 +50,13 @@ class LocalFileStorageTest(unittest.TestCase, FileOperationsTestSuite, FileReadW
         test_dir = pathlib.Path(self.storage_root.name).joinpath(f"test_{self.test_number}")
         test_dir.mkdir()
 
-        LocalFileStorageTest.test_number += 1
+        self.__class__.test_number += 1
 
         test_storage_config = _cfg.PluginConfig(
             protocol="LOCAL",
-            properties={"rootPath": str(test_dir)})
+            properties={
+                "rootPath": str(test_dir),
+                "runtimeFs": "arrow"})
 
         sys_config = _cfg.RuntimeConfig()
         sys_config.storage = _cfg.StorageConfig()
@@ -69,7 +71,7 @@ class LocalFileStorageTest(unittest.TestCase, FileOperationsTestSuite, FileReadW
         cls.storage_root.cleanup()
 
 
-class LocalArrowNativeStorageTest(unittest.TestCase, FileOperationsTestSuite, FileReadWriteTestSuite):
+class LocalPythonImplStorageTest(unittest.TestCase, FileOperationsTestSuite, FileReadWriteTestSuite):
 
     storage_root: tempfile.TemporaryDirectory
     test_number: int
@@ -85,13 +87,13 @@ class LocalArrowNativeStorageTest(unittest.TestCase, FileOperationsTestSuite, Fi
         test_dir = pathlib.Path(self.storage_root.name).joinpath(f"test_{self.test_number}")
         test_dir.mkdir()
 
-        LocalArrowNativeStorageTest.test_number += 1
+        self.__class__.test_number += 1
 
         test_storage_config = _cfg.PluginConfig(
             protocol="LOCAL",
             properties={
                 "rootPath": str(test_dir),
-                "arrowNativeFs": "true"})
+                "runtimeFs": "python"})
 
         sys_config = _cfg.RuntimeConfig()
         sys_config.storage = _cfg.StorageConfig()
@@ -153,7 +155,7 @@ class LocalStorageTest(DataStorageTestSuite):
                 self.storage_format, schema))
 
 
-class LocalCsvStorageTest(unittest.TestCase, LocalStorageTest):
+class LocalCsvFormatStorageTest(unittest.TestCase, LocalStorageTest):
 
     @classmethod
     def setUpClass(cls) -> None:
@@ -299,7 +301,7 @@ class LocalCsvStorageTest(unittest.TestCase, LocalStorageTest):
         self.assertEqual(10, table.num_rows)
 
 
-class LocalArrowStorageTest(unittest.TestCase, LocalStorageTest):
+class LocalArrowFormatStorageTest(unittest.TestCase, LocalStorageTest):
 
     @classmethod
     def setUpClass(cls) -> None:
@@ -311,7 +313,7 @@ class LocalArrowStorageTest(unittest.TestCase, LocalStorageTest):
         cls.storage_root.cleanup()
 
 
-class LocalParquetStorageTest(unittest.TestCase, LocalStorageTest):
+class LocalParquetFormatStorageTest(unittest.TestCase, LocalStorageTest):
 
     @classmethod
     def setUpClass(cls) -> None:

--- a/tracdap-runtime/python/test/tracdap_test/rt/plugins/int_storage_aws.py
+++ b/tracdap-runtime/python/test/tracdap_test/rt/plugins/int_storage_aws.py
@@ -27,7 +27,7 @@ util.configure_logging()
 plugins.PluginManager.register_core_plugins()
 
 
-class S3StorageTest(unittest.TestCase, FileOperationsTestSuite, FileReadWriteTestSuite):
+class S3ArrowStorageTest(unittest.TestCase, FileOperationsTestSuite, FileReadWriteTestSuite):
 
     suite_storage_prefix = f"runtime_storage_test_suite_{uuid.uuid4()}"
     suite_storage: storage.IFileStorage
@@ -37,7 +37,6 @@ class S3StorageTest(unittest.TestCase, FileOperationsTestSuite, FileReadWriteTes
     def setUpClass(cls) -> None:
 
         properties = cls._properties_from_env()
-        properties["arrowNativeFs"] = "true"
 
         suite_storage_config = cfg.PluginConfig(protocol="S3", properties=properties)
 
@@ -52,7 +51,7 @@ class S3StorageTest(unittest.TestCase, FileOperationsTestSuite, FileReadWriteTes
 
         self.suite_storage.mkdir(test_dir)
 
-        S3StorageTest.test_number += 1
+        self.__class__.test_number += 1
 
         properties = self._properties_from_env()
         properties["arrowNativeFs"] = "true"
@@ -71,6 +70,7 @@ class S3StorageTest(unittest.TestCase, FileOperationsTestSuite, FileReadWriteTes
     def _properties_from_env():
 
         properties = dict()
+        properties["runtimeFs"] = "arrow"
         properties["region"] = os.getenv("TRAC_AWS_REGION")
         properties["bucket"] = os.getenv("TRAC_AWS_BUCKET")
 

--- a/tracdap-runtime/python/test/tracdap_test/rt/plugins/int_storage_azure.py
+++ b/tracdap-runtime/python/test/tracdap_test/rt/plugins/int_storage_azure.py
@@ -32,8 +32,6 @@ class AzureBlobStorageTest(unittest.TestCase, FileOperationsTestSuite, FileReadW
     suite_storage: storage.IFileStorage
     test_number: int
 
-    IS_AZURE = True
-
     @classmethod
     def setUpClass(cls) -> None:
 

--- a/tracdap-runtime/python/test/tracdap_test/rt/plugins/int_storage_azure.py
+++ b/tracdap-runtime/python/test/tracdap_test/rt/plugins/int_storage_azure.py
@@ -26,7 +26,7 @@ util.configure_logging()
 plugins.PluginManager.register_core_plugins()
 
 
-class AzureBlobStorageTest(unittest.TestCase, FileOperationsTestSuite, FileReadWriteTestSuite):
+class BlobFsspecStorageTest(unittest.TestCase, FileOperationsTestSuite, FileReadWriteTestSuite):
 
     suite_storage_prefix = f"runtime_storage_test_suite_{uuid.uuid4()}"
     suite_storage: storage.IFileStorage
@@ -50,7 +50,7 @@ class AzureBlobStorageTest(unittest.TestCase, FileOperationsTestSuite, FileReadW
 
         self.suite_storage.mkdir(test_dir)
 
-        AzureBlobStorageTest.test_number += 1
+        self.__class__.test_number += 1
 
         properties = self._properties_from_env()
         properties["prefix"] = test_dir

--- a/tracdap-runtime/python/test/tracdap_test/rt/plugins/int_storage_gcp.py
+++ b/tracdap-runtime/python/test/tracdap_test/rt/plugins/int_storage_gcp.py
@@ -23,9 +23,12 @@ import tracdap.rt._impl.util as util  # noqa
 import tracdap.rt._impl.storage as storage  # noqa
 import tracdap.rt._plugins.storage_aws as storage_aws  # noqa
 
+import pyarrow.fs as pa_fs
+
 plugins.PluginManager.register_core_plugins()
 
 
+@unittest.skipIf(pa_fs.GcsFileSystem is None, "Arrow GCS file system is not available on this platform")
 class GcsArrowStorageTest(unittest.TestCase, FileOperationsTestSuite, FileReadWriteTestSuite):
 
     suite_storage_prefix = f"runtime_storage_test_suite_{uuid.uuid4()}"

--- a/tracdap-runtime/python/test/tracdap_test/rt/plugins/int_storage_gcp.py
+++ b/tracdap-runtime/python/test/tracdap_test/rt/plugins/int_storage_gcp.py
@@ -53,7 +53,7 @@ class GcsArrowStorageTest(unittest.TestCase, FileOperationsTestSuite, FileReadWr
 
         self.suite_storage.mkdir(test_dir)
 
-        GcsArrowStorageTest.test_number += 1
+        self.__class__.test_number += 1
 
         properties = self._properties_from_env()
         properties["prefix"] = test_dir
@@ -121,7 +121,7 @@ class GcsFsspecStorageTest(unittest.TestCase, FileOperationsTestSuite, FileReadW
 
         self.suite_storage.mkdir(test_dir)
 
-        GcsArrowStorageTest.test_number += 1
+        self.__class__.test_number += 1
 
         properties = self._properties_from_env()
         properties["prefix"] = test_dir

--- a/tracdap-runtime/python/test/tracdap_test/rt/plugins/int_storage_gcp.py
+++ b/tracdap-runtime/python/test/tracdap_test/rt/plugins/int_storage_gcp.py
@@ -26,7 +26,7 @@ import tracdap.rt._plugins.storage_aws as storage_aws  # noqa
 plugins.PluginManager.register_core_plugins()
 
 
-class GcsStorageTest(unittest.TestCase, FileOperationsTestSuite, FileReadWriteTestSuite):
+class GcsArrowStorageTest(unittest.TestCase, FileOperationsTestSuite, FileReadWriteTestSuite):
 
     suite_storage_prefix = f"runtime_storage_test_suite_{uuid.uuid4()}"
     suite_storage: storage.IFileStorage
@@ -50,7 +50,7 @@ class GcsStorageTest(unittest.TestCase, FileOperationsTestSuite, FileReadWriteTe
 
         self.suite_storage.mkdir(test_dir)
 
-        GcsStorageTest.test_number += 1
+        GcsArrowStorageTest.test_number += 1
 
         properties = self._properties_from_env()
         properties["prefix"] = test_dir
@@ -68,6 +68,75 @@ class GcsStorageTest(unittest.TestCase, FileOperationsTestSuite, FileReadWriteTe
     def _properties_from_env():
 
         properties = dict()
+        properties["runtimeFs"] = "arrow"
+        properties["bucket"] = os.getenv("TRAC_GCP_BUCKET")
+
+        credentials = os.getenv("TRAC_GCP_CREDENTIALS")
+
+        if credentials is not None:
+            properties["credentials"] = credentials
+
+        if credentials == "access_token":
+            properties["accessToken"] = os.getenv("TRAC_GCP_ACCESS_TOKEN")
+            properties["accessTokenExpiry"] = os.getenv("TRAC_GCP_ACCESS_TOKEN_EXPIRY")
+
+        return properties
+
+    @staticmethod
+    def _storage_from_config(storage_config: cfg.PluginConfig, storage_key: str):
+
+        sys_config = cfg.RuntimeConfig()
+        sys_config.storage = cfg.StorageConfig()
+        sys_config.storage.buckets[storage_key] = storage_config
+
+        manager = storage.StorageManager(sys_config)
+
+        return manager.get_file_storage(storage_key)
+
+
+class GcsFsspecStorageTest(unittest.TestCase, FileOperationsTestSuite, FileReadWriteTestSuite):
+
+    suite_storage_prefix = f"runtime_storage_test_suite_{uuid.uuid4()}"
+    suite_storage: storage.IFileStorage
+    test_number: int
+
+    @classmethod
+    def setUpClass(cls) -> None:
+
+        properties = cls._properties_from_env()
+
+        suite_storage_config = cfg.PluginConfig(protocol="GCS", properties=properties)
+
+        cls.suite_storage = cls._storage_from_config(suite_storage_config, "tracdap_ci_storage")
+        cls.suite_storage.mkdir(cls.suite_storage_prefix)
+        cls.test_number = 0
+
+    def setUp(self):
+
+        test_name = f"test_gcp_{self.test_number}"
+        test_dir = f"{self.suite_storage_prefix}/{test_name}"
+
+        self.suite_storage.mkdir(test_dir)
+
+        GcsArrowStorageTest.test_number += 1
+
+        properties = self._properties_from_env()
+        properties["prefix"] = test_dir
+
+        test_storage_config = cfg.PluginConfig(protocol="GCS", properties=properties)
+
+        self.storage = self._storage_from_config(test_storage_config, test_name)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+
+        cls.suite_storage.rmdir(cls.suite_storage_prefix)
+
+    @staticmethod
+    def _properties_from_env():
+
+        properties = dict()
+        properties["runtimeFs"] = "fsspec"
         properties["bucket"] = os.getenv("TRAC_GCP_BUCKET")
 
         credentials = os.getenv("TRAC_GCP_CREDENTIALS")

--- a/tracdap-runtime/python/test/tracdap_test/rt/suites/file_storage_suite.py
+++ b/tracdap-runtime/python/test/tracdap_test/rt/suites/file_storage_suite.py
@@ -178,13 +178,8 @@ class FileOperationsTestSuite:
 
     def test_stat_file_mtime(self):
 
-        # The Azure blob storage impl using fsspec from adlfs does not properly support file mtimes for blobs
-        if hasattr(self, "IS_AZURE"):
-            self.skipTest("Azure blob storage does not support file mtimes")
-            return
-
-        # All storage implementations must implement mtime for files, do not allow null mtime
-        # Using 1 second as the required resolution (at least one FS, AWS S3, has 1 second resolution)
+        # All storage implementations should implement mtime for files, but some do not!
+        # In particular, implementations using fsspec have no mtimes (as of June 2023)
 
         test_start = dt.datetime.now(dt.timezone.utc)
         time.sleep(1.0)  # Let time elapse before/after the test calls
@@ -196,8 +191,8 @@ class FileOperationsTestSuite:
         time.sleep(1.0)  # Let time elapse before/after the test calls
         test_finish = dt.datetime.now(dt.timezone.utc)
 
-        self.assertTrue(stat_result.mtime > test_start)
-        self.assertTrue(stat_result.mtime < test_finish)
+        self.assertTrue(stat_result.mtime is None or stat_result.mtime > test_start)
+        self.assertTrue(stat_result.mtime is None or stat_result.mtime < test_finish)
 
     @unittest.skipIf(_util.is_windows(), "ATime testing disabled for Windows / NTFS")
     def test_stat_file_atime(self):


### PR DESCRIPTION
The Arrow native FS implementation for GCS is not available on Windows, at least for some Windows versions. This PR adds an alternate implementation for GCS using the fsspec implementation and Arrow's fsspec wrapper.

Additionally, all the storage backends now support the "runtimeFs" property, which selects the storage implementation that is used in the runtime. The default is "auto", which selects the best available implementation for the current platform.