### PR TITLE
Feature / Move validation into gRPC interceptors

### DIFF
--- a/tracdap-libs/tracdap-lib-common/src/main/java/org/finos/tracdap/common/grpc/DelayedExecutionInterceptor.java
+++ b/tracdap-libs/tracdap-lib-common/src/main/java/org/finos/tracdap/common/grpc/DelayedExecutionInterceptor.java
@@ -29,9 +29,6 @@ public class DelayedExecutionInterceptor implements ServerInterceptor {
             ServerCall<ReqT, RespT> call, Metadata headers,
             ServerCallHandler<ReqT, RespT> next) {
 
-        // Since startCall() is not called yet, request a message to trigger the listener
-        call.request(1);
-
         return new DelayedExecutionListener<>(call, headers, next);
     }
 
@@ -64,6 +61,17 @@ public class DelayedExecutionInterceptor implements ServerInterceptor {
         private void startCall() {
 
             delegate = next.startCall(call, headers);
+        }
+
+        @Override
+        public void onReady() {
+
+            // Do not trigger startCall() until the first real message is received
+
+            if (delegate == null)
+                call.request(1);
+            else
+                delegate.onReady();
         }
     }
 }

--- a/tracdap-libs/tracdap-lib-common/src/main/java/org/finos/tracdap/common/grpc/DelayedExecutionInterceptor.java
+++ b/tracdap-libs/tracdap-lib-common/src/main/java/org/finos/tracdap/common/grpc/DelayedExecutionInterceptor.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2024 Accenture Global Solutions Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.finos.tracdap.common.grpc;
+
+import io.grpc.*;
+
+
+public class DelayedExecutionInterceptor implements ServerInterceptor {
+
+    // Delay interceptors to run on the same stack as the first inbound message
+    // For unary calls, this puts the interceptors on the same stack as the main handler
+
+    @Override
+    public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+            ServerCall<ReqT, RespT> call, Metadata headers,
+            ServerCallHandler<ReqT, RespT> next) {
+
+        // Since startCall() is not called yet, request a message to trigger the listener
+        call.request(1);
+
+        return new DelayedExecutionListener<>(call, headers, next);
+    }
+
+    private static class DelayedExecutionListener<ReqT, RespT> extends ForwardingServerCallListener<ReqT> {
+
+        private final ServerCall<ReqT, RespT> call;
+        private final Metadata headers;
+        private final ServerCallHandler<ReqT, RespT> next;
+
+        private ServerCall.Listener<ReqT> delegate;
+
+        public DelayedExecutionListener(
+                ServerCall<ReqT, RespT> call, Metadata headers,
+                ServerCallHandler<ReqT, RespT> next) {
+
+            this.call = call;
+            this.headers = headers;
+            this.next = next;
+        }
+
+        @Override
+        protected ServerCall.Listener<ReqT> delegate() {
+
+            if (delegate == null)
+                startCall();
+
+            return delegate;
+        }
+
+        private void startCall() {
+
+            delegate = next.startCall(call, headers);
+        }
+    }
+}

--- a/tracdap-libs/tracdap-lib-common/src/main/java/org/finos/tracdap/common/grpc/GrpcServiceRegister.java
+++ b/tracdap-libs/tracdap-lib-common/src/main/java/org/finos/tracdap/common/grpc/GrpcServiceRegister.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Fintech Open Source Foundation (FINOS) under one or
+ * more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * FINOS licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.finos.tracdap.common.grpc;
+
+import org.finos.tracdap.common.exception.ETracInternal;
+
+import com.google.protobuf.Descriptors;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+public class GrpcServiceRegister {
+
+    protected final Map<String, Descriptors.ServiceDescriptor> serviceMap;
+    protected final Map<String, Descriptors.MethodDescriptor> methodMap;
+
+    private GrpcServiceRegister(
+            Map<String, Descriptors.ServiceDescriptor> serviceMap,
+            Map<String, Descriptors.MethodDescriptor> methodMap) {
+
+        this.serviceMap = serviceMap;
+        this.methodMap = methodMap;
+    }
+
+    public static Builder newBuilder() {
+
+        return new Builder();
+    }
+
+    public static class Builder extends GrpcServiceRegister {
+
+        private Builder() {
+            super(new HashMap<>(), new HashMap<>());
+        }
+
+        public Builder registerServices(List<Descriptors.ServiceDescriptor> serviceDescriptors) {
+
+            return serviceDescriptors.stream().reduce(this, Builder::registerService, (x, y) -> x);
+        }
+
+        public Builder registerService(Descriptors.ServiceDescriptor serviceDescriptor) {
+
+            serviceMap.put(serviceDescriptor.getFullName(), serviceDescriptor);
+
+            for (var methodDescriptor : serviceDescriptor.getMethods()) {
+
+                var qualifiedMethodName = String.format("%s/%s",
+                        serviceDescriptor.getFullName(),
+                        methodDescriptor.getName());
+
+                methodMap.put(qualifiedMethodName, methodDescriptor);
+            }
+
+            return this;
+        }
+
+        public GrpcServiceRegister build() {
+
+            return new GrpcServiceRegister(serviceMap, methodMap);
+        }
+    }
+
+    public Descriptors.ServiceDescriptor getServiceDescriptor(String serviceName) {
+
+        var descriptor = serviceMap.get(serviceName);
+
+        if (descriptor == null)
+            throw new ETracInternal("Service " + serviceName + " not found");
+
+        return descriptor;
+    }
+
+    public Descriptors.MethodDescriptor getMethodDescriptor(String methodName) {
+
+        var descriptor = methodMap.get(methodName);
+
+        if (descriptor == null)
+            throw new ETracInternal("Method " + methodName + " not found");
+
+        return descriptor;
+    }
+}

--- a/tracdap-libs/tracdap-lib-validation/src/main/java/org/finos/tracdap/common/validation/GrpcRequestValidator.java
+++ b/tracdap-libs/tracdap-lib-validation/src/main/java/org/finos/tracdap/common/validation/GrpcRequestValidator.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Fintech Open Source Foundation (FINOS) under one or
+ * more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * FINOS licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.finos.tracdap.common.validation;
+
+import org.finos.tracdap.common.exception.EValidation;
+import org.finos.tracdap.common.grpc.GrpcErrorMapping;
+import org.finos.tracdap.common.grpc.GrpcServiceRegister;
+
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.Message;
+import io.grpc.*;
+
+
+public class GrpcRequestValidator implements ServerInterceptor {
+
+    private final GrpcServiceRegister serviceRegister;
+    private final Validator validator;
+
+    public GrpcRequestValidator(GrpcServiceRegister serviceRegister) {
+        this.serviceRegister = serviceRegister;
+        this.validator = new Validator();
+    }
+
+    @Override
+    public <ReqT, RespT> ServerCall.Listener<ReqT>
+    interceptCall(
+            ServerCall<ReqT, RespT> serverCall, Metadata metadata,
+            ServerCallHandler<ReqT, RespT> nextHandler) {
+
+        return new ValidationListener<>(serverCall, metadata, nextHandler);
+    }
+
+    private class ValidationListener<ReqT, RespT> extends ForwardingServerCallListener<ReqT> {
+
+        private final ServerCall<ReqT, RespT> serverCall;
+        private final Metadata metadata;
+        private final ServerCallHandler<ReqT, RespT> nextHandler;
+
+        private final Descriptors.MethodDescriptor methodDescriptor;
+
+        private ServerCall.Listener<ReqT> delegate = null;
+        private boolean validated = false;
+
+        public ValidationListener(
+                ServerCall<ReqT, RespT> serverCall,
+                Metadata metadata,
+                ServerCallHandler<ReqT, RespT> nextHandler) {
+
+            this.serverCall = serverCall;
+            this.metadata = metadata;
+            this.nextHandler = nextHandler;
+
+            var grpcDescriptor = serverCall.getMethodDescriptor();
+            var grpcMethodName = grpcDescriptor.getFullMethodName();
+
+            this.methodDescriptor = serviceRegister.getMethodDescriptor(grpcMethodName);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        protected ServerCall.Listener<ReqT> delegate() {
+
+            if (delegate != null)
+                return delegate;
+
+            return (ServerCall.Listener<ReqT>) NOOP_SINK;
+        }
+
+        @Override
+        public void onReady() {
+
+            if (delegate == null)
+                serverCall.request(1);
+            else
+                delegate.onReady();
+        }
+
+        @Override
+        public void onMessage(ReqT req) {
+
+            if (!validated) {
+
+                try {
+
+                    var message = (Message) req;
+
+                    validator.validateFixedMethod(message, methodDescriptor);
+                    validated = true;
+
+                    // Start the server call, messages will be passed on instead of going to the no-op sink
+                    delegate = nextHandler.startCall(serverCall, metadata);
+                }
+                catch (EValidation validationError) {
+
+                    var mappedError = GrpcErrorMapping.processError(validationError);
+                    serverCall.close(mappedError.getStatus(), mappedError.getTrailers());
+                }
+            }
+
+            // If validation has not succeeded, messages are sent to the no-op sink
+            delegate().onMessage(req);
+        }
+    }
+
+    private static final ServerCall.Listener<?> NOOP_SINK= new ServerCall.Listener<>() {};
+}

--- a/tracdap-runtime/python/requirements_plugins.txt
+++ b/tracdap-runtime/python/requirements_plugins.txt
@@ -64,6 +64,7 @@ gcsfs == 2024.3.1
 # Force dependency versions for compliance
 
 aiohttp >= 3.9.5
+attrs < 24.3.0
 
 # END_PLUGIN gcp
 

--- a/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/api/TracMetadataApi.java
+++ b/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/api/TracMetadataApi.java
@@ -17,41 +17,19 @@
 
 package org.finos.tracdap.svc.meta.api;
 
-import com.google.protobuf.Descriptors;
 import org.finos.tracdap.api.*;
-import org.finos.tracdap.common.exception.EUnexpected;
 import org.finos.tracdap.common.grpc.GrpcServerWrap;
 import org.finos.tracdap.metadata.Tag;
 import org.finos.tracdap.metadata.TagHeader;
+import org.finos.tracdap.svc.meta.services.MetadataConstants;
 import org.finos.tracdap.svc.meta.services.MetadataReadService;
 import org.finos.tracdap.svc.meta.services.MetadataSearchService;
 import org.finos.tracdap.svc.meta.services.MetadataWriteService;
-import io.grpc.MethodDescriptor;
+
 import io.grpc.stub.StreamObserver;
-import org.finos.tracdap.svc.meta.services.MetadataConstants;
 
 
 public class TracMetadataApi extends TracMetadataApiGrpc.TracMetadataApiImplBase {
-
-    private static final String SERVICE_NAME = TracMetadataApiGrpc.SERVICE_NAME.substring(TracMetadataApiGrpc.SERVICE_NAME.lastIndexOf(".") + 1);
-    private static final Descriptors.ServiceDescriptor TRAC_METADATA_SERVICE = Metadata.getDescriptor().findServiceByName(SERVICE_NAME);
-
-    static final MethodDescriptor<PlatformInfoRequest, PlatformInfoResponse> PLATFORM_INFO_METHOD = TracMetadataApiGrpc.getPlatformInfoMethod();
-    static final MethodDescriptor<ListTenantsRequest, ListTenantsResponse> LIST_TENANTS_METHOD = TracMetadataApiGrpc.getListTenantsMethod();
-    static final MethodDescriptor<ListResourcesRequest, ListResourcesResponse> LIST_RESOURCES_METHOD = TracMetadataApiGrpc.getListResourcesMethod();
-    static final MethodDescriptor<ResourceInfoRequest, ResourceInfoResponse> RESOURCE_INFO_METHOD = TracMetadataApiGrpc.getResourceInfoMethod();
-
-    static final MethodDescriptor<MetadataWriteRequest, TagHeader> CREATE_OBJECT_METHOD = TracMetadataApiGrpc.getCreateObjectMethod();
-    static final MethodDescriptor<MetadataWriteRequest, TagHeader> UPDATE_OBJECT_METHOD = TracMetadataApiGrpc.getUpdateObjectMethod();
-    static final MethodDescriptor<MetadataWriteRequest, TagHeader> UPDATE_TAG_METHOD = TracMetadataApiGrpc.getUpdateTagMethod();
-
-    static final MethodDescriptor<MetadataReadRequest, Tag> READ_OBJECT_METHOD = TracMetadataApiGrpc.getReadObjectMethod();
-    static final MethodDescriptor<MetadataBatchRequest, MetadataBatchResponse> READ_BATCH_METHOD = TracMetadataApiGrpc.getReadBatchMethod();
-    static final MethodDescriptor<MetadataSearchRequest, MetadataSearchResponse> SEARCH_METHOD = TracMetadataApiGrpc.getSearchMethod();
-
-    static final MethodDescriptor<MetadataGetRequest, Tag> GET_OBJECT_METHOD = TracMetadataApiGrpc.getGetObjectMethod();
-    static final MethodDescriptor<MetadataGetRequest, Tag> GET_LATEST_OBJECT_METHOD = TracMetadataApiGrpc.getGetLatestObjectMethod();
-    static final MethodDescriptor<MetadataGetRequest, Tag> GET_LATEST_TAG_METHOD = TracMetadataApiGrpc.getGetLatestTagMethod();
 
     private final MetadataApiImpl apiImpl;
     private final GrpcServerWrap grpcWrap;
@@ -61,10 +39,7 @@ public class TracMetadataApi extends TracMetadataApiGrpc.TracMetadataApiImplBase
             MetadataWriteService writeService,
             MetadataSearchService searchService) {
 
-        if (TRAC_METADATA_SERVICE == null)
-            throw new EUnexpected();
-
-        apiImpl = new MetadataApiImpl(TRAC_METADATA_SERVICE, readService, writeService, searchService, MetadataConstants.PUBLIC_API);
+        apiImpl = new MetadataApiImpl(readService, writeService, searchService, MetadataConstants.PUBLIC_API);
         grpcWrap = new GrpcServerWrap();
     }
 

--- a/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/api/TrustedMetadataApi.java
+++ b/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/api/TrustedMetadataApi.java
@@ -17,31 +17,20 @@
 
 package org.finos.tracdap.svc.meta.api;
 
-import com.google.protobuf.Descriptors;
 import org.finos.tracdap.api.*;
-import org.finos.tracdap.api.internal.MetadataTrusted;
 import org.finos.tracdap.api.internal.TrustedMetadataApiGrpc;
-import org.finos.tracdap.common.exception.EUnexpected;
 import org.finos.tracdap.common.grpc.GrpcServerWrap;
 import org.finos.tracdap.metadata.Tag;
 import org.finos.tracdap.metadata.TagHeader;
+import org.finos.tracdap.svc.meta.services.MetadataConstants;
 import org.finos.tracdap.svc.meta.services.MetadataReadService;
 import org.finos.tracdap.svc.meta.services.MetadataSearchService;
 import org.finos.tracdap.svc.meta.services.MetadataWriteService;
-import io.grpc.MethodDescriptor;
+
 import io.grpc.stub.StreamObserver;
-import org.finos.tracdap.svc.meta.services.MetadataConstants;
 
 
 public class TrustedMetadataApi extends TrustedMetadataApiGrpc.TrustedMetadataApiImplBase {
-
-    private static final String SERVICE_NAME = TrustedMetadataApiGrpc.SERVICE_NAME.substring(TrustedMetadataApiGrpc.SERVICE_NAME.lastIndexOf(".") + 1);
-    private static final Descriptors.ServiceDescriptor TRUSTED_METADATA_SERVICE = MetadataTrusted.getDescriptor().findServiceByName(SERVICE_NAME);
-
-    static final MethodDescriptor<MetadataWriteRequest, TagHeader> PREALLOCATE_ID_METHOD = TrustedMetadataApiGrpc.getPreallocateIdMethod();
-    static final MethodDescriptor<MetadataWriteRequest, TagHeader> CREATE_PREALLOCATED_OBJECT_METHOD = TrustedMetadataApiGrpc.getCreatePreallocatedObjectMethod();
-
-
 
     private final MetadataApiImpl apiImpl;
     private final GrpcServerWrap grpcWrap;
@@ -51,10 +40,7 @@ public class TrustedMetadataApi extends TrustedMetadataApiGrpc.TrustedMetadataAp
             MetadataWriteService writeService,
             MetadataSearchService searchService) {
 
-        if (TRUSTED_METADATA_SERVICE == null)
-            throw new EUnexpected();
-
-        apiImpl = new MetadataApiImpl(TRUSTED_METADATA_SERVICE, readService, writeService, searchService, MetadataConstants.TRUSTED_API);
+        apiImpl = new MetadataApiImpl(readService, writeService, searchService, MetadataConstants.TRUSTED_API);
         grpcWrap = new GrpcServerWrap();
     }
 


### PR DESCRIPTION
* gRPC listeners require delayed execution of startCall(), which must happen after onMessage()
* To allow streaming calls, handling of the request() and onMessage() events is corrected for delayed execution
* Validation comes after auth but before API call start is recorded in the interceptor chain