### PR TITLE
Compliance update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,17 +16,17 @@
 
 plugins {
 
-    id "org.owasp.dependencycheck" version "7.3.2"
-    id 'com.github.jk1.dependency-license-report' version '2.0'
+    id "org.owasp.dependencycheck"
+    id "com.github.jk1.dependency-license-report"
 
-    id 'maven-publish'
-    id 'signing'
-    id "io.github.gradle-nexus.publish-plugin" version "1.1.0"
+    id "maven-publish"
+    id "signing"
+    id "io.github.gradle-nexus.publish-plugin"
 }
 
-apply from: 'gradle/versions.gradle'
-apply from: 'gradle/functions.gradle'
-apply from: 'gradle/publish.gradle'
+apply from: "gradle/versions.gradle"
+apply from: "gradle/functions.gradle"
+apply from: "gradle/publish.gradle"
 
 import com.github.jk1.license.filter.*
 
@@ -63,8 +63,28 @@ dependencyCheck {
 
     failBuildOnCVSS = 4
 
+    // NVD cache directory - do not overlap with OWASP check for other languages
+    // Note: Cache corruption can stop the scan from running, in which case the cache should be cleared
     data {
-        directory = rootProject.buildDir.path + '/compliance-cache/nvd_platform/'
+        directory = rootProject.buildDir.path + '/compliance-cache/nvd_platform_java/'
+    }
+
+    // Disable analyzers for other languages
+    // This check is for the Java platform components only
+    analyzers {
+
+        nodeEnabled = false
+        assemblyEnabled = false
+        msbuildEnabled = false
+        nuspecEnabled = false
+
+        retirejs {
+            enabled = false
+        }
+
+        nodeAudit {
+            enabled = false
+        }
     }
 }
 

--- a/dev/compliance/owasp-false-positives.xml
+++ b/dev/compliance/owasp-false-positives.xml
@@ -233,7 +233,7 @@
     <!-- https://github.com/netty/netty/issues/8537 -->
 
     <suppress>
-        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-handler@.*$</packageUrl>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-.*@.*$</packageUrl>
         <vulnerabilityName>CVE-2023-4586</vulnerabilityName>
     </suppress>
 

--- a/dev/compliance/owasp-false-positives.xml
+++ b/dev/compliance/owasp-false-positives.xml
@@ -158,6 +158,15 @@
         <cpe>cpe:/a:json-java_project:json-java</cpe>
     </suppress>
 
+    <!-- Yet another mis-detection for the wrong language -->
+    <!-- Java module is already updated to a fixed version -->
+    <!-- https://github.com/jeremylong/DependencyCheck/issues/5992 -->
+
+    <suppress>
+        <packageUrl regex="true">^pkg:maven/com\.azure/azure-identity@.*$</packageUrl>
+        <vulnerabilityName>CVE-2023-36415</vulnerabilityName>
+    </suppress>
+
 
     <!-- ================== -->
     <!-- Special exceptions -->

--- a/dev/compliance/permitted-licenses.json
+++ b/dev/compliance/permitted-licenses.json
@@ -47,6 +47,10 @@
       "moduleLicense": null
     },
     {
+      "moduleName": "com.google.guava:guava-parent",
+      "moduleLicense": null
+    },
+    {
       "moduleName": "io.netty:netty-bom",
       "moduleLicense": null
     },

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -1,8 +1,8 @@
 # Requirements for all the Python build scripts
 
 # Protoc is required for the codegen scripts which work off the API proto files
+protobuf ~= 4.23.0
 protoc-wheel-0 >= 21, < 22
-protobuf >= 4.21, < 4.22
 googleapis-common-protos >= 1.56, < 2.0
 
 # Doc generation

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -6,14 +6,8 @@ protobuf >= 4.21, < 4.22
 googleapis-common-protos >= 1.56, < 2.0
 
 # Doc generation
-sphinx >= 5.1, < 6.0
-sphinx-autoapi >= 1.9, < 2.0
-sphinx-design >= 0.3
-sphinxcontrib-fulltoc >= 1.2, < 2.0
-cloud-sptheme >= 1.10, < 2.0
-
-# Cloud Sphinx theme uses jinja2.Markup, which was deprecated in jinja2 3.0 and removed in 3.1
-# I raised an issue here: foss.heptapod.net/doc-utils/cloud_sptheme/-/issues/47
-# We can use 3.0 until a fix is ready, if no fix comes we can think about changing theme
-
-jinja2 <3.1
+sphinx ~= 7.2.0
+sphinx-autoapi ~= 3.0.0
+sphinx-design ~= 0.5.0
+sphinxcontrib-fulltoc ~= 1.2
+cloud-sptheme ~= 1.10

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -11,3 +11,9 @@ sphinx-autoapi ~= 3.0.0
 sphinx-design ~= 0.5.0
 sphinxcontrib-fulltoc ~= 1.2
 cloud-sptheme ~= 1.10
+
+# Cloud Sphinx theme uses jinja2.Markup, which was deprecated in jinja2 3.0 and removed in 3.1
+# I raised an issue here: foss.heptapod.net/doc-utils/cloud_sptheme/-/issues/47
+# We can use 3.0 until a fix is ready, if no fix comes we can think about changing theme
+
+jinja2 <3.1

--- a/gradle/base-java.gradle
+++ b/gradle/base-java.gradle
@@ -25,6 +25,7 @@ dependencies {
     implementation platform(group: "io.grpc", name: "grpc-bom", version: "${grpc_version}")
     implementation platform(group: "com.google.protobuf", name: "protobuf-bom", version: "${proto_version}")
     implementation platform(group: "com.google.guava", name: "guava-bom", version: "${guava_version}")
+    implementation platform(group: "com.google.guava", name: "guava-parent", version: "${guava_version}")
     implementation platform(group: "com.fasterxml.jackson", name: "jackson-bom", version: "${jackson_version}")
     implementation platform(group: "org.slf4j", name: "slf4j-parent", version: "${slf4j_version}")
     implementation platform(group: "org.apache.logging.log4j", name: "log4j-bom", version: "${log4j_version}")

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -22,7 +22,7 @@ ext {
     proto_plugin_version = "0.8.13"
 
     // Core platform technologies
-    netty_version = '4.1.97.Final'
+    netty_version = '4.1.100.Final'
     guava_version = '32.0.1-jre'
     proto_version = '3.23.2'
     grpc_version = '1.57.2'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -25,7 +25,7 @@ ext {
     netty_version = '4.1.100.Final'
     guava_version = '32.0.1-jre'
     proto_version = '3.23.2'
-    grpc_version = '1.57.2'
+    grpc_version = '1.59.0'
     gapi_version = '2.20.0'
 
     // Data technologies

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -26,7 +26,7 @@ ext {
 
     // Core platform technologies
     netty_version = '4.1.100.Final'
-    guava_version = '32.0.1-jre'
+    guava_version = '32.1.3-jre'
     proto_version = '3.23.2'
     grpc_version = '1.59.0'
     gapi_version = '2.20.0'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -20,6 +20,9 @@ ext {
 
     // Gradle plugin versions
     proto_plugin_version = "0.8.13"
+    nexus_publish_plugin_version = "1.1.0"
+    owasp_check_plugin_version = "8.4.2"
+    license_check_plugin_version = "2.0"
 
     // Core platform technologies
     netty_version = '4.1.100.Final'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -63,9 +63,9 @@ ext {
 
     // Plugins
 
-    aws_sdk_version = '2.20.88'
-    gcp_sdk_version = '26.18.0'
-    azure_sdk_version = '1.2.15'
+    aws_sdk_version = '2.21.11'
+    gcp_sdk_version = '26.26.0'
+    azure_sdk_version = '1.2.18'
 
     // AWS SDK uses Reactive Streams
     // Only the latest version has a good license (MIT-0, prior versions were Creative Commons)

--- a/settings.gradle
+++ b/settings.gradle
@@ -20,6 +20,9 @@ rootProject.name = 'tracdap'
 
 pluginManagement.plugins {
     id 'com.google.protobuf' version "${proto_plugin_version}"
+    id "io.github.gradle-nexus.publish-plugin" version "${nexus_publish_plugin_version}"
+    id "org.owasp.dependencycheck" version "${owasp_check_plugin_version}"
+    id 'com.github.jk1.dependency-license-report' version "${license_check_plugin_version}"
 }
 
 


### PR DESCRIPTION
Includes Netty version update to 4.1.100 to address the HTTP/2 RST security issue