### PR TITLE
Fix / Handle long paths on Windows (Java)

### DIFF
--- a/tracdap-libs/tracdap-lib-data/src/test/java/org/finos/tracdap/common/storage/StorageReadWriteTestSuite.java
+++ b/tracdap-libs/tracdap-lib-data/src/test/java/org/finos/tracdap/common/storage/StorageReadWriteTestSuite.java
@@ -70,6 +70,9 @@ public abstract class StorageReadWriteTestSuite {
     protected IFileStorage storage;
     protected IDataContext dataContext;
 
+    // Windows limits individual path segments to 255 chars
+    private static final String LONG_PATH_TXT_FILE = "long_" + "A".repeat(246) + ".txt";
+
 
     // -----------------------------------------------------------------------------------------------------------------
     // Basic round trip
@@ -88,6 +91,19 @@ public abstract class StorageReadWriteTestSuite {
         var haikuBytes = haiku.getBytes(StandardCharsets.UTF_8);
 
         roundTripTest(storagePath, List.of(haikuBytes), storage, dataContext);
+    }
+
+    @Test
+    void roundTrip_long_path() throws Exception {
+
+        var haiku =
+                "The data goes in;\n" +
+                "For a short while it persists,\n" +
+                "then returns unscathed!";
+
+        var haikuBytes = haiku.getBytes(StandardCharsets.UTF_8);
+
+        roundTripTest(LONG_PATH_TXT_FILE, List.of(haikuBytes), storage, dataContext);
     }
 
     @Test

--- a/tracdap-runtime/python/test/tracdap_test/rt/suites/file_storage_suite.py
+++ b/tracdap-runtime/python/test/tracdap_test/rt/suites/file_storage_suite.py
@@ -201,7 +201,7 @@ class FileOperationsTestSuite:
         self.assertEqual(_storage.FileType.FILE, stat_result.file_type)
         self.assertEqual(expected_size, stat_result.size)
 
-    def test_stat_long_path(self):
+    def test_stat_file_long_path(self):
 
         # Simple case - stat a file
 
@@ -276,6 +276,19 @@ class FileOperationsTestSuite:
 
         self.assertEqual("some_dir/test_dir", stat_result.storage_path)
         self.assertEqual("test_dir", stat_result.file_name)
+        self.assertEqual(_storage.FileType.DIRECTORY, stat_result.file_type)
+
+        # Size field for directories should always be set to 0
+        self.assertEqual(0, stat_result.size)
+
+    def test_stat_dir_long_path(self):
+
+        self.storage.mkdir("some_dir/" + self.LONG_PATH_DIR, True)
+
+        stat_result = self.storage.stat("some_dir/" + self.LONG_PATH_DIR,)
+
+        self.assertEqual("some_dir/" + self.LONG_PATH_DIR, stat_result.storage_path)
+        self.assertEqual(self.LONG_PATH_DIR, stat_result.file_name)
         self.assertEqual(_storage.FileType.DIRECTORY, stat_result.file_type)
 
         # Size field for directories should always be set to 0


### PR DESCRIPTION
Test cases added to the Java storage test suite
No functional change as long paths on Windows are already working in Java