### PR TITLE
Feature / Allow setting props in the metadata model

### DIFF
--- a/gradle/base-java.gradle
+++ b/gradle/base-java.gradle
@@ -21,14 +21,14 @@ repositories {
 dependencies {
 
     // Enforce a single consistent set of versions for core frameworks across the entire project
-    implementation enforcedPlatform(group: "io.netty", name: "netty-bom", version: "${netty_version}")
-    implementation enforcedPlatform(group: "io.grpc", name: "grpc-bom", version: "${grpc_version}")
-    implementation enforcedPlatform(group: "com.google.protobuf", name: "protobuf-bom", version: "${proto_version}")
-    implementation enforcedPlatform(group: "com.google.guava", name: "guava-bom", version: "${guava_version}")
-    implementation enforcedPlatform(group: "com.google.guava", name: "guava-parent", version: "${guava_version}")
-    implementation enforcedPlatform(group: "com.fasterxml.jackson", name: "jackson-bom", version: "${jackson_version}")
-    implementation enforcedPlatform(group: "org.slf4j", name: "slf4j-parent", version: "${slf4j_version}")
-    implementation enforcedPlatform(group: "org.apache.logging.log4j", name: "log4j-bom", version: "${log4j_version}")
+    implementation platform(group: "io.netty", name: "netty-bom", version: "${netty_version}")
+    implementation platform(group: "io.grpc", name: "grpc-bom", version: "${grpc_version}")
+    implementation platform(group: "com.google.protobuf", name: "protobuf-bom", version: "${proto_version}")
+    implementation platform(group: "com.google.guava", name: "guava-bom", version: "${guava_version}")
+    implementation platform(group: "com.google.guava", name: "guava-parent", version: "${guava_version}")
+    implementation platform(group: "com.fasterxml.jackson", name: "jackson-bom", version: "${jackson_version}")
+    implementation platform(group: "org.slf4j", name: "slf4j-parent", version: "${slf4j_version}")
+    implementation platform(group: "org.apache.logging.log4j", name: "log4j-bom", version: "${log4j_version}")
 
     // Logging with SLF 4J, available in all Java modules
     implementation group: 'org.slf4j', name: 'slf4j-api', version: "$slf4j_version"

--- a/tracdap-api/tracdap-metadata/src/main/proto/tracdap/metadata/model.proto
+++ b/tracdap-api/tracdap-metadata/src/main/proto/tracdap/metadata/model.proto
@@ -34,6 +34,8 @@ message ModelParameter {
     string label = 2;
 
     optional Value defaultValue = 3;
+
+    map<string, Value> paramProps = 4;
 }
 
 
@@ -55,6 +57,8 @@ message ModelInputSchema {
     optional string label = 2;
 
     bool optional = 3;
+
+    map<string, Value> inputProps = 4;
 }
 
 /**
@@ -76,6 +80,8 @@ message ModelOutputSchema {
     optional string label = 2;
 
     bool optional = 3;
+
+    map<string, Value> outputProps = 4;
 }
 
 

--- a/tracdap-api/tracdap-metadata/src/main/proto/tracdap/metadata/object.proto
+++ b/tracdap-api/tracdap-metadata/src/main/proto/tracdap/metadata/object.proto
@@ -22,6 +22,7 @@ option java_multiple_files = true;
 option java_outer_classname = "ObjectProtoWrapper";  // Do not create a Java class called "Object"!
 
 import "tracdap/metadata/object_id.proto";
+import "tracdap/metadata/type.proto";
 import "tracdap/metadata/data.proto";
 import "tracdap/metadata/model.proto";
 import "tracdap/metadata/flow.proto";
@@ -76,4 +77,6 @@ message ObjectDefinition {
         StorageDefinition storage = 8;
         SchemaDefinition schema = 9;
     }
+
+    map<string, Value> objectProps = 100;
 }

--- a/tracdap-libs/tracdap-lib-validation/src/main/java/org/finos/tracdap/common/validation/static_/CommonValidators.java
+++ b/tracdap-libs/tracdap-lib-validation/src/main/java/org/finos/tracdap/common/validation/static_/CommonValidators.java
@@ -717,4 +717,12 @@ public class CommonValidators {
         };
     }
 
+    public static ValidationContext standardProps(ValidationContext ctx) {
+
+        return ctx
+            .applyMapKeys(CommonValidators::identifier)
+            .applyMapKeys(CommonValidators::notTracReserved)
+            .applyMapValues(TypeSystemValidator::value, Value.class);
+    }
+
 }

--- a/tracdap-libs/tracdap-lib-validation/src/main/java/org/finos/tracdap/common/validation/static_/FlowValidator.java
+++ b/tracdap-libs/tracdap-lib-validation/src/main/java/org/finos/tracdap/common/validation/static_/FlowValidator.java
@@ -188,9 +188,8 @@ public class FlowValidator {
                 .pop();
 
         ctx = ctx.pushMap(FN_NODE_PROPS)
-                .applyMapKeys(CommonValidators::identifier)
-                .applyMapKeys(CommonValidators::notTracReserved)
-                .applyMapValues(TypeSystemValidator::value, Value.class)
+                .apply(CommonValidators::optional)
+                .apply(CommonValidators::standardProps)
                 .pop();
 
         ctx = ctx.push(FN_LABEL)

--- a/tracdap-libs/tracdap-lib-validation/src/main/java/org/finos/tracdap/common/validation/static_/ModelValidator.java
+++ b/tracdap-libs/tracdap-lib-validation/src/main/java/org/finos/tracdap/common/validation/static_/ModelValidator.java
@@ -17,7 +17,6 @@
 package org.finos.tracdap.common.validation.static_;
 
 import org.finos.tracdap.common.validation.core.ValidationContext;
-import org.finos.tracdap.common.validation.core.ValidationFunction;
 import org.finos.tracdap.common.validation.core.ValidationType;
 import org.finos.tracdap.common.validation.core.Validator;
 import org.finos.tracdap.metadata.*;
@@ -25,7 +24,6 @@ import org.finos.tracdap.metadata.*;
 import com.google.protobuf.Descriptors;
 
 import java.util.HashMap;
-import java.util.Map;
 
 import static org.finos.tracdap.common.validation.ValidationConstants.MODEL_ENTRY_POINT;
 import static org.finos.tracdap.common.validation.ValidationConstants.MODEL_VERSION;
@@ -49,14 +47,17 @@ public class ModelValidator {
     private static final Descriptors.FieldDescriptor MP_PARAM_TYPE;
     private static final Descriptors.FieldDescriptor MP_LABEL;
     private static final Descriptors.FieldDescriptor MP_DEFAULT_VALUE;
+    private static final Descriptors.FieldDescriptor MP_PARAM_PROPS;
 
     private static final Descriptors.Descriptor MODEL_INPUT_SCHEMA;
     private static final Descriptors.FieldDescriptor MIS_SCHEMA;
     private static final Descriptors.FieldDescriptor MIS_LABEL;
+    private static final Descriptors.FieldDescriptor MIS_INPUT_PROPS;
 
     private static final Descriptors.Descriptor MODEL_OUTPUT_SCHEMA;
     private static final Descriptors.FieldDescriptor MOS_SCHEMA;
     private static final Descriptors.FieldDescriptor MOS_LABEL;
+    private static final Descriptors.FieldDescriptor MOS_OUTPUT_PROPS;
 
     static {
 
@@ -74,14 +75,17 @@ public class ModelValidator {
         MP_PARAM_TYPE = field(MODEL_PARAMETER, ModelParameter.PARAMTYPE_FIELD_NUMBER);
         MP_LABEL = field(MODEL_PARAMETER, ModelParameter.LABEL_FIELD_NUMBER);
         MP_DEFAULT_VALUE = field(MODEL_PARAMETER, ModelParameter.DEFAULTVALUE_FIELD_NUMBER);
+        MP_PARAM_PROPS = field(MODEL_PARAMETER, ModelParameter.PARAMPROPS_FIELD_NUMBER);
 
         MODEL_INPUT_SCHEMA = ModelInputSchema.getDescriptor();
         MIS_SCHEMA = field(MODEL_INPUT_SCHEMA, ModelInputSchema.SCHEMA_FIELD_NUMBER);
         MIS_LABEL = field(MODEL_INPUT_SCHEMA, ModelInputSchema.LABEL_FIELD_NUMBER);
+        MIS_INPUT_PROPS = field(MODEL_INPUT_SCHEMA, ModelInputSchema.INPUTPROPS_FIELD_NUMBER);
 
         MODEL_OUTPUT_SCHEMA = ModelOutputSchema.getDescriptor();
         MOS_SCHEMA = field(MODEL_OUTPUT_SCHEMA, ModelOutputSchema.SCHEMA_FIELD_NUMBER);
         MOS_LABEL = field(MODEL_OUTPUT_SCHEMA, ModelOutputSchema.LABEL_FIELD_NUMBER);
+        MOS_OUTPUT_PROPS = field(MODEL_OUTPUT_SCHEMA, ModelOutputSchema.OUTPUTPROPS_FIELD_NUMBER);
     }
 
     @Validator
@@ -183,6 +187,11 @@ public class ModelValidator {
                 .apply(TypeSystemValidator::valueWithType, Value.class, msg.getParamType())
                 .pop();
 
+        ctx = ctx.pushMap(MP_PARAM_PROPS)
+                .apply(CommonValidators::optional)
+                .apply(CommonValidators::standardProps)
+                .pop();
+
         return ctx;
     }
 
@@ -199,6 +208,11 @@ public class ModelValidator {
                 .apply(CommonValidators::labelLengthLimit)
                 .pop();
 
+        ctx = ctx.pushMap(MIS_INPUT_PROPS)
+                .apply(CommonValidators::optional)
+                .apply(CommonValidators::standardProps)
+                .pop();
+
         return ctx;
     }
 
@@ -213,6 +227,11 @@ public class ModelValidator {
         ctx = ctx.push(MOS_LABEL)
                 .apply(CommonValidators::optional)
                 .apply(CommonValidators::labelLengthLimit)
+                .pop();
+
+        ctx = ctx.pushMap(MOS_OUTPUT_PROPS)
+                .apply(CommonValidators::optional)
+                .apply(CommonValidators::standardProps)
                 .pop();
 
         return ctx;

--- a/tracdap-libs/tracdap-lib-validation/src/main/java/org/finos/tracdap/common/validation/static_/ObjectValidator.java
+++ b/tracdap-libs/tracdap-lib-validation/src/main/java/org/finos/tracdap/common/validation/static_/ObjectValidator.java
@@ -45,12 +45,14 @@ public class ObjectValidator {
     private static final Descriptors.Descriptor OBJECT_DEFINITION;
     private static final Descriptors.FieldDescriptor OD_OBJECT_TYPE;
     private static final Descriptors.OneofDescriptor OD_DEFINITION;
+    private static final Descriptors.FieldDescriptor OD_OBJECT_PROPS;
 
     static {
 
         OBJECT_DEFINITION = ObjectDefinition.getDescriptor();
         OD_OBJECT_TYPE = field(OBJECT_DEFINITION, ObjectDefinition.OBJECTTYPE_FIELD_NUMBER);
         OD_DEFINITION = field(OBJECT_DEFINITION, ObjectDefinition.DATA_FIELD_NUMBER).getContainingOneof();
+        OD_OBJECT_PROPS = field(OBJECT_DEFINITION, ObjectDefinition.OBJECTPROPS_FIELD_NUMBER);
     }
 
     @Validator
@@ -65,6 +67,11 @@ public class ObjectValidator {
                 .apply(CommonValidators::required)
                 .apply(ObjectValidator::definitionMatchesType)
                 .applyRegistered()
+                .pop();
+
+        ctx = ctx.pushMap(OD_OBJECT_PROPS)
+                .apply(CommonValidators::optional)
+                .apply(CommonValidators::standardProps)
                 .pop();
 
         return ctx;

--- a/tracdap-libs/tracdap-lib-validation/src/test/java/org/finos/tracdap/common/validation/static_/FlowValidatorTest.java
+++ b/tracdap-libs/tracdap-lib-validation/src/test/java/org/finos/tracdap/common/validation/static_/FlowValidatorTest.java
@@ -39,6 +39,7 @@ public class FlowValidatorTest extends BaseValidatorTest {
                 .putNodes("model_1", FlowNode.newBuilder().setNodeType(FlowNodeType.MODEL_NODE)
                     .addInputs("input_1").addInputs("input_2")
                     .addOutputs("output_1")
+                    .putNodeProps("sample_prop", MetadataCodec.encodeValue(2.0))
                     .build())
                 .putNodes("output_1", FlowNode.newBuilder().setNodeType(FlowNodeType.OUTPUT_NODE).build())
 

--- a/tracdap-runtime/python/src/tracdap/rt/_impl/static_api.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_impl/static_api.py
@@ -92,11 +92,9 @@ class StaticApiImpl(_StaticApiHook):
                 msg = f"Default value for parameter [{param_name}] does not match the declared type"
                 raise _ex.EModelValidation(msg) from e
 
-        encoded_props = self._process_props(param_props, "parameter", param_name)
-
         return _Named(param_name, _meta.ModelParameter(
             param_type_descriptor, label, default_value,
-            paramProps=encoded_props))
+            paramProps=param_props))
 
     def define_parameters(
             self, *params: _tp.Union[_Named[_meta.ModelParameter], _tp.List[_Named[_meta.ModelParameter]]]) \
@@ -167,10 +165,7 @@ class StaticApiImpl(_StaticApiHook):
             input_props=input_props)
 
         schema_def = self.define_schema(*fields, schema_type=_meta.SchemaType.TABLE)
-
-        encoded_props = self._process_props(input_props, "input")
-
-        return _meta.ModelInputSchema(schema=schema_def, label=label, optional=optional, inputProps=encoded_props)
+        return _meta.ModelInputSchema(schema=schema_def, label=label, optional=optional, inputProps=input_props)
 
     def define_output_table(
             self, *fields: _tp.Union[_meta.FieldSchema, _tp.List[_meta.FieldSchema]],
@@ -185,10 +180,7 @@ class StaticApiImpl(_StaticApiHook):
             output_props=output_props)
 
         schema_def = self.define_schema(*fields, schema_type=_meta.SchemaType.TABLE)
-
-        encoded_props = self._process_props(output_props, "output")
-
-        return _meta.ModelOutputSchema(schema=schema_def, label=label, optional=optional, outputProps=encoded_props)
+        return _meta.ModelOutputSchema(schema=schema_def, label=label, optional=optional, outputProps=output_props)
 
     @staticmethod
     def _build_named_dict(
@@ -215,27 +207,3 @@ class StaticApiImpl(_StaticApiHook):
                 field.fieldOrder = index
 
         return _meta.TableSchema([*fields_])
-
-    @staticmethod
-    def _process_props(
-            raw_props: _tp.Dict[str, _tp.Any],
-            item_type: str, item_name: _tp.Optional[str] = None) \
-            -> _tp.Dict[str, _meta.Value]:
-
-        if raw_props is None:
-            return dict()
-
-        encoded_props = dict()
-
-        for key, raw_value in raw_props.items():
-
-            if raw_value is None:
-                item_name_suffix = f" [{item_name}]" if item_name is not None else ""
-                raise _ex.EModelValidation(f"Invalid null property [{key}] for {item_type}{item_name_suffix}")
-
-            encoded_value = _type_system.MetadataCodec.encode_value(raw_value)
-            encoded_props[key] = encoded_value
-
-        return encoded_props
-
-

--- a/tracdap-runtime/python/src/tracdap/rt/_impl/type_system.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_impl/type_system.py
@@ -171,6 +171,23 @@ class MetadataCodec:
             type_desc = _meta.TypeDescriptor(_meta.BasicType.DATE)
             return _meta.Value(type_desc, dateValue=_meta.DateValue(value.isoformat()))
 
+        if isinstance(value, list):
+
+            if len(value) == 0:
+                raise _ex.ETracInternal("Cannot encode an empty list")
+
+            array_raw_type = type(value[0])
+            array_trac_type = TypeMapping.python_to_trac(array_raw_type)
+
+            if any(map(lambda x: type(x) != array_raw_type, value)):
+                raise _ex.ETracInternal("Cannot encode a list with values of different types")
+
+            encoded_items = list(map(lambda x: cls.convert_value(x, array_trac_type), value))
+
+            return _meta.Value(
+                _meta.TypeDescriptor(_meta.BasicType.ARRAY, arrayType=array_trac_type),
+                arrayValue=_meta.ArrayValue(encoded_items))
+
         raise _ex.ETracInternal(f"Value type [{type(value)}] is not supported yet")
 
     @classmethod

--- a/tracdap-runtime/python/src/tracdap/rt/_impl/validation.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_impl/validation.py
@@ -320,6 +320,9 @@ class _StaticValidator:
             else:
                 cls._check_label(param.label, param_name)
 
+            if param.paramProps is not None:
+                cls._valid_identifiers(param.paramProps.keys(), "entry in param props")
+
     @classmethod
     def _check_inputs_or_outputs(cls, inputs_or_outputs):
 
@@ -339,6 +342,13 @@ class _StaticValidator:
 
             label = input_schema.label
             cls._check_label(label, input_name)
+
+            if isinstance(input_schema, meta.ModelInputSchema):
+                if input_schema.inputProps is not None:
+                    cls._valid_identifiers(input_schema.inputProps.keys(), "entry in input props")
+            else:
+                if input_schema.outputProps is not None:
+                    cls._valid_identifiers(input_schema.outputProps.keys(), "entry in output props")
 
     @classmethod
     def _check_single_field(cls, field: meta.FieldSchema, property_type):

--- a/tracdap-runtime/python/src/tracdap/rt/api/hook.py
+++ b/tracdap-runtime/python/src/tracdap/rt/api/hook.py
@@ -80,7 +80,8 @@ class _StaticApiHook:
     @_abc.abstractmethod
     def define_parameter(
             self, param_name: str, param_type: _tp.Union[_meta.TypeDescriptor, _meta.BasicType],
-            label: str, default_value: _tp.Optional[_tp.Any] = None) \
+            label: str, default_value: _tp.Optional[_tp.Any] = None,
+            *, param_props: _tp.Optional[_tp.Dict[str, _tp.Any]] = None) \
             -> _Named[_meta.ModelParameter]:
 
         pass
@@ -121,7 +122,8 @@ class _StaticApiHook:
     def define_input_table(
             self, *fields: _tp.Union[_meta.FieldSchema, _tp.List[_meta.FieldSchema]],
             label: _tp.Optional[str] = None,
-            optional: bool = False) \
+            optional: bool = False,
+            input_props: _tp.Optional[_tp.Dict[str, _tp.Any]] = None) \
             -> _meta.ModelInputSchema:
 
         pass
@@ -130,7 +132,8 @@ class _StaticApiHook:
     def define_output_table(
             self, *fields: _tp.Union[_meta.FieldSchema, _tp.List[_meta.FieldSchema]],
             label: _tp.Optional[str] = None,
-            optional: bool = False) \
+            optional: bool = False,
+            output_props: _tp.Optional[_tp.Dict[str, _tp.Any]] = None) \
             -> _meta.ModelOutputSchema:
 
         pass

--- a/tracdap-runtime/python/src/tracdap/rt/api/static_api.py
+++ b/tracdap-runtime/python/src/tracdap/rt/api/static_api.py
@@ -204,9 +204,7 @@ def P(  # noqa
     :rtype: _Named[:py:class:`ModelParameter <tracdap.rt.metadata.ModelParameter>`]
     """
 
-    return define_parameter(
-        param_name, param_type, label,
-        default_value)
+    return define_parameter(param_name, param_type, label, default_value, param_props=param_props)
 
 
 def define_parameters(

--- a/tracdap-runtime/python/src/tracdap/rt/api/static_api.py
+++ b/tracdap-runtime/python/src/tracdap/rt/api/static_api.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import sys
 import typing as _tp
 import types as _ts
 
@@ -111,7 +112,8 @@ def A(  # noqa
 
 def define_parameter(
         param_name: str, param_type: _tp.Union[TypeDescriptor, BasicType],
-        label: str, default_value: _tp.Optional[_tp.Any] = None) \
+        label: str, default_value: _tp.Optional[_tp.Any] = None,
+        *, param_props: _tp.Optional[_tp.Dict[str, _tp.Any]] = None) \
         -> _Named[ModelParameter]:
 
     """
@@ -128,6 +130,10 @@ def define_parameter(
     the model. TRAC will apply type coercion where possible to ensure the default value matches the parameter type,
     if the default value cannot be coerced to match the parameter type then model validation will fail.
 
+    You can use param_props to associate arbitrary key-value properties with this model parameter.
+    These properties are not used by the TRAC engine, but are stored in the model metadata for
+    the parameter and can be used as needed in 3rd-party applications.
+
     Once defined model parameters can be passed to :py:func:`define_parameters`,
     either as a list or as individual arguments, to create the set of parameters for a model.
 
@@ -135,6 +141,7 @@ def define_parameter(
     :param param_type: The parameter type, expressed in the TRAC type system
     :param label: A descriptive label for the parameter (required)
     :param default_value: A default value to use if no explicit value is supplied (optional)
+    :param param_props: Associate key-value properties with this parameter (not used by the TRAC engine)
     :return: A named model parameter, suitable for passing to :py:func:`define_parameters`
 
     :type param_name: str
@@ -142,11 +149,12 @@ def define_parameter(
                       :py:class:`BasicType <tracdap.rt.metadata.BasicType>`
     :type label: str
     :type default_value: Optional[Any]
+    :type param_props: Optional[Dict[str, Any]]
     :rtype: _Named[:py:class:`ModelParameter <tracdap.rt.metadata.ModelParameter>`]
     """
 
     sa = _StaticApiHook.get_instance()
-    return sa.define_parameter(param_name, param_type, label, default_value)
+    return sa.define_parameter(param_name, param_type, label, default_value, param_props=param_props)
 
 
 def declare_parameter(
@@ -160,6 +168,9 @@ def declare_parameter(
     .. deprecated:: 0.4.4
        Use :py:func:`define_parameter` or :py:func:`P` instead.
 
+    This function is deprecated and will be removed in a future version.
+    Please use :py:func:`define_parameter() <tracdap.rt.api.define_parameter>` instead.
+
     :type param_name: str
     :type param_type: :py:class:`TypeDescriptor <tracdap.rt.metadata.TypeDescriptor>` |
                       :py:class:`BasicType <tracdap.rt.metadata.BasicType>`
@@ -168,6 +179,8 @@ def declare_parameter(
     :rtype: _Named[:py:class:`ModelParameter <tracdap.rt.metadata.ModelParameter>`]
     """
 
+    print("TRAC Warning: declare_parameter() is deprecated, please use define_parameter()", file=sys.stderr)
+
     return define_parameter(param_name, param_type, label, default_value)
 
 
@@ -175,7 +188,8 @@ def P(  # noqa
         param_name: str,
         param_type: _tp.Union[TypeDescriptor, BasicType],
         label: str,
-        default_value: _tp.Optional[_tp.Any] = None) \
+        default_value: _tp.Optional[_tp.Any] = None,
+        *, param_props: _tp.Optional[_tp.Dict[str, _tp.Any]] = None) \
         -> _Named[ModelParameter]:
 
     """
@@ -186,10 +200,11 @@ def P(  # noqa
                       :py:class:`BasicType <tracdap.rt.metadata.BasicType>`
     :type label: str
     :type default_value: Optional[Any]
+    :type param_props: Optional[Dict[str, Any]]
     :rtype: _Named[:py:class:`ModelParameter <tracdap.rt.metadata.ModelParameter>`]
     """
 
-    return declare_parameter(
+    return define_parameter(
         param_name, param_type, label,
         default_value)
 
@@ -226,10 +241,15 @@ def declare_parameters(
     .. deprecated:: 0.4.4
        Use :py:func:`define_parameters` instead.
 
+    This function is deprecated and will be removed in a future version.
+    Please use :py:func:`define_parameters() <tracdap.rt.api.define_parameters>` instead.
+
     :type params: _Named[:py:class:`ModelParameter <tracdap.rt.metadata.ModelParameter>`] |
                   List[_Named[:py:class:`ModelParameter <tracdap.rt.metadata.ModelParameter>`]]
     :rtype: Dict[str, :py:class:`ModelParameter <tracdap.rt.metadata.ModelParameter>`]
     """
+
+    print("TRAC Warning: declare_parameters() is deprecated, please use define_parameters()", file=sys.stderr)
 
     return define_parameters(*params)
 
@@ -278,9 +298,9 @@ def define_field(
     :type label: str
     :type business_key: bool
     :type categorical: bool
-    :type not_null: _tp.Optional[bool]
-    :type format_code: _tp.Optional[str]
-    :type field_order: _tp.Optional[int]
+    :type not_null: Optional[bool]
+    :type format_code: Optional[str]
+    :type field_order: Optional[int]
     :rtype: :py:class:`FieldSchema <tracdap.rt.metadata.FieldSchema>`
     """
 
@@ -307,16 +327,21 @@ def declare_field(
     .. deprecated:: 0.4.4
        Use :py:func:`define_field` or :py:func:`F` instead.
 
+    This function is deprecated and will be removed in a future version.
+    Please use :py:func:`define_field() <tracdap.rt.api.define_field>` instead.
+
     :type field_name: str
     :type field_type: :py:class:`BasicType <tracdap.rt.metadata.BasicType>`
     :type label: str
     :type business_key: bool
     :type categorical: bool
-    :type not_null: _tp.Optional[bool]
-    :type format_code: _tp.Optional[str]
-    :type field_order: _tp.Optional[int]
+    :type not_null: Optional[bool]
+    :type format_code: Optional[str]
+    :type field_order: Optional[int]
     :rtype: :py:class:`FieldSchema <tracdap.rt.metadata.FieldSchema>`
     """
+
+    print("TRAC Warning: declare_field() is deprecated, please use define_field()", file=sys.stderr)
 
     return define_field(
         field_name, field_type, label,
@@ -343,9 +368,9 @@ def F(  # noqa
     :type label: str
     :type business_key: bool
     :type categorical: bool
-    :type not_null: _tp.Optional[bool]
-    :type format_code: _tp.Optional[str]
-    :type field_order: _tp.Optional[int]
+    :type not_null: Optional[bool]
+    :type format_code: Optional[str]
+    :type field_order: Optional[int]
     :rtype: :py:class:`FieldSchema <tracdap.rt.metadata.FieldSchema>`
     """
 
@@ -429,7 +454,8 @@ def load_schema(
 def define_input_table(
         *fields: _tp.Union[FieldSchema, _tp.List[FieldSchema]],
         label: _tp.Optional[str] = None,
-        optional: bool = False) \
+        optional: bool = False,
+        input_props: _tp.Optional[_tp.Dict[str, _tp.Any]] = None) \
         -> ModelInputSchema:
 
     """
@@ -438,20 +464,26 @@ def define_input_table(
     Fields can be supplied either as individual arguments to this function or as a list.
     Individual fields should be defined using :py:func:`define_field` or the shorthand alias :py:func:`F`.
 
+    You can use input_props to associate arbitrary key-value properties with this model input.
+    These properties are not used by the TRAC engine, but are stored in the model metadata for
+    the input and can be used as needed in 3rd-party applications.
+
     :param fields: A set of fields to make up a :py:class:`TableSchema <tracdap.rt.metadata.TableSchema>`
     :param label: An optional label (of type str) for a model input schema. Default value: None.
     :param optional: Mark this input as an optional model input
+    :param input_props: Associate key-value properties with this input (not used by the TRAC engine)
     :return: A model input schema, suitable for returning from :py:meth:`TracModel.define_inputs`
 
     :type fields: :py:class:`FieldSchema <tracdap.rt.metadata.FieldSchema>` |
                   List[:py:class:`FieldSchema <tracdap.rt.metadata.FieldSchema>`]
-    :type label: _tp.Optional[str]
+    :type label: Optional[str]
     :type optional: bool
+    :type input_props: Optional[Dict[str, Any]]
     :rtype: :py:class:`ModelInputSchema <tracdap.rt.metadata.ModelInputSchema>`
     """
 
     sa = _StaticApiHook.get_instance()
-    return sa.define_input_table(*fields, label=label, optional=optional)
+    return sa.define_input_table(*fields, label=label, optional=optional, input_props=input_props)
 
 
 def declare_input_table(
@@ -462,10 +494,15 @@ def declare_input_table(
     .. deprecated:: 0.4.4
        Use :py:func:`define_input_table` instead.
 
+    This function is deprecated and will be removed in a future version.
+    Please use :py:func:`define_input_table() <tracdap.rt.api.define_input_table>` instead.
+
     :type fields: :py:class:`FieldSchema <tracdap.rt.metadata.FieldSchema>` |
                   List[:py:class:`FieldSchema <tracdap.rt.metadata.FieldSchema>`]
     :rtype: :py:class:`ModelInputSchema <tracdap.rt.metadata.ModelInputSchema>`
     """
+
+    print("TRAC Warning: declare_input_table() is deprecated, please use define_input_table()", file=sys.stderr)
 
     return define_input_table(*fields)
 
@@ -473,7 +510,8 @@ def declare_input_table(
 def define_output_table(
         *fields: _tp.Union[FieldSchema, _tp.List[FieldSchema]],
         label: _tp.Optional[str] = None,
-        optional: bool = False) \
+        optional: bool = False,
+        output_props: _tp.Optional[_tp.Dict[str, _tp.Any]] = None) \
         -> ModelOutputSchema:
 
     """
@@ -482,20 +520,26 @@ def define_output_table(
     Fields can be supplied either as individual arguments to this function or as a list.
     Individual fields should be defined using :py:func:`define_field` or the shorthand alias :py:func:`F`.
 
+    You can use output_props to associate arbitrary key-value properties with this model output.
+    These properties are not used by the TRAC engine, but are stored in the model metadata for
+    the output and can be used as needed in 3rd-party applications.
+
     :param fields: A set of fields to make up a :py:class:`TableSchema <tracdap.rt.metadata.TableSchema>`
     :param label: An optional label (of type str) for a model output schema. Default value: None.
     :param optional: Mark this output as an optional model output
+    :param output_props: Associate key-value properties with this output (not used by the TRAC engine)
     :return: A model output schema, suitable for returning from :py:meth:`TracModel.define_outputs`
 
     :type fields: :py:class:`FieldSchema <tracdap.rt.metadata.FieldSchema>` |
                   List[:py:class:`FieldSchema <tracdap.rt.metadata.FieldSchema>`]
-    :type label: _tp.Optional[str]
+    :type label: Optional[str]
     :type optional: bool
+    :type output_props: Optional[Dict[str, Any]]
     :rtype: :py:class:`ModelOutputSchema <tracdap.rt.metadata.ModelOutputSchema>`
     """
 
     sa = _StaticApiHook.get_instance()
-    return sa.define_output_table(*fields, label=label, optional=optional)
+    return sa.define_output_table(*fields, label=label, optional=optional, output_props=output_props)
 
 
 def declare_output_table(
@@ -506,9 +550,17 @@ def declare_output_table(
     .. deprecated:: 0.4.4
        Use :py:func:`define_output_table` instead.
 
+    This function is deprecated and will be removed in a future version.
+    Please use :py:func:`define_output_table() <tracdap.rt.api.define_output_table>` instead.
+
+    This function is deprecated and will be removed in a future version.
+    Please use define_output_table() instead.
+
     :type fields: :py:class:`FieldSchema <tracdap.rt.metadata.FieldSchema>` |
                   List[:py:class:`FieldSchema <tracdap.rt.metadata.FieldSchema>`]
     :rtype: :py:class:`ModelOutputSchema <tracdap.rt.metadata.ModelOutputSchema>`
     """
+
+    print("TRAC Warning: declare_output_table() is deprecated, please use define_output_table()", file==sys.stderr)
 
     return define_output_table(*fields)


### PR DESCRIPTION
Props are not used by the TRAC engine but can be defined by applications to control application logic or store extra relevant information in the TRAC metadata model