### PR TITLE
Fix / GCP bucket naming convention

### DIFF
--- a/tracdap-plugins/gcp-storage/src/main/java/org/finos/tracdap/plugins/gcp/storage/GcsObjectStorage.java
+++ b/tracdap-plugins/gcp-storage/src/main/java/org/finos/tracdap/plugins/gcp/storage/GcsObjectStorage.java
@@ -64,6 +64,7 @@ public class GcsObjectStorage extends CommonFileStorage {
     public static final String PREFIX_PROPERTY = "prefix";
 
     private static final int DELETE_PAGE_SIZE = 1000;
+    private static final String PROJECT_DEFINED_BY_BUCKET = "_";
 
     private final String project;
     private final String bucket;
@@ -92,7 +93,7 @@ public class GcsObjectStorage extends CommonFileStorage {
 
         try {
 
-            bucketName = BucketName.of(project, bucket);
+            bucketName = BucketName.of(PROJECT_DEFINED_BY_BUCKET, bucket);
 
             log.info("INIT [{}], fs = [GCS], project=[{}], bucket = [{}], prefix = [{}]",
                     storageKey, project, bucket, prefix);

--- a/tracdap-plugins/gcp-storage/src/main/java/org/finos/tracdap/plugins/gcp/storage/GcsObjectStorage.java
+++ b/tracdap-plugins/gcp-storage/src/main/java/org/finos/tracdap/plugins/gcp/storage/GcsObjectStorage.java
@@ -64,6 +64,8 @@ public class GcsObjectStorage extends CommonFileStorage {
     public static final String PREFIX_PROPERTY = "prefix";
 
     private static final int DELETE_PAGE_SIZE = 1000;
+
+    // Project name must be set as "_" in the bucket name, since bucket names are globally unique
     private static final String PROJECT_DEFINED_BY_BUCKET = "_";
 
     private final String project;


### PR DESCRIPTION
Project shoudl no longer be specified in the full bucket name string on GCP