### PR TITLE
Feature/  Generic runtime data protocols

### DIFF
--- a/tracdap-runtime/python/src/tracdap/rt/_exec/context.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_exec/context.py
@@ -524,9 +524,6 @@ class TracContextErrorReporter:
 
 class TracContextValidator(TracContextErrorReporter):
 
-    __VALID_IDENTIFIER = re.compile("^[a-zA-Z_]\\w*$",)
-    __RESERVED_IDENTIFIER = re.compile("^(trac_|_)\\w*")
-
     def __init__(
             self, log: logging.Logger,
             model_def: _meta.ModelDefinition,

--- a/tracdap-runtime/python/src/tracdap/rt/_exec/context.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_exec/context.py
@@ -160,10 +160,10 @@ class TracContextImpl(_api.TracContext):
         else:
             schema = data_view.arrow_schema
 
-        raw_table = _data.DataMapping.view_to_arrow(data_view, part_key)
-        table = _data.DataConformance.conform_to_schema(raw_table, schema)
+        table = _data.DataMapping.view_to_arrow(data_view, part_key)
 
-        return converter.from_internal(table, schema.names)
+        # Data conformance is applied automatically inside the converter, if schema != None
+        return converter.from_internal(table, schema)
 
     def get_pandas_table(self, dataset_name: str, use_temporal_objects: tp.Optional[bool] = None) \
             -> "_data.pandas.DataFrame":
@@ -244,8 +244,8 @@ class TracContextImpl(_api.TracContext):
         else:
             schema = data_view.arrow_schema
 
-        raw_table = converter.to_internal(dataset, schema.names)
-        table = _data.DataConformance.conform_to_schema(raw_table, schema)
+        # Data conformance is applied automatically inside the converter, if schema != None
+        table = converter.to_internal(dataset, schema)
         item = _data.DataItem(schema, table)
 
         updated_view = _data.DataMapping.add_item_to_view(data_view, part_key, item)

--- a/tracdap-runtime/python/src/tracdap/rt/_exec/context.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_exec/context.py
@@ -497,6 +497,9 @@ class TracFileStorageImpl(_eapi.TracFileStorage):
 
 class TracContextErrorReporter:
 
+    _VALID_IDENTIFIER = re.compile("^[a-zA-Z_]\\w*$",)
+    _RESERVED_IDENTIFIER = re.compile("^(trac_|_)\\w*")
+
     def __init__(self, log: logging.Logger, checkout_directory: pathlib.Path):
 
         self.__log = log

--- a/tracdap-runtime/python/src/tracdap/rt/_exec/context.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_exec/context.py
@@ -134,7 +134,7 @@ class TracContextImpl(_api.TracContext):
         else:
             return copy.deepcopy(data_view.trac_schema)
 
-    def get_table(self, dataset_name: str, framework, **kwargs) -> _eapi._DATA_FRAMEWORK:  # noqa
+    def get_table(self, dataset_name: str, framework: _eapi.DataFramework[_eapi.DATA_API], **kwargs) -> _eapi.DATA_API:
 
         # Support the experimental API data framework syntax
 
@@ -225,7 +225,7 @@ class TracContextImpl(_api.TracContext):
 
         self.__local_ctx[dataset_name] = updated_view
 
-    def put_table(self, dataset_name: str, dataset: _eapi._DATA_FRAMEWORK, **kwargs):  # noqa
+    def put_table(self, dataset_name: str, dataset: _eapi.DATA_API, **kwargs):  # noqa
 
         # Support the experimental API data framework syntax
 

--- a/tracdap-runtime/python/src/tracdap/rt/_exec/context.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_exec/context.py
@@ -55,8 +55,6 @@ class TracContextImpl(_api.TracContext):
             Output views will contain schemas but no data.
     """
 
-    __DEFAULT_TEMPORAL_OBJECTS = False
-
     def __init__(self,
                  model_def: _meta.ModelDefinition,
                  model_class: _api.TracModel.__class__,
@@ -134,52 +132,21 @@ class TracContextImpl(_api.TracContext):
         else:
             return copy.deepcopy(data_view.trac_schema)
 
-    def get_table(self, dataset_name: str, framework: _eapi.DataFramework[_eapi.DATA_API], **kwargs) -> _eapi.DATA_API:
+    def get_table(self, dataset_name: str, framework: _eapi.DataFramework[_eapi.DATA_API], **framework_args) -> _eapi.DATA_API:  # noqa
 
-        # Support the experimental API data framework syntax
-
-        if framework == _eapi.PANDAS:
-            return self.get_pandas_table(dataset_name, **kwargs)
-        elif framework == _eapi.POLARS:
-            return self.get_polars_table(dataset_name)
-        else:
-            raise _ex.ERuntimeValidation(f"Unsupported data framework [{framework}]")
-
-    def get_pandas_table(self, dataset_name: str, use_temporal_objects: tp.Optional[bool] = None) \
-            -> "_data.pandas.DataFrame":
-
-        _val.require_package("pandas", _data.pandas)
-        _val.validate_signature(self.get_pandas_table, dataset_name, use_temporal_objects)
-
-        data_view, schema = self.__get_data_view(dataset_name)
-        part_key = _data.DataPartKey.for_root()
-
-        if use_temporal_objects is None:
-            use_temporal_objects = self.__DEFAULT_TEMPORAL_OBJECTS
-
-        return _data.DataMapping.view_to_pandas(data_view, part_key, schema, use_temporal_objects)
-
-    def get_polars_table(self, dataset_name: str) -> "_data.polars.DataFrame":
-
-        _val.require_package("polars", _data.polars)
-        _val.validate_signature(self.get_polars_table, dataset_name)
-
-        data_view, schema = self.__get_data_view(dataset_name)
-        part_key = _data.DataPartKey.for_root()
-
-        return _data.DataMapping.view_to_polars(data_view, part_key, schema)
-
-    def __get_data_view(self, dataset_name: str):
-
-        _val.validate_signature(self.__get_data_view, dataset_name)
+        _val.validate_signature(self.get_table, dataset_name, framework)
+        _val.require_package(framework.protocol_name, framework.api_type)
 
         self.__val.check_dataset_valid_identifier(dataset_name)
         self.__val.check_dataset_defined_in_model(dataset_name)
         self.__val.check_dataset_available_in_context(dataset_name)
+        self.__val.check_data_framework_args(framework, framework_args)
 
         static_schema = self.__get_static_schema(self.__model_def, dataset_name)
         data_view = self.__local_ctx.get(dataset_name)
         part_key = _data.DataPartKey.for_root()
+
+        converter = _data.DataConverter.for_framework(framework, **framework_args)
 
         self.__val.check_context_object_type(dataset_name, data_view, _data.DataView)
         self.__val.check_dataset_schema_defined(dataset_name, data_view)
@@ -193,7 +160,19 @@ class TracContextImpl(_api.TracContext):
         else:
             schema = data_view.arrow_schema
 
-        return data_view, schema
+        raw_table = _data.DataMapping.view_to_arrow(data_view, part_key)
+        table = _data.DataConformance.conform_to_schema(raw_table, schema)
+
+        return converter.from_internal(table, schema.names)
+
+    def get_pandas_table(self, dataset_name: str, use_temporal_objects: tp.Optional[bool] = None) \
+            -> "_data.pandas.DataFrame":
+
+        return self.get_table(dataset_name, _eapi.PANDAS, use_temporal_objects=use_temporal_objects)
+
+    def get_polars_table(self, dataset_name: str) -> "_data.polars.DataFrame":
+
+        return self.get_table(dataset_name, _eapi.POLARS)
 
     def put_schema(self, dataset_name: str, schema: _meta.SchemaDefinition):
 
@@ -225,57 +204,28 @@ class TracContextImpl(_api.TracContext):
 
         self.__local_ctx[dataset_name] = updated_view
 
-    def put_table(self, dataset_name: str, dataset: _eapi.DATA_API, **kwargs):  # noqa
+    def put_table(
+            self, dataset_name: str, dataset: _eapi.DATA_API,
+            framework: tp.Optional[_eapi.DataFramework[_eapi.DATA_API]] = None,
+            **framework_args):
 
-        # Support the experimental API data framework syntax
+        _val.validate_signature(self.put_table, dataset_name, dataset, framework)
 
-        if _data.pandas and isinstance(dataset, _data.pandas.DataFrame):
-            self.put_pandas_table(dataset_name, dataset)
-        elif _data.polars and isinstance(dataset, _data.polars.DataFrame):
-            self.put_polars_table(dataset_name, dataset)
-        else:
-            raise _ex.ERuntimeValidation(f"Unsupported data framework[{type(dataset)}]")
+        if framework is None:
+            framework = _data.DataConverter.get_framework(dataset)
 
-    def put_pandas_table(self, dataset_name: str, dataset: "_data.pandas.DataFrame"):
-
-        _val.require_package("pandas", _data.pandas)
-        _val.validate_signature(self.put_pandas_table, dataset_name, dataset)
-
-        part_key = _data.DataPartKey.for_root()
-        data_view, schema = self.__put_data_view(dataset_name, part_key, dataset, _data.pandas.DataFrame)
-
-        # Data conformance is applied inside these conversion functions
-
-        updated_item = _data.DataMapping.pandas_to_item(dataset, schema)
-        updated_view = _data.DataMapping.add_item_to_view(data_view, part_key, updated_item)
-
-        self.__local_ctx[dataset_name] = updated_view
-
-    def put_polars_table(self, dataset_name: str, dataset: "_data.polars.DataFrame"):
-
-        _val.require_package("polars", _data.polars)
-        _val.validate_signature(self.put_polars_table, dataset_name, dataset)
-
-        part_key = _data.DataPartKey.for_root()
-        data_view, schema = self.__put_data_view(dataset_name, part_key, dataset, _data.polars.DataFrame)
-
-        # Data conformance is applied inside these conversion functions
-
-        updated_item = _data.DataMapping.polars_to_item(dataset, schema)
-        updated_view = _data.DataMapping.add_item_to_view(data_view, part_key, updated_item)
-
-        self.__local_ctx[dataset_name] = updated_view
-
-    def __put_data_view(self, dataset_name: str, part_key: _data.DataPartKey, dataset: tp.Any, framework: type):
-
-        _val.validate_signature(self.__put_data_view, dataset_name, part_key, dataset, framework)
+        _val.require_package(framework.protocol_name, framework.api_type)
 
         self.__val.check_dataset_valid_identifier(dataset_name)
         self.__val.check_dataset_is_model_output(dataset_name)
-        self.__val.check_provided_dataset_type(dataset, framework)
+        self.__val.check_provided_dataset_type(dataset, framework.api_type)
+        self.__val.check_data_framework_args(framework, framework_args)
 
         static_schema = self.__get_static_schema(self.__model_def, dataset_name)
         data_view = self.__local_ctx.get(dataset_name)
+        part_key = _data.DataPartKey.for_root()
+
+        converter = _data.DataConverter.for_framework(framework)
 
         if data_view is None:
             if static_schema is not None:
@@ -294,7 +244,21 @@ class TracContextImpl(_api.TracContext):
         else:
             schema = data_view.arrow_schema
 
-        return data_view, schema
+        raw_table = converter.to_internal(dataset, schema.names)
+        table = _data.DataConformance.conform_to_schema(raw_table, schema)
+        item = _data.DataItem(schema, table)
+
+        updated_view = _data.DataMapping.add_item_to_view(data_view, part_key, item)
+
+        self.__local_ctx[dataset_name] = updated_view
+
+    def put_pandas_table(self, dataset_name: str, dataset: "_data.pandas.DataFrame"):
+
+        self.put_table(dataset_name, dataset, _eapi.PANDAS)
+
+    def put_polars_table(self, dataset_name: str, dataset: "_data.polars.DataFrame"):
+
+        self.put_table(dataset_name, dataset, _eapi.POLARS)
 
     def log(self) -> logging.Logger:
 
@@ -578,7 +542,7 @@ class TracContextValidator(TracContextErrorReporter):
         if param_name is None:
             self._report_error(f"Parameter name is null")
 
-        if not self.__VALID_IDENTIFIER.match(param_name):
+        if not self._VALID_IDENTIFIER.match(param_name):
             self._report_error(f"Parameter name {param_name} is not a valid identifier")
 
     def check_param_defined_in_model(self, param_name: str):
@@ -596,7 +560,7 @@ class TracContextValidator(TracContextErrorReporter):
         if dataset_name is None:
             self._report_error(f"Dataset name is null")
 
-        if not self.__VALID_IDENTIFIER.match(dataset_name):
+        if not self._VALID_IDENTIFIER.match(dataset_name):
             self._report_error(f"Dataset name {dataset_name} is not a valid identifier")
 
     def check_dataset_not_defined_in_model(self, dataset_name: str):
@@ -710,12 +674,39 @@ class TracContextValidator(TracContextErrorReporter):
                 f"The object referenced by [{item_name}] in the current context has the wrong type" +
                 f" (expected {expected_type_name}, got {actual_type_name})")
 
+    def check_data_framework_args(self, framework: _eapi.DataFramework, framework_args: tp.Dict[str, tp.Any]):
+
+        expected_args = _data.DataConverter.get_framework_args(framework)
+        unexpected_args = list(filter(lambda arg: arg not in expected_args, framework_args.keys()))
+
+        if any(unexpected_args):
+            unknown_args = ", ".join(unexpected_args)
+            self._report_error(f"Using [{framework}], some arguments were not recognized: [{unknown_args}]")
+
+        for arg_name, arg_type in expected_args.items():
+
+            arg_value = framework_args.get(arg_name)
+
+            if _val.check_type(arg_type, arg_value):
+                continue
+
+            if arg_value is None:
+                self._report_error(f"Using [{framework}], required argument [{arg_name}] is missing")
+
+            else:
+                expected_type_name = self._type_name(arg_type)
+                actual_type_name = self._type_name(type(arg_value))
+
+                self._report_error(
+                    f"Using [{framework}], argument [{arg_name}] has the wrong type" +
+                    f" (expected {expected_type_name}, got {actual_type_name})")
+
     def check_storage_valid_identifier(self, storage_key):
 
         if storage_key is None:
             self._report_error(f"Storage key is null")
 
-        if not self.__VALID_IDENTIFIER.match(storage_key):
+        if not self._VALID_IDENTIFIER.match(storage_key):
             self._report_error(f"Storage key {storage_key} is not a valid identifier")
 
     def check_storage_available(self, storage_map: tp.Dict, storage_key: str):
@@ -742,10 +733,10 @@ class TracContextValidator(TracContextErrorReporter):
 
         module = type_.__module__
 
-        if module is None or module == str.__class__.__module__:
-            return type_.__qualname__
-
-        return module + '.' + type_.__name__
+        if module is None or module == str.__class__.__module__ or module == tp.__name__:
+            return _val.type_name(type_, False)
+        else:
+            return _val.type_name(type_, True)
 
 
 class TracStorageValidator(TracContextErrorReporter):

--- a/tracdap-runtime/python/src/tracdap/rt/_impl/data.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_impl/data.py
@@ -381,6 +381,11 @@ class DataConverter(tp.Generic[T_DATA_API, T_INTERNAL_DATA, T_INTERNAL_SCHEMA]):
 
         raise _ex.EPluginNotAvailable(f"Data framework [{framework}] is not recognized")
 
+    @classmethod
+    def for_dataset(cls, dataset: _api.DATA_API) -> "DataConverter[_api.DATA_API, pa.Table, pa.Schema]":
+
+        return cls.for_framework(cls.get_framework(dataset))
+
     def __init__(self, framework: _api.DataFramework[T_DATA_API]):
         self.framework = framework
 

--- a/tracdap-runtime/python/src/tracdap/rt/_impl/data.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_impl/data.py
@@ -331,6 +331,34 @@ class DataMapping:
 
         raise _ex.ETracInternal(f"Data item does not contain any usable data")
 
+    @classmethod
+    def arrow_to_pandas(
+            cls, table: pa.Table,
+            schema: tp.Optional[pa.Schema] = None,
+            temporal_objects_flag: bool = False) -> "pandas.DataFrame":
+
+        # This is a legacy internal method and should be removed
+        # DataMapping is no longer responsible for individual data APIs
+
+        # Maintained temporarily for compatibility with existing deployments
+
+        converter = PandasArrowConverter(_api.PANDAS, use_temporal_objects=temporal_objects_flag)
+        return converter.from_internal(table, schema)
+
+    @classmethod
+    def pandas_to_arrow(
+            cls, df: "pandas.DataFrame",
+            schema: tp.Optional[pa.Schema] = None) -> pa.Table:
+
+        # This is a legacy internal method and should be removed
+        # DataMapping is no longer responsible for individual data APIs
+
+        # Maintained temporarily for compatibility with existing deployments
+
+        converter = PandasArrowConverter(_api.PANDAS)
+        return converter.to_internal(df, schema)
+
+
 
 T_DATA_API = tp.TypeVar("T_DATA_API")
 T_INTERNAL_DATA = tp.TypeVar("T_INTERNAL_DATA")

--- a/tracdap-runtime/python/src/tracdap/rt/_impl/data.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_impl/data.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import abc
 import dataclasses as dc
 import typing as tp
 import datetime as dt
@@ -31,6 +32,7 @@ try:
 except ModuleNotFoundError:
     polars = None
 
+import tracdap.rt.api.experimental as _api
 import tracdap.rt.metadata as _meta
 import tracdap.rt.exceptions as _ex
 import tracdap.rt._impl.util as _util
@@ -116,73 +118,19 @@ class DataMapping:
 
     # Matches TRAC_ARROW_TYPE_MAPPING in ArrowSchema, tracdap-lib-data
 
-    __TRAC_DECIMAL_PRECISION = 38
-    __TRAC_DECIMAL_SCALE = 12
-    __TRAC_TIMESTAMP_UNIT = "ms"
-    __TRAC_TIMESTAMP_ZONE = None
+    DEFAULT_DECIMAL_PRECISION = 38
+    DEFAULT_DECIMAL_SCALE = 12
+    DEFAULT_TIMESTAMP_UNIT = "ms"
+    DEFAULT_TIMESTAMP_ZONE = None
 
     __TRAC_TO_ARROW_BASIC_TYPE_MAPPING = {
         _meta.BasicType.BOOLEAN: pa.bool_(),
         _meta.BasicType.INTEGER: pa.int64(),
         _meta.BasicType.FLOAT: pa.float64(),
-        _meta.BasicType.DECIMAL: pa.decimal128(__TRAC_DECIMAL_PRECISION, __TRAC_DECIMAL_SCALE),
+        _meta.BasicType.DECIMAL: pa.decimal128(DEFAULT_DECIMAL_PRECISION, DEFAULT_DECIMAL_SCALE),
         _meta.BasicType.STRING: pa.utf8(),
         _meta.BasicType.DATE: pa.date32(),
-        _meta.BasicType.DATETIME: pa.timestamp(__TRAC_TIMESTAMP_UNIT, __TRAC_TIMESTAMP_ZONE)
-    }
-
-    # Check the Pandas dtypes for handling floats are available before setting up the type mapping
-    __PANDAS_VERSION_ELEMENTS = pandas.__version__.split(".")
-    __PANDAS_MAJOR_VERSION = int(__PANDAS_VERSION_ELEMENTS[0])
-    __PANDAS_MINOR_VERSION = int(__PANDAS_VERSION_ELEMENTS[1])
-
-    if __PANDAS_MAJOR_VERSION == 2:
-
-        __PANDAS_DATE_TYPE = pandas.to_datetime([dt.date(2000, 1, 1)]).as_unit(__TRAC_TIMESTAMP_UNIT).dtype
-        __PANDAS_DATETIME_TYPE = pandas.to_datetime([dt.datetime(2000, 1, 1, 0, 0, 0)]).as_unit(__TRAC_TIMESTAMP_UNIT).dtype
-
-        @classmethod
-        def __pandas_datetime_type(cls, tz, unit):
-            if tz is None and unit is None:
-                return cls.__PANDAS_DATETIME_TYPE
-            _unit = unit if unit is not None else cls.__TRAC_TIMESTAMP_UNIT
-            if tz is None:
-                return pandas.to_datetime([dt.datetime(2000, 1, 1, 0, 0, 0)]).as_unit(_unit).dtype
-            else:
-                return pandas.DatetimeTZDtype(tz=tz, unit=_unit)
-
-    # Minimum supported version for Pandas is 1.2, when pandas.Float64Dtype was introduced
-    elif __PANDAS_MAJOR_VERSION == 1 and __PANDAS_MINOR_VERSION >= 2:
-
-        __PANDAS_DATE_TYPE = pandas.to_datetime([dt.date(2000, 1, 1)]).dtype
-        __PANDAS_DATETIME_TYPE = pandas.to_datetime([dt.datetime(2000, 1, 1, 0, 0, 0)]).dtype
-
-        @classmethod
-        def __pandas_datetime_type(cls, tz, unit):  # noqa
-            if tz is None:
-                return cls.__PANDAS_DATETIME_TYPE
-            else:
-                return pandas.DatetimeTZDtype(tz=tz)
-
-    else:
-        raise _ex.EStartup(f"Pandas version not supported: [{pandas.__version__}]")
-
-    # Only partial mapping is possible, decimal and temporal dtypes cannot be mapped this way
-    __ARROW_TO_PANDAS_TYPE_MAPPING = {
-        pa.bool_(): pandas.BooleanDtype(),
-        pa.int8(): pandas.Int8Dtype(),
-        pa.int16(): pandas.Int16Dtype(),
-        pa.int32(): pandas.Int32Dtype(),
-        pa.int64(): pandas.Int64Dtype(),
-        pa.uint8(): pandas.UInt8Dtype(),
-        pa.uint16(): pandas.UInt16Dtype(),
-        pa.uint32(): pandas.UInt32Dtype(),
-        pa.uint64(): pandas.UInt64Dtype(),
-        pa.float16(): pandas.Float32Dtype(),
-        pa.float32(): pandas.Float32Dtype(),
-        pa.float64(): pandas.Float64Dtype(),
-        pa.string(): pandas.StringDtype(),
-        pa.utf8(): pandas.StringDtype()
+        _meta.BasicType.DATETIME: pa.timestamp(DEFAULT_TIMESTAMP_UNIT, DEFAULT_TIMESTAMP_ZONE)
     }
 
     __ARROW_TO_TRAC_BASIC_TYPE_MAPPING = {
@@ -243,7 +191,7 @@ class DataMapping:
             return pa.float64()
 
         if python_type == decimal.Decimal:
-            return pa.decimal128(cls.__TRAC_DECIMAL_PRECISION, cls.__TRAC_DECIMAL_SCALE)
+            return pa.decimal128(cls.DEFAULT_DECIMAL_PRECISION, cls.DEFAULT_DECIMAL_SCALE)
 
         if python_type == str:
             return pa.utf8()
@@ -252,7 +200,7 @@ class DataMapping:
             return pa.date32()
 
         if python_type == dt.datetime:
-            return pa.timestamp(cls.__TRAC_TIMESTAMP_UNIT, cls.__TRAC_TIMESTAMP_ZONE)
+            return pa.timestamp(cls.DEFAULT_TIMESTAMP_UNIT, cls.DEFAULT_TIMESTAMP_ZONE)
 
         raise _ex.ETracInternal(f"No Arrow type mapping available for Python type [{python_type}]")
 
@@ -293,8 +241,8 @@ class DataMapping:
     def trac_arrow_decimal_type(cls) -> pa.Decimal128Type:
 
         return pa.decimal128(
-            cls.__TRAC_DECIMAL_PRECISION,
-            cls.__TRAC_DECIMAL_SCALE)
+            cls.DEFAULT_DECIMAL_PRECISION,
+            cls.DEFAULT_DECIMAL_SCALE,)
 
     @classmethod
     def arrow_to_trac_schema(cls, arrow_schema: pa.Schema) -> _meta.SchemaDefinition:
@@ -336,41 +284,6 @@ class DataMapping:
             return _meta.BasicType.DATETIME
 
         raise _ex.ETracInternal(f"No data type mapping available for Arrow type [{arrow_type}]")
-
-    @classmethod
-    def pandas_date_type(cls):
-        return cls.__PANDAS_DATE_TYPE
-
-    @classmethod
-    def pandas_datetime_type(cls, tz=None, unit=None):
-        return cls.__pandas_datetime_type(tz, unit)
-
-    @classmethod
-    def view_to_pandas(
-            cls, view:  DataView,  part: DataPartKey, schema: tp.Optional[pa.Schema],
-            temporal_objects_flag: bool) -> "pandas.DataFrame":
-
-        table = cls.view_to_arrow(view, part)
-        return cls.arrow_to_pandas(table, schema, temporal_objects_flag)
-
-    @classmethod
-    def view_to_polars(
-            cls, view:  DataView, part: DataPartKey, schema: tp.Optional[pa.Schema]):
-
-        table = cls.view_to_arrow(view, part)
-        return cls.arrow_to_polars(table, schema)
-
-    @classmethod
-    def pandas_to_item(cls, df: "pandas.DataFrame", schema: tp.Optional[pa.Schema]) -> DataItem:
-
-        table = cls.pandas_to_arrow(df, schema)
-        return DataItem(table.schema, table)
-
-    @classmethod
-    def polars_to_item(cls, df: "polars.DataFrame", schema: tp.Optional[pa.Schema]) -> DataItem:
-
-        table = cls.polars_to_arrow(df, schema)
-        return DataItem(table.schema, table)
 
     @classmethod
     def add_item_to_view(cls, view: DataView, part: DataPartKey, item: DataItem) -> DataView:
@@ -418,25 +331,155 @@ class DataMapping:
 
         raise _ex.ETracInternal(f"Data item does not contain any usable data")
 
-    @classmethod
-    def arrow_to_pandas(
-            cls, table: pa.Table, schema: tp.Optional[pa.Schema] = None,
-            temporal_objects_flag: bool = False) -> "pandas.DataFrame":
 
-        if schema is not None:
-            table = DataConformance.conform_to_schema(table, schema, warn_extra_columns=False)
+T_DATA_API = tp.TypeVar("T_DATA_API")
+T_DATA_INTERNAL = tp.TypeVar("T_DATA_INTERNAL")
+
+
+class DataConverter(tp.Generic[T_DATA_API, T_DATA_INTERNAL]):
+
+    # Available per-framework args, to enable framework-specific type-checking in public APIs
+    # These should (for a purist point of view) be in the individual converter classes
+    # For now there are only a few converters and they are all defined here, so this is OK
+    __FRAMEWORK_ARGS = {
+        _api.PANDAS: {"use_temporal_objects": tp.Optional[bool]},
+        _api.POLARS: {}
+    }
+
+    @classmethod
+    def get_framework(cls, dataset: _api.DATA_API) -> _api.DataFramework[_api.DATA_API]:
+
+        if pandas and isinstance(dataset, pandas.DataFrame):
+            return _api.PANDAS
+
+        if polars and isinstance(dataset, polars.DataFrame):
+            return _api.POLARS
+
+        data_api_type = f"{type(dataset).__module__}.{type(dataset).__name__}"
+        raise _ex.EPluginNotAvailable(f"No data framework available for type [{data_api_type}]")
+
+    @classmethod
+    def get_framework_args(cls, framework: _api.DataFramework[_api.DATA_API]) -> tp.Dict[str, type]:
+
+        return cls.__FRAMEWORK_ARGS.get(framework) or {}
+
+    @classmethod
+    def for_framework(cls, framework: _api.DataFramework[_api.DATA_API], **framework_args) -> "DataConverter[_api.DATA_API, pa.Table]":
+
+        if framework == _api.PANDAS:
+            if pandas is not None:
+                return PandasArrowConverter(**framework_args)
+            else:
+                raise _ex.EPluginNotAvailable(f"Optional package [{framework}] is not installed")
+
+        if framework == _api.POLARS:
+            if polars is not None:
+                return PolarsArrowConverter()
+            else:
+                raise _ex.EPluginNotAvailable(f"Optional package [{framework}] is not installed")
+
+        raise _ex.EPluginNotAvailable(f"Data framework [{framework}] is not recognized")
+
+    @abc.abstractmethod
+    def from_internal(self, dataset: T_DATA_INTERNAL, column_filter: tp.Optional[tp.List[str]] = None) -> T_DATA_API:
+        pass
+
+    @abc.abstractmethod
+    def to_internal(self, dataset: T_DATA_API, column_filter: tp.Optional[tp.List[str]] = None) -> T_DATA_INTERNAL:
+        pass
+
+    @abc.abstractmethod
+    def infer_schema(self, dataset: T_DATA_API) -> _meta.SchemaDefinition:
+        pass
+
+
+class PandasArrowConverter(DataConverter[pandas.DataFrame, pa.Table]):
+
+    # Check the Pandas dtypes for handling floats are available before setting up the type mapping
+    __PANDAS_VERSION_ELEMENTS = pandas.__version__.split(".")
+    __PANDAS_MAJOR_VERSION = int(__PANDAS_VERSION_ELEMENTS[0])
+    __PANDAS_MINOR_VERSION = int(__PANDAS_VERSION_ELEMENTS[1])
+
+    if __PANDAS_MAJOR_VERSION == 2:
+
+        __PANDAS_DATE_TYPE = pandas.to_datetime([dt.date(2000, 1, 1)]).as_unit(DataMapping.DEFAULT_TIMESTAMP_UNIT).dtype
+        __PANDAS_DATETIME_TYPE = pandas.to_datetime([dt.datetime(2000, 1, 1, 0, 0, 0)]).as_unit(DataMapping.DEFAULT_TIMESTAMP_UNIT).dtype
+
+        @classmethod
+        def __pandas_datetime_type(cls, tz, unit):
+            if tz is None and unit is None:
+                return cls.__PANDAS_DATETIME_TYPE
+            _unit = unit if unit is not None else DataMapping.DEFAULT_TIMESTAMP_UNIT
+            if tz is None:
+                return pandas.to_datetime([dt.datetime(2000, 1, 1, 0, 0, 0)]).as_unit(_unit).dtype
+            else:
+                return pandas.DatetimeTZDtype(tz=tz, unit=_unit)
+
+    # Minimum supported version for Pandas is 1.2, when pandas.Float64Dtype was introduced
+    elif __PANDAS_MAJOR_VERSION == 1 and __PANDAS_MINOR_VERSION >= 2:
+
+        __PANDAS_DATE_TYPE = pandas.to_datetime([dt.date(2000, 1, 1)]).dtype
+        __PANDAS_DATETIME_TYPE = pandas.to_datetime([dt.datetime(2000, 1, 1, 0, 0, 0)]).dtype
+
+        @classmethod
+        def __pandas_datetime_type(cls, tz, unit):  # noqa
+            if tz is None:
+                return cls.__PANDAS_DATETIME_TYPE
+            else:
+                return pandas.DatetimeTZDtype(tz=tz)
+
+    else:
+        raise _ex.EStartup(f"Pandas version not supported: [{pandas.__version__}]")
+
+    # Only partial mapping is possible, decimal and temporal dtypes cannot be mapped this way
+    __ARROW_TO_PANDAS_TYPE_MAPPING = {
+        pa.bool_(): pandas.BooleanDtype(),
+        pa.int8(): pandas.Int8Dtype(),
+        pa.int16(): pandas.Int16Dtype(),
+        pa.int32(): pandas.Int32Dtype(),
+        pa.int64(): pandas.Int64Dtype(),
+        pa.uint8(): pandas.UInt8Dtype(),
+        pa.uint16(): pandas.UInt16Dtype(),
+        pa.uint32(): pandas.UInt32Dtype(),
+        pa.uint64(): pandas.UInt64Dtype(),
+        pa.float16(): pandas.Float32Dtype(),
+        pa.float32(): pandas.Float32Dtype(),
+        pa.float64(): pandas.Float64Dtype(),
+        pa.string(): pandas.StringDtype(),
+        pa.utf8(): pandas.StringDtype()
+    }
+
+    __DEFAULT_TEMPORAL_OBJECTS = False
+
+    # Expose date type for testing
+    @classmethod
+    def pandas_date_type(cls):
+        return cls.__PANDAS_DATE_TYPE
+
+    # Expose datetime type for testing
+    @classmethod
+    def pandas_datetime_type(cls, tz=None, unit=None):
+        return cls.__pandas_datetime_type(tz, unit)
+
+    def __init__(self, use_temporal_objects: tp.Optional[bool] = None):
+        if use_temporal_objects is None:
+            self.__temporal_objects_flag = self.__DEFAULT_TEMPORAL_OBJECTS
         else:
-            DataConformance.check_duplicate_fields(table.schema.names, False)
+            self.__temporal_objects_flag = use_temporal_objects
+
+    def from_internal(self, table: pa.Table, column_filter: tp.Optional[tp.List[str]] = None) -> pandas.DataFrame:
+
+        filtered_table = table.select(column_filter) if column_filter else table
 
         # Use Arrow's built-in function to convert to Pandas
-        return table.to_pandas(
+        return filtered_table.to_pandas(
 
             # Mapping for arrow -> pandas types for core types
-            types_mapper=cls.__ARROW_TO_PANDAS_TYPE_MAPPING.get,
+            types_mapper=self.__ARROW_TO_PANDAS_TYPE_MAPPING.get,
 
             # Use Python objects for dates and times if temporal_objects_flag is set
-            date_as_object=temporal_objects_flag,  # noqa
-            timestamp_as_object=temporal_objects_flag,  # noqa
+            date_as_object=self.__temporal_objects_flag,  # noqa
+            timestamp_as_object=self.__temporal_objects_flag,  # noqa
 
             # Do not bring any Arrow metadata into Pandas dataframe
             ignore_metadata=True,  # noqa
@@ -445,19 +488,7 @@ class DataMapping:
             # This is a significant performance win for very wide datasets
             split_blocks=True)  # noqa
 
-    @classmethod
-    def arrow_to_polars(
-            cls, table: pa.Table, schema: tp.Optional[pa.Schema] = None) -> "polars.DataFrame":
-
-        if schema is not None:
-            table = DataConformance.conform_to_schema(table, schema, warn_extra_columns=False)
-        else:
-            DataConformance.check_duplicate_fields(table.schema.names, False)
-
-        return polars.from_arrow(table)
-
-    @classmethod
-    def pandas_to_arrow(cls, df: "pandas.DataFrame", schema: tp.Optional[pa.Schema] = None) -> pa.Table:
+    def to_internal(self, df: pandas.DataFrame, column_filter: tp.Optional[tp.List[str]] = None) -> pa.Table:
 
         # Converting pandas -> arrow needs care to ensure type coercion is applied correctly
         # Calling Table.from_pandas with the supplied schema will very often reject data
@@ -467,11 +498,9 @@ class DataMapping:
         # As an optimisation, the column filter means columns will not be converted if they are not needed
         # E.g. if a model outputs lots of undeclared columns, there is no need to convert them
 
-        column_filter = DataConformance.column_filter(df.columns, schema)  # noqa
-
         if len(df) > 0:
 
-            table = pa.Table.from_pandas(df, columns=column_filter, preserve_index=False)  # noqa
+            return pa.Table.from_pandas(df, columns=column_filter, preserve_index=False)  # noqa
 
         # Special case handling for converting an empty dataframe
         # These must flow through the pipe with valid schemas, like any other dataset
@@ -482,46 +511,33 @@ class DataMapping:
             empty_df = df.filter(column_filter) if column_filter else df
             empty_schema = pa.Schema.from_pandas(empty_df, preserve_index=False)  # noqa
 
-            table = pa.Table.from_batches(list(), empty_schema)  # noqa
+            return pa.Table.from_batches(list(), empty_schema)  # noqa
 
-        # If there is no explict schema, give back the table exactly as it was received from Pandas
-        # There could be an option here to infer and coerce for TRAC standard types
-        # E.g. unsigned int 32 -> signed int 64, TRAC standard integer type
+    def infer_schema(self, dataset: pandas.DataFrame) -> _meta.SchemaDefinition:
 
-        if schema is None:
-            DataConformance.check_duplicate_fields(table.schema.names, False)
-            return table
+        arrow_schema = pa.Schema.from_pandas(dataset, preserve_index=False)  # noqa
+        return DataMapping.arrow_to_trac_schema(arrow_schema)
 
-        # If a schema has been supplied, apply data conformance
-        # If column filtering has been applied, we also need to filter the pandas dtypes used for hinting
 
-        else:
-            df_types = df.dtypes.filter(column_filter) if column_filter else df.dtypes
-            return DataConformance.conform_to_schema(table, schema, df_types)
+class PolarsArrowConverter(DataConverter[polars.DataFrame, pa.Table]):
 
-    @classmethod
-    def pandas_to_arrow_schema(cls, df: "pandas.DataFrame") -> pa.Schema:
+    def __init__(self):
+        pass
 
-        return pa.Schema.from_pandas(df, preserve_index=False)  # noqa
+    def from_internal(self, table: pa.Table, column_filter: tp.Optional[tp.List[str]] = None) -> polars.DataFrame:
 
-    @classmethod
-    def polars_to_arrow(cls, df: "polars.DataFrame", schema: tp.Optional[pa.Schema] = None) -> pa.Table:
+        filtered_table = table.select(column_filter) if column_filter else table
+        return polars.from_arrow(filtered_table)
 
-        column_filter = DataConformance.column_filter(df.columns, schema)
+    def to_internal(self, df: polars.DataFrame, column_filter: tp.Optional[tp.List[str]] = None,) -> pa.Table:
 
         filtered_df = df.select(polars.col(*column_filter)) if column_filter else df
-        table = filtered_df.to_arrow()
+        return filtered_df.to_arrow()
 
-        if schema is None:
-            DataConformance.check_duplicate_fields(table.schema.names, False)
-            return table
-        else:
-            return DataConformance.conform_to_schema(table, schema, None)
+    def infer_schema(self, dataset: T_DATA_API) -> _meta.SchemaDefinition:
 
-    @classmethod
-    def polars_to_arrow_schema(cls, df: "polars.DataFrame") -> pa.Schema:
-
-        return df.top_k(1).to_arrow().schema
+        arrow_schema = dataset.top_k(1).to_arrow().schema
+        return DataMapping.arrow_to_trac_schema(arrow_schema)
 
 
 class DataConformance:
@@ -549,6 +565,16 @@ class DataConformance:
     __E_TIMEZONE_DOES_NOT_MATCH = \
         "Field [{field_name}] cannot be converted from {vector_type} to {field_type}, " + \
         "source and target have different time zones"
+
+    @classmethod
+    def apply_conformance(
+            cls, table:  pa.Table, schema: tp.Optional[pa.Schema],
+            pandas_types=None, warn_extra_columns=True) -> pa.Table:
+
+        if schema is not None:
+            return DataConformance.conform_to_schema(table, schema, pandas_types, warn_extra_columns)
+        else:
+            return DataConformance.check_duplicate_fields(table.schema.names, False)
 
     @classmethod
     def column_filter(cls, columns: tp.List[str], schema: tp.Optional[pa.Schema]) -> tp.Optional[tp.List[str]]:

--- a/tracdap-runtime/python/src/tracdap/rt/_impl/data.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_impl/data.py
@@ -340,7 +340,7 @@ class DataConverter(tp.Generic[T_DATA_API, T_DATA_INTERNAL]):
 
     # Available per-framework args, to enable framework-specific type-checking in public APIs
     # These should (for a purist point of view) be in the individual converter classes
-    # For now there are only a few converters and they are all defined here, so this is OK
+    # For now there are only a few converters, they are all defined here so this is OK
     __FRAMEWORK_ARGS = {
         _api.PANDAS: {"use_temporal_objects": tp.Optional[bool]},
         _api.POLARS: {}
@@ -678,7 +678,7 @@ class DataConformance:
         # Columns not defined in the schema will not be included in the conformed output
         if warn_extra_columns and table.num_columns > len(schema.types):
 
-            schema_columns = set(map(str.lower, schema.names))
+            schema_columns = set(map(lambda c: c.lower(), schema.names))
             extra_columns = [
                 f"[{col}]"
                 for col in table.schema.names

--- a/tracdap-runtime/python/src/tracdap/rt/_impl/util.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_impl/util.py
@@ -262,6 +262,16 @@ def get_args(metaclass: type):
         return None
 
 
+def get_constraints(metaclass: tp.TypeVar):
+
+    return metaclass.__constraints__ or None
+
+
+def get_bound(metaclass: tp.TypeVar):
+
+    return metaclass.__bound__ or None
+
+
 def try_clean_dir(dir_path: pathlib.Path, remove: bool = False) -> bool:
 
     normalized_path = windows_unc_path(dir_path)

--- a/tracdap-runtime/python/src/tracdap/rt/_impl/validation.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_impl/validation.py
@@ -44,6 +44,10 @@ def check_type(expected_type: tp.Type, value: tp.Any) -> bool:
     return _TypeValidator.check_type(expected_type, value)
 
 
+def type_name(type_: tp.Type, qualified: bool) -> str:
+    return _TypeValidator._type_name(type_, qualified)  # noqa
+
+
 def quick_validate_model_def(model_def: meta.ModelDefinition):
     StaticValidator.quick_validate_model_def(model_def)
 
@@ -274,7 +278,10 @@ class _TypeValidator:
                 return f"Named[{named_type}]"
 
             if origin is tp.Union:
-                return "|".join(map(cls._type_name, args))
+                if len(args) == 2 and args[1] == type(None):
+                    return f"Optional[{cls._type_name(args[0])}]"
+                else:
+                    return "|".join(map(cls._type_name, args))
 
             if origin is list:
                 list_type = cls._type_name(args[0])

--- a/tracdap-runtime/python/src/tracdap/rt/_impl/validation.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_impl/validation.py
@@ -48,6 +48,13 @@ def quick_validate_model_def(model_def: meta.ModelDefinition):
     StaticValidator.quick_validate_model_def(model_def)
 
 
+T_SKIP_VAL = tp.TypeVar("T_SKIP_VAL")
+
+class SkipValidation(tp.Generic[T_SKIP_VAL]):
+    def __init__(self, skip_type: tp.Type[T_SKIP_VAL]):
+        self.skip_type = skip_type
+
+
 class _TypeValidator:
 
     # The metaclass for generic types varies between versions of the typing library
@@ -56,22 +63,21 @@ class _TypeValidator:
 
     # Cache method signatures to avoid inspection on every call
     # Inspecting a function signature can take ~ half a second in Python 3.7
-    __method_cache: tp.Dict[str, inspect.Signature] = dict()
+    __method_cache: tp.Dict[str, tp.Tuple[inspect.Signature, tp.Any]] = dict()
 
     _log: logging.Logger = util.logger_for_namespace(__name__)
 
     @classmethod
     def validate_signature(cls, method: tp.Callable, *args, **kwargs):
 
-        if method.__name__ in cls.__method_cache:
-            signature = cls.__method_cache[method.__name__]
+        if method.__qualname__ in cls.__method_cache:
+            signature, hints = cls.__method_cache[method.__qualname__]
         else:
             signature = inspect.signature(method)
-            cls.__method_cache[method.__name__] = signature
+            hints = tp.get_type_hints(method)
+            cls.__method_cache[method.__qualname__] = signature, hints
 
-        hints = tp.get_type_hints(method)
         named_params = list(signature.parameters.keys())
-
         positional_index = 0
 
         for param_name, param in signature.parameters.items():
@@ -87,11 +93,12 @@ class _TypeValidator:
     @classmethod
     def validate_return_type(cls, method: tp.Callable, value: tp.Any):
 
-        if method.__name__ in cls.__method_cache:
-            signature = cls.__method_cache[method.__name__]
+        if method.__qualname__ in cls.__method_cache:
+            signature, hints = cls.__method_cache[method.__qualname__]
         else:
             signature = inspect.signature(method)
-            cls.__method_cache[method.__name__] = signature
+            hints = tp.get_type_hints(method)
+            cls.__method_cache[method.__qualname__] = signature, hints
 
         correct_type = cls._validate_type(signature.return_annotation, value)
 
@@ -181,6 +188,12 @@ class _TypeValidator:
         if expected_type == tp.Any:
             return True
 
+        # Sometimes we need to validate a partial set of arguments
+        # Explicitly passing a SkipValidation value allows for this
+        if isinstance(value, SkipValidation):
+            if value.skip_type == expected_type:
+                return True
+
         if isinstance(expected_type, cls.__generic_metaclass):
 
             origin = util.get_origin(expected_type)
@@ -221,6 +234,26 @@ class _TypeValidator:
                 return isinstance(value, origin)
 
             raise ex.ETracInternal(f"Validation of [{origin.__name__}] generic parameters is not supported yet")
+
+        # Support for generic type variables
+        if isinstance(expected_type, tp.TypeVar):
+
+            # If there are any constraints or a bound, those must be honoured
+
+            constraints =  util.get_constraints(expected_type)
+            bound = util.get_bound(expected_type)
+
+            if constraints:
+                if not any(map(lambda c: type(value) == c, constraints)):
+                    return False
+
+            if bound:
+                if not isinstance(value, bound):
+                    return False
+
+            # So long as constraints / bound are ok, any type matches a generic type var
+            return True
+
 
         # Validate everything else as a concrete type
 

--- a/tracdap-runtime/python/src/tracdap/rt/api/experimental.py
+++ b/tracdap-runtime/python/src/tracdap/rt/api/experimental.py
@@ -22,56 +22,64 @@ from tracdap.rt.api import *
 from .hook import _StaticApiHook
 
 
-_DATA_FRAMEWORK = _tp.TypeVar('_DATA_FRAMEWORK')
+_PROTOCOL = _tp.TypeVar('_PROTOCOL')
+DATA_API = _tp.TypeVar('DATA_API')
 
 
-class _DataFramework(_tp.Generic[_DATA_FRAMEWORK]):
+@_dc.dataclass(frozen=True)
+class _Protocol(_tp.Generic[_PROTOCOL]):
 
-    PANDAS: "_DataFramework"
-    POLARS: "_DataFramework"
-
-    def __init__(self, framework_name, framework_type: _DATA_FRAMEWORK):
-        self.__framework_name = framework_name
-        self.__framework_type = framework_type
+    protocol_name: str
+    api_type: _tp.Type[_PROTOCOL]
 
     def __str__(self):
-        return self.__framework_name
+        return self.protocol_name
+
+
+class DataFramework(_Protocol[DATA_API]):
+
+    def __init__(self, protocol_name: str, api_type: _tp.Type[DATA_API]):
+        super().__init__(protocol_name, api_type)
+
+    PANDAS: "DataFramework[DATA_API]"
+    POLARS: "DataFramework[DATA_API]"
 
 
 if _tp.TYPE_CHECKING:
 
     if pandas:
-        _DataFramework.PANDAS = _DataFramework('pandas', pandas.DataFrame)
+        DataFramework.PANDAS = DataFramework('pandas', pandas.DataFrame)
         """The original Python dataframe library, most widely used"""
     else:
-        _DataFramework.PANDAS = _DataFramework('pandas', None)
+        DataFramework.PANDAS = DataFramework('pandas', None)
         """Pandas data framework is not installed"""
 
     if polars:
-        _DataFramework.POLARS = _DataFramework('polars', polars.DataFrame)
+        DataFramework.POLARS = DataFramework('polars', polars.DataFrame)
         """A modern, fast and simple alternative to Pandas"""
     else:
-        _DataFramework.POLARS = _DataFramework('polars', None)
+        DataFramework.POLARS = DataFramework('polars', None)
         """Polars data framework is not installed"""
 
 else:
 
-    _DataFramework.PANDAS = _DataFramework('pandas', None)
-    _DataFramework.POLARS = _DataFramework('polars', None)
+    DataFramework.PANDAS = DataFramework('pandas', None)
+    DataFramework.POLARS = DataFramework('polars', None)
 
-PANDAS = _DataFramework.PANDAS
-POLARS = _DataFramework.POLARS
+
+PANDAS = DataFramework.PANDAS
+POLARS = DataFramework.POLARS
 
 
 class TracContext(TracContext):
 
     @_abc.abstractmethod
-    def get_table(self, dataset_name: str, framework: _DataFramework[_DATA_FRAMEWORK]) -> _DATA_FRAMEWORK:
+    def get_table(self, dataset_name: str, framework: DataFramework[DATA_API]) -> DATA_API:
 
         pass
 
     @_abc.abstractmethod
-    def put_table(self, dataset_name: str, dataset: _DATA_FRAMEWORK):
+    def put_table(self, dataset_name: str, dataset: DATA_API):
 
         pass
 

--- a/tracdap-runtime/python/src/tracdap/rt/api/experimental.py
+++ b/tracdap-runtime/python/src/tracdap/rt/api/experimental.py
@@ -88,7 +88,7 @@ def init_static():
     _static_impl.StaticApiImpl.register_impl()
 
 
-def infer_schema(dataset: _tp.Any) -> SchemaDefinition:
+def infer_schema(dataset: DATA_API) -> SchemaDefinition:
     sa = _StaticApiHook.get_instance()
     return sa.infer_schema(dataset)
 

--- a/tracdap-runtime/python/test/tracdap_test/rt/exec/test_context.py
+++ b/tracdap-runtime/python/test/tracdap_test/rt/exec/test_context.py
@@ -148,8 +148,9 @@ class TracContextTest(unittest.TestCase):
         customer_loans_schema = _test_model_def.inputs.get("customer_loans").schema
         customer_loans_view = _data.DataView.for_trac_schema(customer_loans_schema)
 
-        customer_loans_delta0 = _data.PandasArrowConverter().to_internal(
-            self.LOANS_DATA, customer_loans_view.arrow_schema)
+        customer_loans_delta0 = _data.DataConverter \
+            .for_dataset(self.LOANS_DATA) \
+            .to_internal(self.LOANS_DATA, customer_loans_view.arrow_schema)
 
         customer_loans_view = _data.DataMapping.add_item_to_view(
             customer_loans_view, _data.DataPartKey.for_root(),

--- a/tracdap-runtime/python/test/tracdap_test/rt/exec/test_context.py
+++ b/tracdap-runtime/python/test/tracdap_test/rt/exec/test_context.py
@@ -148,12 +148,12 @@ class TracContextTest(unittest.TestCase):
         customer_loans_schema = _test_model_def.inputs.get("customer_loans").schema
         customer_loans_view = _data.DataView.for_trac_schema(customer_loans_schema)
 
-        customer_loans_delta0 = _data.DataMapping.pandas_to_item(
+        customer_loans_delta0 = _data.PandasArrowConverter().to_internal(
             self.LOANS_DATA, customer_loans_view.arrow_schema)
 
         customer_loans_view = _data.DataMapping.add_item_to_view(
             customer_loans_view, _data.DataPartKey.for_root(),
-            customer_loans_delta0)
+            _data.DataItem(customer_loans_view.arrow_schema, customer_loans_delta0))
 
         profit_by_region_schema = _test_model_def.outputs.get("profit_by_region").schema
         profit_by_region_view = _data.DataView.for_trac_schema(profit_by_region_schema)

--- a/tracdap-runtime/python/test/tracdap_test/rt/suites/file_storage_suite.py
+++ b/tracdap-runtime/python/test/tracdap_test/rt/suites/file_storage_suite.py
@@ -30,7 +30,7 @@ _util.configure_logging()
 # For testing, alias to secrets.token_bytes if it is not available (available since 3.6)
 if "randbytes" not in random.__dict__:
     import secrets
-    random.__dict__["randbytes"] = secrets.token_bytes
+    setattr(random, "randbytes", secrets.token_bytes)
 
 
 class FileOperationsTestSuite:
@@ -1089,10 +1089,6 @@ class FileReadWriteTestSuite:
     # That means all handles/streams/locks are closed and for write operation partially written files are removed
     # It is difficult to verify this using the abstracted storage API!
     # These tests look for common symptoms of resource leaks that may catch some common errors
-    #
-    # Error states in the streams are checked directly by mocking/spying on the Java Flow API
-    # E.g. Illegal state and cancellation exceptions are checked explicitly
-    # This is different from the functional tests, which unwrap stream state errors to look for EStorage errors
     #
     # Using the storage API it is not possible to simulate errors that occur in the storage back end
     # E.g. loss of connection to a storage service or disk full during a write operation


### PR DESCRIPTION
Make DATA_API a generic type (e.g. pandas, polars etc.)
Encapsulate logic for each data API into a single converter class
Allow TRAC to run when some data modules are missing

Pandas is still a hard dependency for now, but it doesn't have to be, this could be changed in the next major release