### PR TITLE
Revert Arrow 14 Upgrade

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,46 +75,47 @@ jobs:
         environment:
 
           # Latest supported versions on all 3 major platforms
-          - { PLATFORM: "windows",
-              PYTHON_VERSION: "3.12",
-              PANDAS_DEPENDENCY: "pandas ~= 2.1.0",
-              PYSPARK_DEPENDENCY: "pyspark ~= 3.5.0" }
-
-          - { PLATFORM: "macos",
-              PYTHON_VERSION: "3.12",
-              PANDAS_DEPENDENCY: "pandas ~= 2.1.0",
-              PYSPARK_DEPENDENCY: "pyspark ~= 3.5.0" }
-
-          - { PLATFORM: "ubuntu",
-              PYTHON_VERSION: "3.12",
-              PANDAS_DEPENDENCY: "pandas ~= 2.1.0",
-              PYSPARK_DEPENDENCY: "pyspark ~= 3.5.0" }
-
-          # Intermediate supported versions, force testing against .0 for Pandas 2.0
-          - { PLATFORM: "ubuntu",
+          - { ENV_NAME: "Windows, 3.11, Pandas 2.1, PySpark 3.4",
+              PLATFORM: 'windows-latest',
               PYTHON_VERSION: "3.11",
-              PANDAS_DEPENDENCY: "pandas == 2.0.0",
-              PYSPARK_DEPENDENCY: "pyspark ~= 3.4.0" }
+              PANDAS_VERSION: "~= 2.1.0",
+              PYSPARK_VERSION: "~= 3.4.0" }
 
-          - { PLATFORM: "ubuntu",
-              PYTHON_VERSION: "3.10",
-              PANDAS_DEPENDENCY: "pandas ~= 1.5.0",
-              PYSPARK_DEPENDENCY: "pyspark ~= 3.3.0" }
+          - { ENV_NAME: "macOS, 3.11, Pandas 2.1, PySpark 3.4",
+              PLATFORM: 'macos-latest',
+              PYTHON_VERSION: "3.11",
+              PANDAS_VERSION: "~= 2.1.0",
+              PYSPARK_VERSION: "~= 3.4.0" }
 
-          - { PLATFORM: "ubuntu",
+          - { ENV_NAME: "Linux, 3.11, Pandas 2.1, PySpark 3.4",
+              PLATFORM: 'ubuntu-latest',
+              PYTHON_VERSION: "3.11",
+              PANDAS_VERSION: "~= 2.1.0",
+              PYSPARK_VERSION: "~= 3.4.0" }
+
+          # Intermediate supported versions
+          - { ENV_NAME: "Linux, 3.9, Pandas 2.0, PySpark 3.3",
+              PLATFORM: 'ubuntu-latest',
               PYTHON_VERSION: "3.9",
-              PANDAS_DEPENDENCY: "pandas ~= 1.3.0",
-              PYSPARK_DEPENDENCY: "pyspark ~= 3.1.0" }
+              # Force .0 patch version for Pandas 2.0 series
+              PANDAS_VERSION: "== 2.0.0",
+              PYSPARK_VERSION: "~= 3.3.0" }
 
-          # Oldest supported versions, force testing against .0 for Pandas and PySpark
+          - { ENV_NAME: "Linux, 3.9, Pandas 1.5, PySpark 3.2",
+              PLATFORM: 'ubuntu-latest',
+              PYTHON_VERSION: "3.9",
+              PANDAS_VERSION: "~= 1.5.0",
+              PYSPARK_VERSION: "~= 3.2.0" }
+
+          # Oldest supported versions, force testing against .0 for Python, Pandas and PySpark
           # If those don't work due to bugs, we need to update README for the supported versions
-          - { PLATFORM: "ubuntu",
+          - { ENV_NAME: "Linux, 3.8, Pandas 1.2, PySpark 3.0",
+              PLATFORM: 'ubuntu-latest',
               PYTHON_VERSION: "3.8",
-              PANDAS_DEPENDENCY: "pandas == 1.2.0",
-              PYSPARK_DEPENDENCY: "pyspark == 3.0.0" }
+              PANDAS_VERSION: "== 1.2.0",
+              PYSPARK_VERSION: "== 3.0.0" }
 
-    # E.g. platform = "windows" -> build image = "windows-latest"
-    runs-on: ${{ matrix.environment.PLATFORM }}-latest
+    runs-on: ${{ matrix.environment.PLATFORM }}
     timeout-minutes: 20
 
     steps:
@@ -135,9 +136,9 @@ jobs:
 
       - name: Install dependencies
         run: |
+          pip install "pyspark ${{ matrix.environment.PYSPARK_VERSION }}"
+          pip install "pandas ${{ matrix.environment.PANDAS_VERSION }}"
           cd tracdap-runtime/python
-          pip install "${{ matrix.environment.PANDAS_DEPENDENCY }}"
-          pip install "${{ matrix.environment.PYSPARK_DEPENDENCY }}"
           pip install -r requirements.txt
 
       - name: Protoc code generation

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -32,7 +32,7 @@ ext {
     gapi_version = '2.20.0'
 
     // Data technologies
-    arrow_version = '14.0.0'
+    arrow_version = '13.0.0'
     jackson_version = '2.15.2'
     jackson_databind_version = '2.15.2'
 

--- a/tracdap-runtime/python/README.md
+++ b/tracdap-runtime/python/README.md
@@ -16,9 +16,9 @@ Documentation for the TRAC platform is available on our website at
 
 The TRAC runtime for Python has these requirements:
 
-* Python: 3.8 up to 3.12
-* Pandas: 1.2 up to 2.1
-* PySpark 3.0 up to 3.5 (optional)
+* Python: 3.8 up to 3.11.x
+* Pandas: 1.2 up to 2.1.x
+* PySpark 3.0 up to 3.4.x (optional)
 
 3rd party libraries may impose additional constraints on supported versions of Python, Pandas or PySpark.
 

--- a/tracdap-runtime/python/requirements.txt
+++ b/tracdap-runtime/python/requirements.txt
@@ -10,7 +10,7 @@
 protobuf == 4.23.2
 
 # Core data framework is based on Arrow
-pyarrow == 14.0.0
+pyarrow == 13.0.0
 
 # PyYAML is used to load config supplied in YAML format
 pyyaml == 6.0

--- a/tracdap-runtime/python/requirements.txt
+++ b/tracdap-runtime/python/requirements.txt
@@ -13,7 +13,7 @@ protobuf == 4.23.2
 pyarrow == 14.0.0
 
 # PyYAML is used to load config supplied in YAML format
-pyyaml == 6.0.1
+pyyaml == 6.0
 
 # Python implementation of Git, for model loading
 dulwich == 0.21.5
@@ -39,7 +39,7 @@ pandas >= 1.2.0, < 2.2.0
 
 # PySpark - Support the 3.x series
 
-pyspark >= 3.0.0, < 3.6.0
+pyspark >= 3.0.0, < 3.5.0
 
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/tracdap-runtime/python/setup.cfg
+++ b/tracdap-runtime/python/setup.cfg
@@ -54,12 +54,12 @@ package_dir =
 
 # Support a range of Python versions
 # (These versions are tested in CI)
-python_requires = >= 3.8, < 3.13
+python_requires = >= 3.8, < 3.12
 
 install_requires =
     protobuf == 4.23.2
     pyarrow == 14.0.0
-    pyyaml == 6.0.1
+    pyyaml == 6.0.0
     dulwich == 0.21.5
     requests == 2.31.0
 
@@ -72,7 +72,7 @@ install_requires =
 spark =
     # Support a range of PySpark versions
     # (These versions are tested in CI)
-    pyspark >= 3.0.0, < 3.6.0
+    pyspark >= 3.0.0, < 3.5.0
 
 aws =
     botocore == 1.29.156

--- a/tracdap-runtime/python/setup.cfg
+++ b/tracdap-runtime/python/setup.cfg
@@ -58,7 +58,7 @@ python_requires = >= 3.8, < 3.12
 
 install_requires =
     protobuf == 4.23.2
-    pyarrow == 14.0.0
+    pyarrow == 13.0.0
     pyyaml == 6.0.0
     dulwich == 0.21.5
     requests == 2.31.0


### PR DESCRIPTION
There is a regression for AWS S3 stroage in Apache Arrow 14:

https://github.com/apache/arrow/issues/38618

We need to hold off upgrading until this is addressed, or implement a workaround.

This change also rolls back support for Python 3.12. Arrow 14 comes with a wheel for 3.12 where Arrow 13 needs to run build wheel tools (these will fail on many machines that don't have all the extra build tools available).