### PR TITLE
Maintenance update

### DIFF
--- a/dev/codegen/protoc-ctrl.py
+++ b/dev/codegen/protoc-ctrl.py
@@ -21,7 +21,7 @@ import logging
 import tempfile
 
 import protoc
-import google.api  # noqa
+import google.api.http_pb2 as gapi_http_module
 
 
 SCRIPT_NAME = pathlib.Path(__file__).stem
@@ -85,7 +85,7 @@ class ProtoApiExtensions:
         _copytree(protoc_inc_src, protoc_inc_dst)
 
         # Google API protos for annotating web services
-        gapi_src = pathlib.Path(google.api.__file__).parent
+        gapi_src = pathlib.Path(gapi_http_module.__file__).parent
         gapi_dst = pathlib.Path(self.temp_dir_name).joinpath("google/api")
 
         _log.info(f"Copying {gapi_src} -> {gapi_dst}")

--- a/tracdap-libs/tracdap-lib-common/build.gradle
+++ b/tracdap-libs/tracdap-lib-common/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     // Logging implementation is manipulated in lib-common but not exposed to client code
     implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: "$log4j_version"
     implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: "$log4j_version"
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: "$log4j_version"
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j2-impl', version: "$log4j_version"
 
     testImplementation project(':tracdap-lib-test')
 }

--- a/tracdap-runtime/python/requirements.txt
+++ b/tracdap-runtime/python/requirements.txt
@@ -34,8 +34,10 @@ requests == 2.31.0
 
 # Pandas - baseline support for series 1.x
 # We do not support the 0.x series! 1.2 added the new dType for integers which supports nulls
+# NumPy 2.0 is not supported in TRAC 0.5.x
 
 pandas >= 1.2.0, < 2.2.0
+numpy < 2.0.0
 
 # PySpark - Support 2.4.x and the 3.x series
 

--- a/tracdap-runtime/python/setup.cfg
+++ b/tracdap-runtime/python/setup.cfg
@@ -63,9 +63,10 @@ install_requires =
     dulwich == 0.21.2
     requests == 2.31.0
 
-    # Support a range of Pandas versions
-    # (These versions are tested in CI)
+    # Support a range of Pandas versions (These versions are tested in CI)
+    # NumPy 2.0 is not supported in TRAC 0.5.x
     pandas >= 1.2.0, < 2.2.0
+    numpy < 2.0.0
 
 [options.extras_require]
 


### PR DESCRIPTION
* Fix logging facade in the Java platform
* Fix code generation due to breaking changes in Protobuf
* Explicitly exclude support for NumPy 2, which has been released but is not binary compatible with NumPy 1