### PR TITLE
Feature/ Upgrade to Arrow 14

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -32,7 +32,7 @@ ext {
     gapi_version = '2.20.0'
 
     // Data technologies
-    arrow_version = '13.0.0'
+    arrow_version = '14.0.2'
     jackson_version = '2.15.2'
     jackson_databind_version = '2.15.2'
 

--- a/tracdap-runtime/python/requirements.txt
+++ b/tracdap-runtime/python/requirements.txt
@@ -10,7 +10,7 @@
 protobuf == 4.23.2
 
 # Core data framework is based on Arrow
-pyarrow == 13.0.0
+pyarrow == 14.0.2
 
 # PyYAML is used to load config supplied in YAML format
 pyyaml == 6.0

--- a/tracdap-runtime/python/setup.cfg
+++ b/tracdap-runtime/python/setup.cfg
@@ -58,7 +58,7 @@ python_requires = >= 3.8, < 3.12
 
 install_requires =
     protobuf == 4.23.2
-    pyarrow == 13.0.0
+    pyarrow == 14.0.2
     pyyaml == 6.0.0
     dulwich == 0.21.5
     requests == 2.31.0


### PR DESCRIPTION
Upgrade to Arrow 14 is now possible with 14.0.2, following a regression fix for delete_dir() in Arrow's S3 filesystem

https://github.com/apache/arrow/issues/38618
