### PR TITLE
Feature / Make ctx.log a property

### DIFF
--- a/examples/models/python/src/tutorial/data_export.py
+++ b/examples/models/python/src/tutorial/data_export.py
@@ -54,7 +54,7 @@ class DataExportExample(trac.TracDataExport):
         no_overwrite = ctx.get_parameter("no_overwrite")
 
         if no_overwrite and storage.exists(export_file):
-            ctx.log().info(f"Export of [{export_file}] will be skipped because the file already exists")
+            ctx.log.info(f"Export of [{export_file}] will be skipped because the file already exists")
             return
 
         with storage.write_byte_stream(export_file) as stream:

--- a/examples/models/python/src/tutorial/data_import.py
+++ b/examples/models/python/src/tutorial/data_import.py
@@ -150,7 +150,7 @@ class SelectiveDataImport(trac.TracDataImport):
 
             else:
 
-                ctx.log().warning(f"Requested table [{table_name}] not found in storage [{storage_key}]")
+                ctx.log.warning(f"Requested table [{table_name}] not found in storage [{storage_key}]")
 
 
 class SimpleDataImport(trac.TracDataImport):

--- a/examples/models/python/src/tutorial/hello_world.py
+++ b/examples/models/python/src/tutorial/hello_world.py
@@ -34,10 +34,10 @@ class HelloWorldModel(trac.TracModel):
 
     def run_model(self, ctx: trac.TracContext):
 
-        ctx.log().info("Hello world model is running")
+        ctx.log.info("Hello world model is running")
 
         input_number = ctx.get_parameter("input_number")
-        ctx.log().info(f"The input number is {input_number}")
+        ctx.log.info(f"The input number is {input_number}")
 
 
 if __name__ == "__main__":

--- a/tracdap-runtime/python/src/tracdap/rt/_impl/exec/context.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_impl/exec/context.py
@@ -35,11 +35,11 @@ import tracdap.rt._impl.core.util as _util
 import tracdap.rt._impl.core.validation as _val
 
 
-class _LogWrapper:
+class _TracLogWrapper:
 
     # Wrapper for the ctx.log property, to keep backwards compatability
     # ctx.log.info("New style log message, ctx.log is a property")
-    # ctx.log().info("Old style log message, ctx.log() is a method")
+    # ctx.log().info("Old style log message, ctx.log() is a method call")
 
     def __init__(self, log):
         self.__log = log
@@ -89,7 +89,7 @@ class TracContextImpl(_api.TracContext):
             log_provider = _logging.LogProvider()
 
         self.__ctx_log = log_provider.logger_for_object(self)
-        self.__model_log = _LogWrapper(log_provider.logger_for_class(model_class))
+        self.__model_log = _TracLogWrapper(log_provider.logger_for_class(model_class))
 
         self.__model_def = model_def
         self.__model_class = model_class

--- a/tracdap-runtime/python/src/tracdap/rt/_impl/exec/context.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_impl/exec/context.py
@@ -35,20 +35,21 @@ import tracdap.rt._impl.core.util as _util
 import tracdap.rt._impl.core.validation as _val
 
 
-class _TracLogWrapper:
+class _TracLogWrapper(_logging.Logger):
 
     # Wrapper for the ctx.log property, to keep backwards compatability
     # ctx.log.info("New style log message, ctx.log is a property")
     # ctx.log().info("Old style log message, ctx.log() is a method call")
 
-    def __init__(self, log):
-        self.__log = log
+    def __init__(self, delegate: _logging.Logger):
+        super().__init__(delegate.name, delegate.level)
+        self.__delegate = delegate
+
+    def _log(self, level, msg, args, exc_info=None, extra=None, stack_info=False, stacklevel=1):
+        self.__delegate._log(level, msg, args, exc_info, extra, stack_info, stacklevel)
 
     def __call__(self):
-        return self.__log
-
-    def __getattr__(self, name):
-        return getattr(self.__log, name)
+        return self
 
 
 class TracContextImpl(_api.TracContext):

--- a/tracdap-runtime/python/src/tracdap/rt/_impl/exec/context.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_impl/exec/context.py
@@ -431,7 +431,7 @@ class TracContextImpl(_api.TracContext):
         return memory_stream(DelayedClose())
 
     @property
-    def log(self) -> logging.Logger:
+    def log(self) -> tp.Union[logging.Logger, tp.Callable[[], _logging.Logger]]:
 
         return self.__model_log  # noqa
 

--- a/tracdap-runtime/python/src/tracdap/rt/api/model_api.py
+++ b/tracdap-runtime/python/src/tracdap/rt/api/model_api.py
@@ -462,10 +462,14 @@ class TracContext(metaclass=_abc.ABCMeta):
 
         pass
 
-    def log(self) -> _logging.Logger:
+    @property
+    def log(self) -> _tp.Union[
+            _logging.Logger,
+            _tp.Callable[[], _logging.Logger]  # DOCGEN_REMOVE
+        ]:
 
         """
-        Get a Python logger that can be used for writing model logs.
+        A Python logger that can be used for writing model logs.
 
         Logs written to this logger are recorded by TRAC. When models are run on the platform,
         these logs are assembled and saved with the job outputs as a dataset, that can be queried
@@ -475,7 +479,7 @@ class TracContext(metaclass=_abc.ABCMeta):
         :rtype: :py:class:`logging.Logger`
         """
 
-        pass
+        return None  # noqa
 
 
 class TracModel(metaclass=_abc.ABCMeta):

--- a/tracdap-runtime/python/test/tracdap_test/rt/exec/test_context.py
+++ b/tracdap-runtime/python/test/tracdap_test/rt/exec/test_context.py
@@ -312,6 +312,7 @@ class TracContextTest(unittest.TestCase):
         # Test new log property syntax
 
         log2 = self.ctx.log
+        self.assertIsInstance(log2, logging.Logger)
 
         with self.assertLogs(log.name, logging.INFO):
             log2.info("Model logger test")

--- a/tracdap-runtime/python/test/tracdap_test/rt/exec/test_context.py
+++ b/tracdap-runtime/python/test/tracdap_test/rt/exec/test_context.py
@@ -301,11 +301,20 @@ class TracContextTest(unittest.TestCase):
 
     def test_get_log(self):
 
+        # Test old method-call syntax
+
         log = self.ctx.log()
         self.assertIsInstance(log, logging.Logger)
 
         with self.assertLogs(log.name, logging.INFO):
             log.info("Model logger test")
+
+        # Test new log property syntax
+
+        log2 = self.ctx.log
+
+        with self.assertLogs(log.name, logging.INFO):
+            log2.info("Model logger test")
 
     """
     Functionality not available yet:


### PR DESCRIPTION
Backwards compatibility is maintained, so both old style and new style will work.

ctx.log.info("New style logging, ctx.log is a property")
ctx.log().info("Old style logging, ctx.log() is a method call")