### PR TITLE
Fix / Backport of Windows long path fix for model loading

### DIFF
--- a/tracdap-runtime/python/src/tracdap/rt/_plugins/_helpers.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_plugins/_helpers.py
@@ -18,6 +18,7 @@
 # And we don't want to put them .ext, those are public APIs that need to be maintained
 
 import logging
+import pathlib
 import platform
 import urllib.parse
 import typing as tp
@@ -177,6 +178,16 @@ __IS_WINDOWS = platform.system() == "Windows"
 
 def is_windows():
     return __IS_WINDOWS
+
+
+def windows_unc_path(path: pathlib.Path) -> pathlib.Path:
+
+    # Convert a path to its UNC form on Windows
+
+    if is_windows() and not str(path).startswith("\\\\?\\"):
+        return pathlib.Path("\\\\?\\" + str(path.resolve()))
+    else:
+        return path
 
 
 def logger_for_object(obj: object) -> logging.Logger:

--- a/tracdap-runtime/python/src/tracdap/rt/_plugins/repo_git.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_plugins/repo_git.py
@@ -169,7 +169,8 @@ class GitRepository(IModelRepository):
 
         self._log.info("=> git init")
 
-        repo = git_repo.Repo.init(str(checkout_dir))
+        safe_checkout_dir = _helpers.windows_unc_path(checkout_dir)
+        repo = git_repo.Repo.init(str(safe_checkout_dir))
         self._apply_config_from_properties(repo)
 
         # Set up origin

--- a/tracdap-runtime/python/test/tracdap_test/rt/impl/test_models.py
+++ b/tracdap-runtime/python/test/tracdap_test/rt/impl/test_models.py
@@ -107,7 +107,16 @@ class ImportModelTest(unittest.TestCase):
 
         loader.destroy_scope(self.test_scope)
 
-    def test_load_local_ok(self):
+    def test_local_local_ok(self):
+
+        self._test_load_local(self.test_scope)
+
+    def test_local_local_long_scope(self):
+
+        long_scope = "long_" + "A" * 250
+        self._test_load_local(long_scope)
+
+    def _test_load_local(self, test_scope):
 
         example_repo_url = pathlib.Path(__file__) \
             .parent \
@@ -129,16 +138,16 @@ class ImportModelTest(unittest.TestCase):
         )
 
         loader = models.ModelLoader(sys_config, self.scratch_dir)
-        loader.create_scope(self.test_scope)
+        loader.create_scope(test_scope)
 
-        model_class = loader.load_model_class(self.test_scope, stub_model_def)
+        model_class = loader.load_model_class(test_scope, stub_model_def)
         model = model_class()
 
         self.assertIsInstance(model_class, api.TracModel.__class__)
         self.assertIsInstance(model, model_class)
         self.assertIsInstance(model, api.TracModel)
 
-        loader.destroy_scope(self.test_scope)
+        loader.destroy_scope(test_scope)
 
     def test_load_git_ok(self):
 


### PR DESCRIPTION
Backport to address the most common problems with Windows max path length
Covers the model loader using Git repositories

The fix for local storage is not backported due to substantial updates in the storage layer for the 0.6 series
Storage managed by TRAC will not normally have issues with deeply nested paths

