### PR TITLE
Feature / Runtime child jobs, parallel and sequential job groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@
 
 /examples/models/python/data/outputs/**
 /examples/models/python/data/data/**
+/examples/models/python/data/primary/**
+/examples/models/python/data/generated/**
 /examples/models/python/data/exports/**
 !/examples/models/python/data/exports/.keep
 /examples/apps/javascript/node_modules/**

--- a/examples/models/python/config/job_group.yaml
+++ b/examples/models/python/config/job_group.yaml
@@ -1,0 +1,49 @@
+
+
+job:
+  jobGroup:
+    sequential:
+      jobs:
+
+        - importData:
+
+            model: tutorial.data_import.SimpleDataImport
+
+            parameters:
+              storage_key: staging_data
+              source_file: sample_data.parquet
+
+            outputs:
+              customer_loans: primary/data_import/customer_loans.csv
+
+            storageAccess:
+              - staging_data
+
+        - runModel:
+
+            model: tutorial.using_data.UsingDataModel
+
+            parameters:
+              eur_usd_rate: 1.2071
+              default_weighting: 1.5
+              filter_defaults: false
+
+            inputs:
+              customer_loans: primary/data_import/customer_loans.csv
+
+            outputs:
+              profit_by_region: generated/using_data/profit_by_region.csv
+
+        - exportData:
+
+            model: tutorial.data_export.DataExportExample
+
+            parameters:
+              storage_key: exported_data
+              export_comment: "Exporting some example data"
+
+            inputs:
+              profit_by_region: generated/using_data/profit_by_region.csv
+
+            storageAccess:
+              - exported_data

--- a/examples/models/python/src/tutorial/job_group.py
+++ b/examples/models/python/src/tutorial/job_group.py
@@ -1,0 +1,17 @@
+#  Copyright 2024 Accenture Global Solutions Limited
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import tracdap.rt.launch as launch
+
+launch.launch_job("config/job_group.yaml", "config/sys_config.yaml", dev_mode=True)

--- a/tracdap-api/tracdap-metadata/src/main/proto/tracdap/metadata/job.proto
+++ b/tracdap-api/tracdap-metadata/src/main/proto/tracdap/metadata/job.proto
@@ -197,7 +197,7 @@ message ExportDataJob {
  * Specify the group type for a JOB_GROUP job
  */
 enum JobGroupType {
-  EMPTY_JOB_GROUP = 0;
+  JOB_GROUP_TYPE_NOT_SET = 0;
   SEQUENTIAL_JOB_GROUP = 1;
   PARALLEL_JOB_GROUP = 2;
 }

--- a/tracdap-api/tracdap-metadata/src/main/proto/tracdap/metadata/job.proto
+++ b/tracdap-api/tracdap-metadata/src/main/proto/tracdap/metadata/job.proto
@@ -45,6 +45,9 @@ enum JobType {
 
   /// Export data to external locations
   EXPORT_DATA = 5;
+
+  /// A job built from a collection of other jobs
+  JOB_GROUP = 6;
 }
 
 /**
@@ -98,6 +101,7 @@ message JobDefinition {
     ImportModelJob importModel = 4;
     ImportDataJob importData = 5;
     ExportDataJob exportData = 6;
+    JobGroup jobGroup = 7;
   }
 }
 
@@ -187,3 +191,44 @@ message ExportDataJob {
 
   repeated TagUpdate outputAttrs = 8;
 }
+
+
+/**
+ * Specify the group type for a JOB_GROUP job
+ */
+enum JobGroupType {
+  EMPTY_JOB_GROUP = 0;
+  SEQUENTIAL_JOB_GROUP = 1;
+  PARALLEL_JOB_GROUP = 2;
+}
+
+/**
+ * Specification for a JOB_GROUP job, which runs a collection of other jobs
+ */
+message JobGroup {
+
+  JobGroupType jobGroupType = 1;
+
+  oneof jobGroupDetails {
+    SequentialJobGroup sequential = 2;
+    ParallelJobGroup parallel = 3;
+  }
+}
+
+/**
+ * A job group where each job runs in sequence
+ */
+message SequentialJobGroup {
+
+  repeated JobDefinition jobs = 1;
+}
+
+/**
+ * A job group where all jobs runs in parallel
+ */
+message ParallelJobGroup {
+
+  repeated JobDefinition jobs = 1;
+}
+
+

--- a/tracdap-runtime/python/src/tracdap/rt/_exec/dev_mode.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_exec/dev_mode.py
@@ -199,7 +199,7 @@ class DevModeTranslator:
 
         job_group = job_def.jobGroup
 
-        if job_group.jobGroupType is None or job_group.jobGroupType == _meta.JobGroupType.EMPTY_JOB_GROUP:
+        if job_group.jobGroupType is None or job_group.jobGroupType == _meta.JobGroupType.JOB_GROUP_TYPE_NOT_SET:
             job_group = self._process_job_group_type(job_group)
 
         group_details = self._get_job_group_detail(job_group)

--- a/tracdap-runtime/python/src/tracdap/rt/_exec/dev_mode.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_exec/dev_mode.py
@@ -34,7 +34,15 @@ DEV_MODE_JOB_CONFIG = [
     re.compile(r"job\.\w+\.outputs\.\w+"),
     re.compile(r"job\.\w+\.models\.\w+"),
     re.compile(r"job\.\w+\.model"),
-    re.compile(r"job\.\w+\.flow")]
+    re.compile(r"job\.\w+\.flow"),
+
+    re.compile(r".*\.jobs\.\d+\.\w+\.parameters\.\w+"),
+    re.compile(r".*\.jobs\.\d+\.\w+\.inputs\.\w+"),
+    re.compile(r".*\.jobs\.\d+\.\w+\.outputs\.\w+"),
+    re.compile(r".*\.jobs\.\d+\.\w+\.models\.\w+"),
+    re.compile(r".*\.jobs\.\d+\.\w+\.model"),
+    re.compile(r".*\.jobs\.\d+\.\w+\.flow")
+]
 
 DEV_MODE_SYS_CONFIG = []
 
@@ -57,38 +65,6 @@ class DevModeTranslator:
         sys_config = cls._process_storage(sys_config, config_mgr)
 
         return sys_config
-
-    @classmethod
-    def translate_job_config(
-            cls,
-            sys_config: _cfg.RuntimeConfig,
-            job_config: _cfg.JobConfig,
-            scratch_dir: pathlib.Path,
-            config_mgr: _cfg_p.ConfigManager,
-            model_class: tp.Optional[_api.TracModel.__class__]) \
-            -> _cfg.JobConfig:
-
-        cls._log.info(f"Applying dev mode config translation to job config")
-
-        # Protobuf semantics for a blank jobId should be an object, but objectId will be an empty string
-        if not job_config.jobId or not job_config.jobId.objectId:
-            job_config = cls._process_job_id(job_config)
-
-        if job_config.job.jobType is None or job_config.job.jobType == _meta.JobType.JOB_TYPE_NOT_SET:
-            job_config = cls._process_job_type(job_config)
-
-        # Load and populate any models provided as a Python class or class name
-        job_config = cls._process_models(sys_config, job_config, scratch_dir, model_class)
-
-        # Fow flows, load external flow definitions then perform auto-wiring and type inference
-        if job_config.job.jobType == _meta.JobType.RUN_FLOW:
-            job_config = cls._process_flow_definition(job_config, config_mgr)
-
-        # Apply processing to the parameters, inputs and outputs
-        job_config = cls._process_parameters(job_config)
-        job_config = cls._process_inputs_and_outputs(sys_config, job_config)
-
-        return job_config
 
     @classmethod
     def _add_integrated_repo(cls, sys_config: _cfg.RuntimeConfig) -> _cfg.RuntimeConfig:
@@ -159,6 +135,86 @@ class DevModeTranslator:
         cls._log.error(msg)
         raise _ex.EConfigParse(msg)
 
+
+    def __init__(self, sys_config: _cfg.RuntimeConfig, config_mgr: _cfg_p.ConfigManager, scratch_dir: pathlib.Path):
+        self._sys_config = sys_config
+        self._config_mgr = config_mgr
+        self._scratch_dir = scratch_dir
+        self._model_loader: tp.Optional[_models.ModelLoader] = None
+
+    def translate_job_config(
+            self, job_config: _cfg.JobConfig,
+            model_class: tp.Optional[_api.TracModel.__class__] = None) \
+            -> _cfg.JobConfig:
+
+        try:
+            self._log.info(f"Applying dev mode config translation to job config")
+
+            self._model_loader = _models.ModelLoader(self._sys_config, self._scratch_dir)
+            self._model_loader.create_scope("DEV_MODE_TRANSLATION")
+
+            job_config = copy.deepcopy(job_config)
+            job_def = job_config.job
+
+            # Protobuf semantics for a blank jobId should be an object, but objectId will be an empty string
+            if not job_config.jobId or not job_config.jobId.objectId:
+                job_config = self._process_job_id(job_config)
+
+            job_config, job_def = self.translate_job_def(job_config, job_def, model_class)
+            job_config.job = job_def
+
+            return job_config
+
+        finally:
+            self._model_loader.destroy_scope("DEV_MODE_TRANSLATION")
+            self._model_loader = None
+
+    def translate_job_def(
+            self, job_config: _cfg.JobConfig, job_def: _meta.JobDefinition,
+            model_class: tp.Optional[_api.TracModel.__class__] = None) \
+            -> tp.Tuple[_cfg.JobConfig, _meta.JobDefinition]:
+
+        if job_def.jobType is None or job_def.jobType == _meta.JobType.JOB_TYPE_NOT_SET:
+            job_def = self._process_job_type(job_def)
+
+        # Load and populate any models provided as a Python class or class name
+        job_config, job_def = self._process_models(job_config, job_def, model_class)
+
+        # Fow flows, load external flow definitions then perform auto-wiring and type inference
+        if job_def.jobType == _meta.JobType.RUN_FLOW:
+            job_config, job_def = self._process_flow_definition(job_config, job_def)
+
+        if job_def.jobType == _meta.JobType.JOB_GROUP:
+            job_config, job_def = self.translate_job_group(job_config, job_def)
+
+        # Apply processing to the parameters, inputs and outputs
+        job_config, job_def = self._process_parameters(job_config, job_def)
+        job_config, job_def = self._process_inputs_and_outputs(job_config, job_def)
+
+        return job_config, job_def
+
+    def translate_job_group(
+            self, job_config: _cfg.JobConfig, job_def: _meta.JobDefinition) \
+            -> tp.Tuple[_cfg.JobConfig, _meta.JobDefinition]:
+
+        job_group = job_def.jobGroup
+
+        if job_group.jobGroupType is None or job_group.jobGroupType == _meta.JobGroupType.EMPTY_JOB_GROUP:
+            job_group = self._process_job_group_type(job_group)
+
+        group_details = self._get_job_group_detail(job_group)
+
+        if hasattr(group_details, "jobs"):
+            child_jobs = []
+            for child_def in group_details.jobs:
+                job_config, child_def = self.translate_job_def(job_config, child_def)
+                child_jobs.append(child_def)
+            group_details.jobs = child_jobs
+
+        job_def.jobGroup = job_group
+
+        return job_config, job_def
+
     @classmethod
     def _add_job_resource(
             cls, job_config: _cfg.JobConfig,
@@ -183,22 +239,25 @@ class DevModeTranslator:
         return translated_config
 
     @classmethod
-    def _process_job_type(cls, job_config: _cfg.JobConfig):
+    def _process_job_type(cls, job_def: _meta.JobDefinition):
 
-        if job_config.job.runModel is not None:
+        if job_def.runModel is not None:
             job_type = _meta.JobType.RUN_MODEL
 
-        elif job_config.job.runFlow is not None:
+        elif job_def.runFlow is not None:
             job_type = _meta.JobType.RUN_FLOW
 
-        elif job_config.job.importModel is not None:
+        elif job_def.importModel is not None:
             job_type = _meta.JobType.IMPORT_MODEL
 
-        elif job_config.job.importData is not None:
+        elif job_def.importData is not None:
             job_type = _meta.JobType.IMPORT_DATA
 
-        elif job_config.job.exportData is not None:
+        elif job_def.exportData is not None:
             job_type = _meta.JobType.EXPORT_DATA
+
+        elif job_def.jobGroup is not None:
+            job_type = _meta.JobType.JOB_GROUP
 
         else:
             cls._log.error("Could not infer job type")
@@ -206,102 +265,127 @@ class DevModeTranslator:
 
         cls._log.info(f"Inferred job type = [{job_type.name}]")
 
-        job_def = copy.copy(job_config.job)
+        job_def = copy.copy(job_def)
         job_def.jobType = job_type
 
-        job_config = copy.copy(job_config)
-        job_config.job = job_def
-
-        return job_config
+        return job_def
 
     @classmethod
-    def _get_job_detail(cls, job_config: _cfg.JobConfig):
+    def _process_job_group_type(cls, job_group: _meta.JobGroup) -> _meta.JobGroup:
 
-        if job_config.job.jobType == _meta.JobType.RUN_MODEL:
-            return job_config.job.runModel
+        if job_group.sequential is not None:
+            job_group_type = _meta.JobGroupType.SEQUENTIAL_JOB_GROUP
 
-        if job_config.job.jobType == _meta.JobType.RUN_FLOW:
-            return job_config.job.runFlow
+        elif job_group.parallel is not None:
+            job_group_type = _meta.JobGroupType.PARALLEL_JOB_GROUP
 
-        if job_config.job.jobType == _meta.JobType.IMPORT_MODEL:
-            return job_config.job.importModel
+        else:
+            cls._log.error("Could not infer job group type")
+            raise _ex.EConfigParse("Could not infer job group type")
 
-        if job_config.job.jobType == _meta.JobType.IMPORT_DATA:
-            return job_config.job.importData
+        cls._log.info(f"Inferred job group type = [{job_group_type.name}]")
 
-        if job_config.job.jobType == _meta.JobType.EXPORT_DATA:
-            return job_config.job.exportData
+        job_group = copy.copy(job_group)
+        job_group.jobGroupType = job_group_type
 
-        raise _ex.EConfigParse(f"Could not get job details for job type [{job_config.job.jobType}]")
+        return job_group
 
     @classmethod
+    def _get_job_detail(cls, job_def: _meta.JobDefinition):
+
+        if job_def.jobType == _meta.JobType.RUN_MODEL:
+            return job_def.runModel
+
+        if job_def.jobType == _meta.JobType.RUN_FLOW:
+            return job_def.runFlow
+
+        if job_def.jobType == _meta.JobType.IMPORT_MODEL:
+            return job_def.importModel
+
+        if job_def.jobType == _meta.JobType.IMPORT_DATA:
+            return job_def.importData
+
+        if job_def.jobType == _meta.JobType.EXPORT_DATA:
+            return job_def.exportData
+
+        if job_def.jobType == _meta.JobType.JOB_GROUP:
+            return job_def.jobGroup
+
+        raise _ex.EConfigParse(f"Could not get job details for job type [{job_def.jobType}]")
+
+    @classmethod
+    def _get_job_group_detail(cls, job_group: _meta.JobGroup):
+
+        if job_group.jobGroupType == _meta.JobGroupType.SEQUENTIAL_JOB_GROUP:
+            return job_group.sequential
+
+        if job_group.jobGroupType == _meta.JobGroupType.PARALLEL_JOB_GROUP:
+            return job_group.parallel
+
+        raise _ex.EConfigParse(f"Could not get job group details for group type [{job_group.jobGroupType}]")
+
     def _process_models(
-            cls,
-            sys_config: _cfg.RuntimeConfig,
-            job_config: _cfg.JobConfig,
-            scratch_dir: pathlib.Path,
+            self, job_config: _cfg.JobConfig, job_def: _meta.JobDefinition,
             model_class: tp.Optional[_api.TracModel.__class__]) \
-            -> _cfg.JobConfig:
-
-        model_loader = _models.ModelLoader(sys_config, scratch_dir)
-        model_loader.create_scope("DEV_MODE_TRANSLATION")
+            -> tp.Tuple[_cfg.JobConfig, _meta.JobDefinition]:
 
         # This processing works on the assumption that job details follow a convention for addressing models
         # Jobs requiring a single model have a field called "model"
         # Jobs requiring multiple models have a field called "models@, which is a dict
 
-        job_detail = cls._get_job_detail(job_config)
+        job_detail = self._get_job_detail(job_def)
 
         # If a model class is supplied in code, use that to generate the model def
         if model_class is not None:
 
             # Passing a model class via launch_model() is only supported for job types with a single model
             if not hasattr(job_detail, "model"):
-                raise _ex.EJobValidation(f"Job type [{job_config.job.jobType}] cannot be launched using launch_model()")
+                raise _ex.EJobValidation(f"Job type [{job_def.jobType}] cannot be launched using launch_model()")
 
-            model_id, model_obj = cls._generate_model_for_class(model_loader, model_class)
+            model_id, model_obj = self._generate_model_for_class(model_class)
             job_detail.model = _util.selector_for(model_id)
-            job_config = cls._add_job_resource(job_config, model_id, model_obj)
+            job_config = self._add_job_resource(job_config, model_id, model_obj)
 
         # Otherwise look for models specified as a single string, and take that as the entry point
         else:
 
             # Jobs with a single model
             if hasattr(job_detail, "model") and isinstance(job_detail.model, str):
-                model_id, model_obj = cls._generate_model_for_entry_point(model_loader, job_detail.model)  # noqa
+                model_id, model_obj = self._generate_model_for_entry_point(job_detail.model)  # noqa
                 job_detail.model = _util.selector_for(model_id)
-                job_config = cls._add_job_resource(job_config, model_id, model_obj)
+                job_config = self._add_job_resource(job_config, model_id, model_obj)
 
-            # Jobs with multiple modlels
+            elif hasattr(job_detail, "model") and isinstance(job_detail.model, _meta.TagSelector):
+                if job_detail.model.objectType == _meta.ObjectType.OBJECT_TYPE_NOT_SET:
+                    error = f"Missing required property [model] for job type [{job_def.jobType.name}]"
+                    self._log.error(error)
+                    raise _ex.EJobValidation(error)
+
+            # Jobs with multiple models
             elif hasattr(job_detail, "models") and isinstance(job_detail.models, dict):
                 for model_key, model_detail in job_detail.models.items():
                     if isinstance(model_detail, str):
-                        model_id, model_obj = cls._generate_model_for_entry_point(model_loader, model_detail)
+                        model_id, model_obj = self._generate_model_for_entry_point(model_detail)
                         job_detail.models[model_key] = _util.selector_for(model_id)
-                        job_config = cls._add_job_resource(job_config, model_id, model_obj)
+                        job_config = self._add_job_resource(job_config, model_id, model_obj)
 
-        model_loader.destroy_scope("DEV_MODE_TRANSLATION")
+        return job_config, job_def
 
-        return job_config
-
-    @classmethod
     def _generate_model_for_class(
-            cls, model_loader: _models.ModelLoader, model_class: _api.TracModel.__class__) \
+            self, model_class: _api.TracModel.__class__) \
             -> (_meta.TagHeader, _meta.ObjectDefinition):
 
         model_entry_point = f"{model_class.__module__}.{model_class.__name__}"
+        return self._generate_model_for_entry_point(model_entry_point)
 
-        return cls._generate_model_for_entry_point(model_loader, model_entry_point)
-
-    @classmethod
     def _generate_model_for_entry_point(
-            cls, model_loader: _models.ModelLoader, model_entry_point: str) \
+            self, model_entry_point: str) \
             -> (_meta.TagHeader, _meta.ObjectDefinition):
 
         model_id = _util.new_object_id(_meta.ObjectType.MODEL)
         model_key = _util.object_key(model_id)
 
-        cls._log.info(f"Generating model definition for [{model_entry_point}] with ID = [{model_key}]")
+        self._log.info(f"Generating model definition for [{model_entry_point}] with ID = [{model_key}]")
 
         skeleton_modeL_def = _meta.ModelDefinition(  # noqa
             language="python",
@@ -312,8 +396,8 @@ class DevModeTranslator:
             inputs={},
             outputs={})
 
-        model_class = model_loader.load_model_class("DEV_MODE_TRANSLATION", skeleton_modeL_def)
-        model_def = model_loader.scan_model(skeleton_modeL_def, model_class)
+        model_class = self._model_loader.load_model_class("DEV_MODE_TRANSLATION", skeleton_modeL_def)
+        model_def = self._model_loader.scan_model(skeleton_modeL_def, model_class)
 
         model_object = _meta.ObjectDefinition(
             objectType=_meta.ObjectType.MODEL,
@@ -321,56 +405,57 @@ class DevModeTranslator:
 
         return model_id, model_object
 
-    @classmethod
-    def _process_flow_definition(cls, job_config: _cfg.JobConfig, config_mgr: _cfg_p.ConfigManager) -> _cfg.JobConfig:
+    def _process_flow_definition(
+            self, job_config: _cfg.JobConfig, job_def: _meta.JobDefinition) \
+            -> tp.Tuple[_cfg.JobConfig, _meta.JobDefinition]:
 
-        flow_details = job_config.job.runFlow.flow
+        flow_details = job_def.runFlow.flow
 
         # Do not apply translation if flow is specified as an object ID / selector (assume full config is supplied)
         if isinstance(flow_details, _meta.TagHeader) or isinstance(flow_details, _meta.TagSelector):
-            return job_config
+            return job_config, job_def
 
         # Otherwise, flow is specified as the path to dev-mode flow definition
         if not isinstance(flow_details, str):
             err = f"Invalid config value for [job.runFlow.flow]: Expected path or tag selector, got [{flow_details}])"
-            cls._log.error(err)
+            self._log.error(err)
             raise _ex.EConfigParse(err)
 
         flow_id = _util.new_object_id(_meta.ObjectType.FLOW)
         flow_key = _util.object_key(flow_id)
 
-        cls._log.info(f"Generating flow definition from [{flow_details}] with ID = [{flow_key}]")
+        self._log.info(f"Generating flow definition from [{flow_details}] with ID = [{flow_key}]")
 
-        flow_def = config_mgr.load_config_object(flow_details, _meta.FlowDefinition)
+        flow_def = self._config_mgr.load_config_object(flow_details, _meta.FlowDefinition)
 
         # Validate models against the flow (this could move to _impl.validation and check prod jobs as well)
-        cls._check_models_for_flow(flow_def, job_config)
+        self._check_models_for_flow(flow_def, job_def, job_config)
 
         # Auto-wiring and inference only applied to externally loaded flows for now
-        flow_def = cls._autowire_flow(flow_def, job_config)
-        flow_def = cls._apply_type_inference(flow_def, job_config)
+        flow_def = self._autowire_flow(flow_def, job_def, job_config)
+        flow_def = self._apply_type_inference(flow_def, job_def, job_config)
 
         flow_obj = _meta.ObjectDefinition(
             objectType=_meta.ObjectType.FLOW,
             flow=flow_def)
 
+        job_def = copy.copy(job_def)
+        job_def.runFlow = copy.copy(job_def.runFlow)
+        job_def.runFlow.flow = _util.selector_for(flow_id)
+
         job_config = copy.copy(job_config)
-        job_config.job = copy.copy(job_config.job)
-        job_config.job.runFlow = copy.copy(job_config.job.runFlow)
         job_config.resources = copy.copy(job_config.resources)
+        job_config = self._add_job_resource(job_config, flow_id, flow_obj)
 
-        job_config = cls._add_job_resource(job_config, flow_id, flow_obj)
-        job_config.job.runFlow.flow = _util.selector_for(flow_id)
-
-        return job_config
+        return job_config, job_def
 
     @classmethod
-    def _check_models_for_flow(cls, flow: _meta.FlowDefinition, job_config: _cfg.JobConfig):
+    def _check_models_for_flow(cls, flow: _meta.FlowDefinition, job_def: _meta.JobDefinition, job_config: _cfg.JobConfig):
 
         model_nodes = dict(filter(lambda n: n[1].nodeType == _meta.FlowNodeType.MODEL_NODE, flow.nodes.items()))
 
-        missing_models = list(filter(lambda m: m not in job_config.job.runFlow.models, model_nodes.keys()))
-        extra_models = list(filter(lambda m: m not in model_nodes, job_config.job.runFlow.models.keys()))
+        missing_models = list(filter(lambda m: m not in job_def.runFlow.models, model_nodes.keys()))
+        extra_models = list(filter(lambda m: m not in model_nodes, job_def.runFlow.models.keys()))
 
         if any(missing_models):
             error = f"Missing models in job definition: {', '.join(missing_models)}"
@@ -384,7 +469,7 @@ class DevModeTranslator:
 
         for model_name, model_node in model_nodes.items():
 
-            model_selector = job_config.job.runFlow.models[model_name]
+            model_selector = job_def.runFlow.models[model_name]
             model_obj = _util.get_job_resource(model_selector, job_config)
 
             model_inputs = set(model_obj.model.inputs.keys())
@@ -396,9 +481,9 @@ class DevModeTranslator:
                 raise _ex.EJobValidation(error)
 
     @classmethod
-    def _autowire_flow(cls, flow: _meta.FlowDefinition, job_config: _cfg.JobConfig):
+    def _autowire_flow(cls, flow: _meta.FlowDefinition, job_def: _meta.JobDefinition, job_config: _cfg.JobConfig):
 
-        job = job_config.job.runFlow
+        job = job_def.runFlow
         nodes = copy.copy(flow.nodes)
         edges: tp.Dict[str, _meta.FlowEdge] = dict()
 
@@ -485,7 +570,10 @@ class DevModeTranslator:
         return autowired_flow
 
     @classmethod
-    def _apply_type_inference(cls, flow: _meta.FlowDefinition, job_config: _cfg.JobConfig) -> _meta.FlowDefinition:
+    def _apply_type_inference(
+            cls, flow: _meta.FlowDefinition,
+            job_def: _meta.JobDefinition, job_config: _cfg.JobConfig) \
+            -> _meta.FlowDefinition:
 
         updated_flow = copy.copy(flow)
         updated_flow.parameters = copy.copy(flow.parameters)
@@ -506,17 +594,17 @@ class DevModeTranslator:
 
             if node.nodeType == _meta.FlowNodeType.PARAMETER_NODE and node_name not in flow.parameters:
                 targets = edges_by_source.get(node_name) or []
-                model_parameter = cls._infer_parameter(node_name, targets, job_config)
+                model_parameter = cls._infer_parameter(node_name, targets, job_def, job_config)
                 updated_flow.parameters[node_name] = model_parameter
 
             if node.nodeType == _meta.FlowNodeType.INPUT_NODE and node_name not in flow.inputs:
                 targets = edges_by_source.get(node_name) or []
-                model_input = cls._infer_input_schema(node_name, targets, job_config)
+                model_input = cls._infer_input_schema(node_name, targets, job_def, job_config)
                 updated_flow.inputs[node_name] = model_input
 
             if node.nodeType == _meta.FlowNodeType.OUTPUT_NODE and node_name not in flow.outputs:
                 sources = edges_by_target.get(node_name) or []
-                model_output = cls._infer_output_schema(node_name, sources, job_config)
+                model_output = cls._infer_output_schema(node_name, sources, job_def, job_config)
                 updated_flow.outputs[node_name] = model_output
 
         return updated_flow
@@ -524,13 +612,14 @@ class DevModeTranslator:
     @classmethod
     def _infer_parameter(
             cls, param_name: str, targets: tp.List[_meta.FlowSocket],
-            job_config: _cfg.JobConfig) -> _meta.ModelParameter:
+            job_def: _meta.JobDefinition, job_config: _cfg.JobConfig) \
+            -> _meta.ModelParameter:
 
         model_params = []
 
         for target in targets:
 
-            model_selector = job_config.job.runFlow.models.get(target.node)
+            model_selector = job_def.runFlow.models.get(target.node)
             model_obj = _util.get_job_resource(model_selector, job_config)
             model_param = model_obj.model.parameters.get(target.socket)
             model_params.append(model_param)
@@ -560,13 +649,14 @@ class DevModeTranslator:
     @classmethod
     def _infer_input_schema(
             cls, input_name: str, targets: tp.List[_meta.FlowSocket],
-            job_config: _cfg.JobConfig) -> _meta.ModelInputSchema:
+            job_def: _meta.JobDefinition, job_config: _cfg.JobConfig) \
+            -> _meta.ModelInputSchema:
 
         model_inputs = []
 
         for target in targets:
 
-            model_selector = job_config.job.runFlow.models.get(target.node)
+            model_selector = job_def.runFlow.models.get(target.node)
             model_obj = _util.get_job_resource(model_selector, job_config)
             model_input = model_obj.model.inputs.get(target.socket)
             model_inputs.append(model_input)
@@ -594,13 +684,14 @@ class DevModeTranslator:
     @classmethod
     def _infer_output_schema(
             cls, output_name: str, sources: tp.List[_meta.FlowSocket],
-            job_config: _cfg.JobConfig) -> _meta.ModelOutputSchema:
+            job_def: _meta.JobDefinition, job_config: _cfg.JobConfig) \
+            -> _meta.ModelOutputSchema:
 
         model_outputs = []
 
         for source in sources:
 
-            model_selector = job_config.job.runFlow.models.get(source.node)
+            model_selector = job_def.runFlow.models.get(source.node)
             model_obj = _util.get_job_resource(model_selector, job_config)
             model_input = model_obj.model.inputs.get(source.socket)
             model_outputs.append(model_input)
@@ -624,11 +715,13 @@ class DevModeTranslator:
         return f"{socket.node}.{socket.socket}" if socket.socket else socket.node
 
     @classmethod
-    def _process_parameters(cls, job_config: _cfg.JobConfig) -> _cfg.JobConfig:
+    def _process_parameters(
+            cls, job_config: _cfg.JobConfig, job_def: _meta.JobDefinition) \
+            -> tp.Tuple[_cfg.JobConfig, _meta.JobDefinition]:
 
         # This relies on convention for naming properties across similar job types
 
-        job_detail = cls._get_job_detail(job_config)
+        job_detail = cls._get_job_detail(job_def)
 
         if hasattr(job_detail, "model"):
             model_key = _util.object_key(job_detail.model)
@@ -646,7 +739,7 @@ class DevModeTranslator:
 
             job_detail.parameters = cls._process_parameters_dict(param_specs, raw_values)
 
-        return job_config
+        return job_config, job_def
 
     @classmethod
     def _process_parameters_dict(
@@ -677,10 +770,11 @@ class DevModeTranslator:
 
         return encoded_values
 
-    @classmethod
-    def _process_inputs_and_outputs(cls, sys_config: _cfg.RuntimeConfig, job_config: _cfg.JobConfig) -> _cfg.JobConfig:
+    def _process_inputs_and_outputs(
+            self, job_config: _cfg.JobConfig, job_def: _meta.JobDefinition) \
+            -> tp.Tuple[_cfg.JobConfig, _meta.JobDefinition]:
 
-        job_detail = cls._get_job_detail(job_config)
+        job_detail = self._get_job_detail(job_def)
 
         if hasattr(job_detail, "model"):
             model_obj = _util.get_job_resource(job_detail.model, job_config)
@@ -693,7 +787,7 @@ class DevModeTranslator:
             required_outputs = flow_obj.flow.outputs
 
         else:
-            return job_config
+            return job_config, job_def
 
         job_inputs = job_detail.inputs
         job_outputs = job_detail.outputs
@@ -705,8 +799,8 @@ class DevModeTranslator:
                 model_input = required_inputs[input_key]
                 input_schema = model_input.schema if model_input and not model_input.dynamic else None
 
-                input_id = cls._process_input_or_output(
-                    sys_config, input_key, input_value, job_resources,
+                input_id = self._process_input_or_output(
+                    input_key, input_value, job_resources,
                     new_unique_file=False, schema=input_schema)
 
                 job_inputs[input_key] = _util.selector_for(input_id)
@@ -717,17 +811,16 @@ class DevModeTranslator:
                 model_output= required_outputs[output_key]
                 output_schema = model_output.schema if model_output and not model_output.dynamic else None
 
-                output_id = cls._process_input_or_output(
-                    sys_config, output_key, output_value, job_resources,
+                output_id = self._process_input_or_output(
+                   output_key, output_value, job_resources,
                     new_unique_file=True, schema=output_schema)
 
                 job_outputs[output_key] = _util.selector_for(output_id)
 
-        return job_config
+        return job_config, job_def
 
-    @classmethod
     def _process_input_or_output(
-            cls, sys_config, data_key, data_value,
+            self, data_key, data_value,
             resources: tp.Dict[str, _meta.ObjectDefinition],
             new_unique_file=False,
             schema: tp.Optional[_meta.SchemaDefinition] = None) \
@@ -738,8 +831,8 @@ class DevModeTranslator:
 
         if isinstance(data_value, str):
             storage_path = data_value
-            storage_key = sys_config.storage.defaultBucket
-            storage_format = cls.infer_format(storage_path, sys_config.storage)
+            storage_key = self._sys_config.storage.defaultBucket
+            storage_format = self.infer_format(storage_path, self._sys_config.storage)
             snap_version = 1
 
         elif isinstance(data_value, dict):
@@ -749,14 +842,14 @@ class DevModeTranslator:
             if not storage_path:
                 raise _ex.EConfigParse(f"Invalid configuration for input [{data_key}] (missing required value 'path'")
 
-            storage_key = data_value.get("storageKey") or sys_config.storage.defaultBucket
-            storage_format = data_value.get("format") or cls.infer_format(storage_path, sys_config.storage)
+            storage_key = data_value.get("storageKey") or self._sys_config.storage.defaultBucket
+            storage_format = data_value.get("format") or self.infer_format(storage_path, self._sys_config.storage)
             snap_version = 1
 
         else:
             raise _ex.EConfigParse(f"Invalid configuration for input '{data_key}'")
 
-        cls._log.info(f"Generating data definition for [{data_key}] with ID = [{_util.object_key(data_id)}]")
+        self._log.info(f"Generating data definition for [{data_key}] with ID = [{_util.object_key(data_id)}]")
 
         # For unique outputs, increment the snap number to find a new unique snap
         # These are not incarnations, bc likely in dev mode model code and inputs are changing
@@ -764,7 +857,7 @@ class DevModeTranslator:
 
         if new_unique_file:
 
-            x_storage_mgr = _storage.StorageManager(sys_config)
+            x_storage_mgr = _storage.StorageManager(self._sys_config)
             x_storage = x_storage_mgr.get_file_storage(storage_key)
             x_orig_path = pathlib.PurePath(storage_path)
             x_name = x_orig_path.name
@@ -781,9 +874,9 @@ class DevModeTranslator:
                 x_name = f"{x_orig_path.stem}-{snap_version}"
                 storage_path = str(x_orig_path.parent.joinpath(x_name))
 
-            cls._log.info(f"Output for [{data_key}] will be snap version {snap_version}")
+            self._log.info(f"Output for [{data_key}] will be snap version {snap_version}")
 
-        data_obj, storage_obj = cls._generate_input_definition(
+        data_obj, storage_obj = self._generate_input_definition(
             data_id, storage_id, storage_key, storage_path, storage_format,
             snap_index=snap_version, delta_index=1, incarnation_index=1,
             schema=schema)

--- a/tracdap-runtime/python/src/tracdap/rt/_exec/engine.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_exec/engine.py
@@ -345,8 +345,10 @@ class GraphBuilder(_actors.Actor):
         self._log.info("Building execution graph")
 
         # TODO: Get sys config, or find a way to pass storage settings
-        graph_data = _graph.GraphBuilder.build_job(self.job_config, self.result_spec)
-        graph_nodes = {node_id: _EngineNode(node, {}) for node_id, node in graph_data.nodes.items()}
+        graph_builder = _graph.GraphBuilder(self.job_config, self.result_spec)
+        graph_spec = graph_builder.build_job(self.job_config.job)
+
+        graph_nodes = {node_id: _EngineNode(node, {}) for node_id, node in graph_spec.nodes.items()}
         graph = _EngineContext(graph_nodes, pending_nodes=set(graph_nodes.keys()))
 
         self._log.info("Resolving graph nodes to executable code")
@@ -355,7 +357,7 @@ class GraphBuilder(_actors.Actor):
             node.function = self._resolver.resolve_node(node.node)
 
         self.graph = graph
-        self.actors().send_parent("job_graph", self.graph, graph_data.root_id)
+        self.actors().send_parent("job_graph", self.graph, graph_spec.root_id)
 
     @_actors.Message
     def get_execution_graph(self):

--- a/tracdap-runtime/python/src/tracdap/rt/_exec/functions.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_exec/functions.py
@@ -715,7 +715,7 @@ class ChildJobFunction(NodeFunction[None]):
 
     def _execute(self, ctx: NodeContext):
         # This node should never execute, the engine intercepts child job nodes and provides special handling
-        raise _ex.ETracInternal("Child job was not processed correctly(this is a bug)")
+        raise _ex.ETracInternal("Child job was not processed correctly (this is a bug)")
 
 
 

--- a/tracdap-runtime/python/src/tracdap/rt/_exec/functions.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_exec/functions.py
@@ -699,12 +699,24 @@ class RunModelFunc(NodeFunction[Bundle[_data.DataView]]):
             output_section = _graph.GraphBuilder.build_runtime_outputs(self.node.id.namespace, dynamic_outputs)
             new_nodes.update(output_section.nodes)
 
-            ctx_id = NodeId.of("trac_build_result", self.node.id.namespace, result_type=None)
+            ctx_id = NodeId.of("trac_job_result", self.node.id.namespace, result_type=None)
             new_deps[ctx_id] = list(_graph.Dependency(nid, _graph.DependencyType.HARD) for nid in output_section.outputs)
 
             self.node_callback.send_graph_updates(new_nodes, new_deps)
 
         return results
+
+
+class ChildJobFunction(NodeFunction[None]):
+
+    def __init__(self, node: ChildJobNode):
+        super().__init__()
+        self.node = node
+
+    def _execute(self, ctx: NodeContext):
+        # This node should never execute, the engine intercepts child job nodes and provides special handling
+        raise _ex.ETracInternal("Child job was not processed correctly(this is a bug)")
+
 
 
 # ----------------------------------------------------------------------------------------------------------------------
@@ -790,6 +802,7 @@ class FunctionResolver:
         DataResultNode: DataResultFunc,
         StaticValueNode: StaticValueFunc,
         RuntimeOutputsNode: RuntimeOutputsFunc,
+        ChildJobNode: ChildJobFunction,
         BundleItemNode: NoopFunc,
         NoopNode: NoopFunc,
         RunModelResultNode: NoopFunc

--- a/tracdap-runtime/python/src/tracdap/rt/_exec/functions.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_exec/functions.py
@@ -696,7 +696,7 @@ class RunModelFunc(NodeFunction[Bundle[_data.DataView]]):
 
                 new_nodes[result_node_id] = result_node
 
-            output_section = _graph.GraphBuilder.build_runtime_outputs(self.node.id.namespace, dynamic_outputs)
+            output_section = _graph.GraphBuilder.build_runtime_outputs(dynamic_outputs, self.node.id.namespace)
             new_nodes.update(output_section.nodes)
 
             ctx_id = NodeId.of("trac_job_result", self.node.id.namespace, result_type=None)

--- a/tracdap-runtime/python/src/tracdap/rt/_exec/functions.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_exec/functions.py
@@ -696,7 +696,7 @@ class RunModelFunc(NodeFunction[Bundle[_data.DataView]]):
 
                 new_nodes[result_node_id] = result_node
 
-            output_section = _graph.GraphBuilder.build_runtime_outputs(dynamic_outputs, self.node.id.namespace)
+            output_section = _graph.GraphBuilder.build_runtime_outputs(self.node.id.namespace, dynamic_outputs)
             new_nodes.update(output_section.nodes)
 
             ctx_id = NodeId.of("trac_build_result", self.node.id.namespace, result_type=None)

--- a/tracdap-runtime/python/src/tracdap/rt/_exec/graph.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_exec/graph.py
@@ -19,7 +19,7 @@ import dataclasses as dc
 import tracdap.rt._impl.data as _data  # noqa
 import tracdap.rt.metadata as meta
 import tracdap.rt.config as cfg
-
+from tracdap.rt_gen.domain.tracdap.config import JobResult
 
 _T = tp.TypeVar('_T')
 
@@ -414,3 +414,12 @@ class SaveJobResultNode(Node[None]):
 
     def _node_dependencies(self) -> tp.Dict[NodeId, DependencyType]:
         return {self.job_result_id: DependencyType.HARD}
+
+
+@_node_type
+class ChildJobNode(Node[cfg.JobResult]):
+
+    job_id: meta.TagHeader
+    job_def: meta.JobDefinition
+
+    graph: Graph

--- a/tracdap-runtime/python/src/tracdap/rt/_exec/graph.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_exec/graph.py
@@ -19,7 +19,6 @@ import dataclasses as dc
 import tracdap.rt._impl.data as _data  # noqa
 import tracdap.rt.metadata as meta
 import tracdap.rt.config as cfg
-from tracdap.rt_gen.domain.tracdap.config import JobResult
 
 _T = tp.TypeVar('_T')
 

--- a/tracdap-runtime/python/src/tracdap/rt/_exec/graph.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_exec/graph.py
@@ -20,6 +20,7 @@ import tracdap.rt._impl.data as _data  # noqa
 import tracdap.rt.metadata as meta
 import tracdap.rt.config as cfg
 
+
 _T = tp.TypeVar('_T')
 
 

--- a/tracdap-runtime/python/src/tracdap/rt/_exec/graph_builder.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_exec/graph_builder.py
@@ -501,7 +501,7 @@ class GraphBuilder:
         return GraphSection(nodes, inputs=inputs)
 
     @classmethod
-    def build_runtime_outputs(cls, job_namespace: NodeNamespace, output_names: tp.List[str]):
+    def build_runtime_outputs(cls, output_names: tp.List[str], job_namespace: NodeNamespace):
 
         # This method is called dynamically during job execution
         # So it cannot use stateful information like self._job_config or self._job_namespace

--- a/tracdap-runtime/python/src/tracdap/rt/_exec/graph_builder.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_exec/graph_builder.py
@@ -54,7 +54,7 @@ class GraphBuilder:
         if job_def.jobType in [meta.JobType.IMPORT_DATA, meta.JobType.EXPORT_DATA]:
             return self.build_standard_job(job_def, self.build_import_export_data_job)
 
-        raise _ex.EConfigParse(f"Job type [{job_def.jobType}] is not supported yet")
+        raise _ex.EJobValidation(f"Job type [{job_def.jobType}] is not supported yet")
 
     def build_standard_job(self, job_def: meta.JobDefinition, build_func: __JOB_BUILD_FUNC):
 
@@ -538,7 +538,7 @@ class GraphBuilder:
             return self.build_flow(namespace, job_def, model_or_flow.flow)
 
         else:
-            raise _ex.EConfigParse("Invalid job config given to the execution engine")
+            raise _ex.EJobValidation("Invalid job config given to the execution engine")
 
     def build_model(
             self, namespace: NodeNamespace,
@@ -727,8 +727,7 @@ class GraphBuilder:
                 push_mapping, pop_mapping,
                 explicit_deps)
 
-        # Missing / invalid node type - should be caught in static validation
-        raise _ex.ETracInternal(f"Flow node [{node_name}] has invalid node type [{node.nodeType}]")
+        raise _ex.EJobValidation(f"Flow node [{node_name}] has invalid node type [{node.nodeType}]")
 
     @classmethod
     def check_model_compatibility(

--- a/tracdap-runtime/python/src/tracdap/rt/_exec/runtime.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_exec/runtime.py
@@ -333,10 +333,8 @@ class TracRuntime:
                 config_file_name="job")
 
         if self._dev_mode:
-            job_config = _dev_mode.DevModeTranslator.translate_job_config(
-                self._sys_config, job_config,
-                self._scratch_dir, self._config_mgr,
-                model_class)
+            translator = _dev_mode.DevModeTranslator(self._sys_config, self._config_mgr, self._scratch_dir)
+            job_config = translator.translate_job_config(job_config, model_class)
 
         return job_config
 

--- a/tracdap-runtime/python/test/tracdap_examples/test_tutorial.py
+++ b/tracdap-runtime/python/test/tracdap_examples/test_tutorial.py
@@ -169,3 +169,10 @@ class TutorialModelsTest(unittest.TestCase):
         sys_config = self.examples_root.joinpath("config/sys_config.yaml")
 
         launch.launch_model(UsingPolarsModel, job_config, sys_config, dev_mode=True)
+
+    def test_group_import_process_export(self):
+
+        job_config = self.examples_root.joinpath("config/job_group.yaml")
+        sys_config = self.examples_root.joinpath("config/sys_config.yaml")
+
+        launch.launch_job(job_config, sys_config, dev_mode=True)

--- a/tracdap-runtime/python/test/tracdap_test/rt/jobs/test_core_jobs.py
+++ b/tracdap-runtime/python/test/tracdap_test/rt/jobs/test_core_jobs.py
@@ -97,8 +97,8 @@ class CoreJobsTest(unittest.TestCase):
             scratch_dir = pathlib.Path(tmpdir)
 
             # Let dev mode translator sort out the data / storage definitions
-            job_config = dev_mode.DevModeTranslator.translate_job_config(
-                self.sys_config, job_config, scratch_dir, None, None)
+            translator = dev_mode.DevModeTranslator(self.sys_config, None, scratch_dir)  # No config mgr
+            job_config = translator.translate_job_config(job_config)
 
             trac_runtime = runtime.TracRuntime(
                 self.sys_config,
@@ -120,8 +120,8 @@ class CoreJobsTest(unittest.TestCase):
             scratch_dir = pathlib.Path(tmpdir)
 
             # Let dev mode translator sort out the data / storage definitions
-            job_config = dev_mode.DevModeTranslator.translate_job_config(
-                self.sys_config, job_config, scratch_dir, None, None)
+            translator = dev_mode.DevModeTranslator(self.sys_config, None, scratch_dir)  # No config mgr
+            job_config = translator.translate_job_config(job_config)
 
             # Make the input dataset use an external schema
 


### PR DESCRIPTION
* Adds the concept of a child job to the runtime execution engine
* Job groups added to the metadata model for defining child jobs
* Parallel and sequential job groups are supported
* Nested job groups are supported
* Works with dev mode translation
* Includes an example job sequence for import -> process -> export
* Only available in the runtime, platform support will come later