### PR TITLE
Add /available endpoint to trac-gateway

### DIFF
--- a/tracdap-libs/tracdap-lib-common/build.gradle
+++ b/tracdap-libs/tracdap-lib-common/build.gradle
@@ -60,6 +60,9 @@ dependencies {
     api group: 'io.grpc', name: 'grpc-protobuf', version: "$grpc_version"
     api group: 'io.grpc', name: 'grpc-context', version: "$grpc_version"
 
+    // Standard gRPC health service (grpc.health.v1) - used for service readiness / the gateway /availablez probe
+    api group: 'io.grpc', name: 'grpc-services', version: "$grpc_version"
+
     // CLI is implemented with Apache Commons CLI
     implementation group: 'commons-cli', name: 'commons-cli', version: "$commons_cli_version"
 

--- a/tracdap-libs/tracdap-lib-common/src/main/java/org/finos/tracdap/common/grpc/GrpcServiceRegister.java
+++ b/tracdap-libs/tracdap-lib-common/src/main/java/org/finos/tracdap/common/grpc/GrpcServiceRegister.java
@@ -96,4 +96,13 @@ public class GrpcServiceRegister {
 
         return descriptor;
     }
+
+    public Descriptors.MethodDescriptor findMethodDescriptor(String methodName) {
+
+        // Returns null instead of throwing when the method is not registered. Some methods on a
+        // TRAC server are not TRAC API methods (e.g. the standard gRPC health service), and callers
+        // may legitimately need to handle those rather than treating them as an error.
+
+        return methodMap.get(methodName);
+    }
 }

--- a/tracdap-libs/tracdap-lib-common/src/main/java/org/finos/tracdap/common/service/TracServiceBase.java
+++ b/tracdap-libs/tracdap-lib-common/src/main/java/org/finos/tracdap/common/service/TracServiceBase.java
@@ -23,6 +23,9 @@ import org.finos.tracdap.common.config.ConfigManager;
 import org.finos.tracdap.common.exception.EStartup;
 import org.finos.tracdap.common.exception.ETrac;
 
+import io.grpc.BindableService;
+import io.grpc.health.v1.HealthCheckResponse.ServingStatus;
+import io.grpc.protobuf.services.HealthStatusManager;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configurator;
@@ -164,6 +167,31 @@ public abstract class TracServiceBase {
     private final Duration startupTimeout = DEFAULT_STARTUP_TIMEOUT;
     private final Duration shutdownTimeout = DEFAULT_SHUTDOWN_TIMEOUT;
 
+    // Standard gRPC health service (grpc.health.v1), starts as NOT_SERVING and flips to SERVING
+    // only once doStartup() has completed successfully (see start() / stop()).
+    private final HealthStatusManager healthStatusManager = initHealthStatusManager();
+
+    private static HealthStatusManager initHealthStatusManager() {
+        var manager = new HealthStatusManager();
+        manager.setStatus(HealthStatusManager.SERVICE_NAME_ALL_SERVICES, ServingStatus.NOT_SERVING);
+        return manager;
+    }
+
+    /**
+     * The standard gRPC health service (grpc.health.v1) for this service.
+     *
+     * <p>Services must register this on their gRPC server, e.g.
+     * {@code serverBuilder.addService(getHealthService())}. The base class reports NOT_SERVING
+     * until doStartup() completes successfully, then SERVING, and NOT_SERVING again once shutdown
+     * begins. The gateway /availablez endpoint uses this to report true service readiness rather
+     * than a bare TCP connection (which only confirms the port is bound).</p>
+     *
+     * @return The gRPC health service to register on the service's server
+     */
+    protected BindableService getHealthService() {
+        return healthStatusManager.getHealthService();
+    }
+
     /**
      * Entry point for spawning a new service
      *
@@ -266,6 +294,9 @@ public abstract class TracServiceBase {
 
             timedSequence(t -> {doStartup(t); return null;}, startupTimeout, "startup");
 
+            // Startup completed successfully - report SERVING on the gRPC health service
+            healthStatusManager.setStatus(HealthStatusManager.SERVICE_NAME_ALL_SERVICES, ServingStatus.SERVING);
+
             // If requested, install a shutdown handler for a graceful exit
             // This is needed when running a real server instance, but not when running embedded tests
             if (registerShutdownHook) {
@@ -315,6 +346,9 @@ public abstract class TracServiceBase {
         try {
 
             log.info("Service is going down...");
+
+            // Report NOT_SERVING as soon as shutdown begins, so readiness probes stop treating this service as available
+            healthStatusManager.enterTerminalState();
 
             var exitCode = timedSequence(this::doShutdown, shutdownTimeout, "shutdown");
 

--- a/tracdap-libs/tracdap-lib-common/src/main/java/org/finos/tracdap/common/service/TracServiceBase.java
+++ b/tracdap-libs/tracdap-lib-common/src/main/java/org/finos/tracdap/common/service/TracServiceBase.java
@@ -171,6 +171,11 @@ public abstract class TracServiceBase {
     // only once doStartup() has completed successfully (see start() / stop()).
     private final HealthStatusManager healthStatusManager = initHealthStatusManager();
 
+    // Protocol-neutral view of the same readiness state, for services that do not expose gRPC
+    // (e.g. HTTP / Jetty services that serve their own /availablez endpoint). True only while the
+    // service has completed startup and is not shutting down - see start() / stop().
+    private volatile boolean serving = false;
+
     private static HealthStatusManager initHealthStatusManager() {
         var manager = new HealthStatusManager();
         manager.setStatus(HealthStatusManager.SERVICE_NAME_ALL_SERVICES, ServingStatus.NOT_SERVING);
@@ -190,6 +195,21 @@ public abstract class TracServiceBase {
      */
     protected BindableService getHealthService() {
         return healthStatusManager.getHealthService();
+    }
+
+    /**
+     * Whether the service has completed startup and is ready to serve requests.
+     *
+     * <p>Returns true only after doStartup() has completed successfully, and false again once
+     * shutdown begins. This is the protocol-neutral equivalent of the gRPC health SERVING status,
+     * intended for HTTP services that expose their own readiness endpoint (e.g. /availablez).
+     * Because doStartup() brings up critical dependencies (a service that cannot reach its database
+     * fails startup and never becomes serving), a serving service is genuinely able to do its job.</p>
+     *
+     * @return true if the service is started and not shutting down
+     */
+    protected boolean isServing() {
+        return serving;
     }
 
     /**
@@ -296,6 +316,7 @@ public abstract class TracServiceBase {
 
             // Startup completed successfully - report SERVING on the gRPC health service
             healthStatusManager.setStatus(HealthStatusManager.SERVICE_NAME_ALL_SERVICES, ServingStatus.SERVING);
+            serving = true;
 
             // If requested, install a shutdown handler for a graceful exit
             // This is needed when running a real server instance, but not when running embedded tests
@@ -348,6 +369,7 @@ public abstract class TracServiceBase {
             log.info("Service is going down...");
 
             // Report NOT_SERVING as soon as shutdown begins, so readiness probes stop treating this service as available
+            serving = false;
             healthStatusManager.enterTerminalState();
 
             var exitCode = timedSequence(this::doShutdown, shutdownTimeout, "shutdown");

--- a/tracdap-libs/tracdap-lib-test/src/main/java/org/finos/tracdap/test/helpers/PlatformTest.java
+++ b/tracdap-libs/tracdap-lib-test/src/main/java/org/finos/tracdap/test/helpers/PlatformTest.java
@@ -42,6 +42,7 @@ import org.finos.tracdap.tools.secrets.SecretTool;
 import org.finos.tracdap.test.config.ConfigHelpers;
 
 import io.grpc.*;
+import io.grpc.health.v1.HealthGrpc;
 import io.grpc.stub.AbstractStub;
 import io.grpc.netty.NettyChannelBuilder;
 import io.netty.channel.nio.NioEventLoopGroup;
@@ -232,6 +233,14 @@ public class PlatformTest implements BeforeAllCallback, AfterAllCallback {
         var channel = serviceChannels.get(serviceKey);
         var client = clientFactory.apply(channel);
         return clientConcerns.configureClient(client);
+    }
+
+    public HealthGrpc.HealthBlockingStub healthClientBlocking(String serviceKey) {
+        if (!serviceChannels.containsKey(serviceKey))
+            throw new ETracInternal("Client not started for service key [" + serviceKey + "]");
+        // Deliberately without client concerns - this matches the gateway /availablez probe,
+        // which issues a bare, unauthenticated gRPC health check directly to each service.
+        return HealthGrpc.newBlockingStub(serviceChannels.get(serviceKey));
     }
 
     public TracMetadataApiGrpc.TracMetadataApiFutureStub metaClientFuture() {

--- a/tracdap-libs/tracdap-lib-validation/src/main/java/org/finos/tracdap/common/validation/ValidationInterceptor.java
+++ b/tracdap-libs/tracdap-lib-validation/src/main/java/org/finos/tracdap/common/validation/ValidationInterceptor.java
@@ -82,16 +82,29 @@ public class ValidationInterceptor extends DelayedExecutionInterceptor {
             this.loggingEnabled = loggingEnabled;
 
             // Look up the descriptor for this call, to use for validation
+            // Methods that are not TRAC API methods (e.g. the standard gRPC health service) are not
+            // registered and have no validation rules - findMethodDescriptor returns null for those,
+            // and onMessage() passes them straight through without validation.
             var grpcDescriptor = serverCall.getMethodDescriptor();
             var grpcMethodName = grpcDescriptor.getFullMethodName();
 
-            this.methodDescriptor = serviceRegister.getMethodDescriptor(grpcMethodName);
+            this.methodDescriptor = serviceRegister.findMethodDescriptor(grpcMethodName);
         }
 
         @Override
         public void onMessage(ReqT req) {
 
             if (!validated) {
+
+                // Non-TRAC methods (e.g. the gRPC health service) have no registered validator -
+                // pass them straight through without validation.
+                if (methodDescriptor == null) {
+
+                    validated = true;
+                    startCall();
+                    delegate().onMessage(req);
+                    return;
+                }
 
                 try {
 

--- a/tracdap-services/tracdap-gateway/build.gradle
+++ b/tracdap-services/tracdap-gateway/build.gradle
@@ -56,6 +56,10 @@ dependencies {
     implementation group: 'io.netty', name: 'netty-codec-http2', version: "$netty_version"
     implementation group: 'io.netty', name: 'netty-handler-proxy', version: "$netty_version"
 
+    // gRPC client transport - the gateway acts as a gRPC client only for the /availablez health probe
+    // (grpc-stub / grpc-protobuf / grpc-services come transitively from tracdap-lib-common)
+    implementation group: 'io.grpc', name: 'grpc-netty', version: "$grpc_version"
+
     // Protobuf for Java
     implementation group: 'com.google.protobuf', name: 'protobuf-java', version: "$proto_version"
     implementation group: 'com.google.protobuf', name: 'protobuf-java-util', version: "$proto_version"

--- a/tracdap-services/tracdap-gateway/src/main/java/org/finos/tracdap/gateway/TracPlatformGateway.java
+++ b/tracdap-services/tracdap-gateway/src/main/java/org/finos/tracdap/gateway/TracPlatformGateway.java
@@ -77,6 +77,7 @@ public class TracPlatformGateway extends TracServiceBase {
     private final ConfigManager configManager;
 
     private ServiceConfig serviceConfig;
+    private PlatformConfig platformConfig;
 
     private EventLoopGroup bossGroup = null;
     private EventLoopGroup workerGroup = null;
@@ -103,7 +104,7 @@ public class TracPlatformGateway extends TracServiceBase {
         try {
             log.info("Preparing gateway config...");
 
-            var platformConfig = configManager.loadRootConfigObject(PlatformConfig.class);
+            platformConfig = configManager.loadRootConfigObject(PlatformConfig.class);
             serviceConfig = platformConfig.getServicesOrThrow(ConfigKeys.GATEWAY_SERVICE_KEY);
             proxyPort = (short) serviceConfig.getPort();
 
@@ -246,7 +247,7 @@ public class TracPlatformGateway extends TracServiceBase {
     }
 
     private ChannelHandler httpHandler() {
-        return new Http1Router(routes, redirects, connId.getAndIncrement());
+        return new Http1Router(routes, redirects, connId.getAndIncrement(), platformConfig);
     }
 
     private ChannelHandler websocketHandler() {

--- a/tracdap-services/tracdap-gateway/src/main/java/org/finos/tracdap/gateway/builders/RouteBuilder.java
+++ b/tracdap-services/tracdap-gateway/src/main/java/org/finos/tracdap/gateway/builders/RouteBuilder.java
@@ -38,8 +38,8 @@ public class RouteBuilder {
     public static final String HEALTH_CHECK_PATH = "/healthz";
 
     public static final String AVAILABLE_NAME = "Service Availability";
-    public static final String AVAILABLE_KEY = "available";
-    public static final String AVAILABLE_PATH = "/available";
+    public static final String AVAILABLE_KEY = "availablez";
+    public static final String AVAILABLE_PATH = "/availablez";
 
     private static final Logger log = LoggerFactory.getLogger(RouteBuilder.class);
 

--- a/tracdap-services/tracdap-gateway/src/main/java/org/finos/tracdap/gateway/builders/RouteBuilder.java
+++ b/tracdap-services/tracdap-gateway/src/main/java/org/finos/tracdap/gateway/builders/RouteBuilder.java
@@ -37,6 +37,10 @@ public class RouteBuilder {
     public static final String HEALTH_CHECK_KEY = "healthz";
     public static final String HEALTH_CHECK_PATH = "/healthz";
 
+    public static final String AVAILABLE_NAME = "Service Availability";
+    public static final String AVAILABLE_KEY = "available";
+    public static final String AVAILABLE_PATH = "/available";
+
     private static final Logger log = LoggerFactory.getLogger(RouteBuilder.class);
 
     private static final ClassLoader API_CLASSLOADER = RouteBuilder.class.getClassLoader();
@@ -63,6 +67,13 @@ public class RouteBuilder {
         if (!customHealth) {
             var healthCheckRoute = buildHealthCheckRoute();
             routes.add(healthCheckRoute);
+        }
+
+        var customAvailable = customRoutes.stream().anyMatch(route -> route.getRouteKey().equals(AVAILABLE_KEY));
+
+        if (!customAvailable) {
+            var availableRoute = buildAvailableRoute();
+            routes.add(availableRoute);
         }
 
         for (var serviceInfo : services) {
@@ -121,6 +132,27 @@ public class RouteBuilder {
         var matcher = (IRouteMatcher) (method, url) ->
                 url.getPath().equals(HEALTH_CHECK_PATH) &&
                 (method == HttpMethod.HEAD || method == HttpMethod.GET);
+
+        return new Route(routeIndex, routeConfig, matcher);
+    }
+
+    private Route buildAvailableRoute() {
+
+        var routeIndex = nextRouteIndex++;
+
+        var routeConfig = RouteConfig.newBuilder()
+                .setRouteKey(AVAILABLE_KEY)
+                .setRouteName(AVAILABLE_NAME)
+                .setRouteType(RoutingProtocol.INTERNAL)
+                .addProtocols(RoutingProtocol.HTTP)
+                .setMatch(RoutingMatch.newBuilder()
+                        .setPath(AVAILABLE_PATH))
+                .setTarget(RoutingTarget.newBuilder()
+                        .setScheme(AVAILABLE_KEY))
+                .build();
+
+        var matcher = (IRouteMatcher) (method, url) ->
+                url.getPath().equals(AVAILABLE_PATH) && method == HttpMethod.GET;
 
         return new Route(routeIndex, routeConfig, matcher);
     }

--- a/tracdap-services/tracdap-gateway/src/main/java/org/finos/tracdap/gateway/proxy/internal/AvailabilityHandler.java
+++ b/tracdap-services/tracdap-gateway/src/main/java/org/finos/tracdap/gateway/proxy/internal/AvailabilityHandler.java
@@ -44,7 +44,7 @@ import java.util.concurrent.TimeUnit;
 
 public class AvailabilityHandler extends ChannelInboundHandlerAdapter {
 
-    public static final String PROTOCOL = "available";
+    public static final String PROTOCOL = "availablez";
 
     private static final int PROBE_TIMEOUT_MS = 2000;
     private static final int TOTAL_TIMEOUT_S = 5;

--- a/tracdap-services/tracdap-gateway/src/main/java/org/finos/tracdap/gateway/proxy/internal/AvailabilityHandler.java
+++ b/tracdap-services/tracdap-gateway/src/main/java/org/finos/tracdap/gateway/proxy/internal/AvailabilityHandler.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Fintech Open Source Foundation (FINOS) under one or
+ * more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * FINOS licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.finos.tracdap.gateway.proxy.internal;
+
+import org.finos.tracdap.common.exception.ETracInternal;
+import org.finos.tracdap.common.util.LoggingHelpers;
+import org.finos.tracdap.common.util.RoutingUtils;
+import org.finos.tracdap.config.PlatformConfig;
+import org.finos.tracdap.gateway.builders.ServiceInfo;
+import org.finos.tracdap.gateway.proxy.http.HttpProtocol;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.http.*;
+import io.netty.util.ReferenceCountUtil;
+import org.slf4j.Logger;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+
+public class AvailabilityHandler extends ChannelInboundHandlerAdapter {
+
+    public static final String PROTOCOL = "available";
+
+    private static final int PROBE_TIMEOUT_MS = 2000;
+    private static final int TOTAL_TIMEOUT_S = 5;
+
+    private static final ThreadLocal<Logger> logMap = new ThreadLocal<>();
+    private final Logger log = LoggingHelpers.threadLocalLogger(this, logMap);
+
+    private final HttpProtocol httpProtocol;
+    private final long connId;
+    private final PlatformConfig platformConfig;
+
+    public AvailabilityHandler(HttpProtocol httpProtocol, long connId, PlatformConfig platformConfig) {
+        this.httpProtocol = httpProtocol;
+        this.connId = connId;
+        this.platformConfig = platformConfig;
+    }
+
+    @Override
+    public void channelRead(@Nonnull ChannelHandlerContext ctx, @Nonnull Object msg) {
+
+        try {
+
+            if (msg instanceof HttpRequest) {
+
+                if (httpProtocol != HttpProtocol.HTTP_1_1 && httpProtocol != HttpProtocol.HTTP_1_0)
+                    throw new ETracInternal("Availability check requires HTTP/1 protocol");
+
+                var request = (HttpRequest) msg;
+                processRequest(ctx, request);
+            }
+            else if (!(msg instanceof HttpContent)) {
+
+                log.warn("Unexpected message type ({}) in availability handler", msg.getClass().getName());
+            }
+        }
+        finally {
+            ReferenceCountUtil.release(msg);
+        }
+    }
+
+    private void processRequest(ChannelHandlerContext ctx, HttpRequest request) {
+
+        var method = request.method();
+
+        if (method != HttpMethod.GET)
+            throw new ETracInternal("Invalid HTTP method for availability check: " + method);
+
+        var responseBody = checkAvailability();
+        var responseBytes = responseBody.getBytes(StandardCharsets.UTF_8);
+        var responseBuf = Unpooled.wrappedBuffer(responseBytes);
+
+        var headers = new DefaultHttpHeaders()
+                .add(HttpHeaderNames.CONTENT_TYPE, "text/plain; charset=UTF-8")
+                .addInt(HttpHeaderNames.CONTENT_LENGTH, responseBytes.length);
+
+        var response = new DefaultFullHttpResponse(
+                request.protocolVersion(),
+                HttpResponseStatus.OK,
+                responseBuf,
+                headers, new DefaultHttpHeaders());
+
+        ctx.writeAndFlush(response);
+    }
+
+    private String checkAvailability() {
+
+        var services = ServiceInfo.buildServiceInfo(platformConfig);
+
+        // Start a probe for each service in parallel
+        var probes = new LinkedHashMap<String, CompletableFuture<Boolean>>();
+
+        for (var service : services) {
+            var serviceKey = service.serviceKey();
+            var probe = CompletableFuture.supplyAsync(() -> probeService(serviceKey));
+            probes.put(serviceKey, probe);
+        }
+
+        // Wait for all probes to complete
+        try {
+            CompletableFuture
+                    .allOf(probes.values().toArray(new CompletableFuture[0]))
+                    .get(TOTAL_TIMEOUT_S, TimeUnit.SECONDS);
+        }
+        catch (Exception e) {
+            log.warn("Availability probe timed out or was interrupted: {}", e.getMessage());
+        }
+
+        // Build the plain-text response
+        var sb = new StringBuilder();
+
+        for (var entry : probes.entrySet()) {
+            var available = false;
+            try {
+                available = entry.getValue().getNow(false);
+            }
+            catch (Exception e) {
+                log.debug("Probe result unavailable for [{}]: {}", entry.getKey(), e.getMessage());
+            }
+            sb.append(entry.getKey()).append('=').append(available ? "yes" : "no").append('\n');
+        }
+
+        return sb.toString();
+    }
+
+    private boolean probeService(String serviceKey) {
+
+        try {
+            var target = RoutingUtils.serviceTarget(platformConfig, serviceKey);
+            var host = target.getHost();
+            var port = (int) target.getPort();
+
+            try (var socket = new Socket()) {
+                socket.connect(new InetSocketAddress(host, port), PROBE_TIMEOUT_MS);
+                return true;
+            }
+        }
+        catch (IOException e) {
+            log.debug("Service [{}] probe failed: {}", serviceKey, e.getMessage());
+            return false;
+        }
+    }
+}

--- a/tracdap-services/tracdap-gateway/src/main/java/org/finos/tracdap/gateway/proxy/internal/AvailabilityHandler.java
+++ b/tracdap-services/tracdap-gateway/src/main/java/org/finos/tracdap/gateway/proxy/internal/AvailabilityHandler.java
@@ -35,6 +35,7 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.net.SocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.concurrent.CompletableFuture;
@@ -54,11 +55,13 @@ public class AvailabilityHandler extends ChannelInboundHandlerAdapter {
     private final HttpProtocol httpProtocol;
     private final long connId;
     private final PlatformConfig platformConfig;
+    private final SocketAddress remoteAddress;
 
-    public AvailabilityHandler(HttpProtocol httpProtocol, long connId, PlatformConfig platformConfig) {
+    public AvailabilityHandler(HttpProtocol httpProtocol, long connId, PlatformConfig platformConfig, SocketAddress remoteAddress) {
         this.httpProtocol = httpProtocol;
         this.connId = connId;
         this.platformConfig = platformConfig;
+        this.remoteAddress = remoteAddress;
     }
 
     @Override
@@ -90,6 +93,15 @@ public class AvailabilityHandler extends ChannelInboundHandlerAdapter {
 
         if (method != HttpMethod.GET)
             throw new ETracInternal("Invalid HTTP method for availability check: " + method);
+
+        if (!isLocalhost(remoteAddress)) {
+            var response = new DefaultFullHttpResponse(
+                    request.protocolVersion(), HttpResponseStatus.FORBIDDEN,
+                    Unpooled.EMPTY_BUFFER, new DefaultHttpHeaders().addInt(HttpHeaderNames.CONTENT_LENGTH, 0),
+                    new DefaultHttpHeaders());
+            ctx.writeAndFlush(response);
+            return;
+        }
 
         var responseBody = checkAvailability();
         var responseBytes = responseBody.getBytes(StandardCharsets.UTF_8);
@@ -164,5 +176,15 @@ public class AvailabilityHandler extends ChannelInboundHandlerAdapter {
             log.debug("Service [{}] probe failed: {}", serviceKey, e.getMessage());
             return false;
         }
+    }
+
+    private static boolean isLocalhost(SocketAddress address) {
+
+        if (address instanceof InetSocketAddress) {
+            var inetAddr = ((InetSocketAddress) address).getAddress();
+            return inetAddr != null && inetAddr.isLoopbackAddress();
+        }
+
+        return false;
     }
 }

--- a/tracdap-services/tracdap-gateway/src/main/java/org/finos/tracdap/gateway/proxy/internal/AvailabilityHandler.java
+++ b/tracdap-services/tracdap-gateway/src/main/java/org/finos/tracdap/gateway/proxy/internal/AvailabilityHandler.java
@@ -24,6 +24,11 @@ import org.finos.tracdap.config.PlatformConfig;
 import org.finos.tracdap.gateway.builders.ServiceInfo;
 import org.finos.tracdap.gateway.proxy.http.HttpProtocol;
 
+import io.grpc.ManagedChannel;
+import io.grpc.health.v1.HealthCheckRequest;
+import io.grpc.health.v1.HealthCheckResponse.ServingStatus;
+import io.grpc.health.v1.HealthGrpc;
+import io.grpc.netty.NettyChannelBuilder;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
@@ -32,9 +37,7 @@ import io.netty.util.ReferenceCountUtil;
 import org.slf4j.Logger;
 
 import javax.annotation.Nonnull;
-import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.net.Socket;
 import java.net.SocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
@@ -162,19 +165,47 @@ public class AvailabilityHandler extends ChannelInboundHandlerAdapter {
 
     private boolean probeService(String serviceKey) {
 
+        // A bare TCP connection only proves the service has bound its port, not that it can serve
+        // requests. Instead, issue a standard gRPC health check (grpc.health.v1.Health/Check): the
+        // service reports SERVING only once its startup sequence has fully completed.
+
+        ManagedChannel channel = null;
+
         try {
             var target = RoutingUtils.serviceTarget(platformConfig, serviceKey);
             var host = target.getHost();
             var port = (int) target.getPort();
 
-            try (var socket = new Socket()) {
-                socket.connect(new InetSocketAddress(host, port), PROBE_TIMEOUT_MS);
-                return true;
-            }
+            // Internal gateway -> service hops are plaintext (see RoutingUtils.serviceTarget), matching
+            // the previous TCP probe. Terminating TLS at the edge is handled separately by the gateway.
+            channel = NettyChannelBuilder.forAddress(host, port)
+                    .usePlaintext()
+                    .build();
+
+            var healthCheck = HealthGrpc.newBlockingStub(channel)
+                    .withDeadlineAfter(PROBE_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+
+            // Empty service name = overall server health
+            var request = HealthCheckRequest.newBuilder().setService("").build();
+            var response = healthCheck.check(request);
+
+            return response.getStatus() == ServingStatus.SERVING;
         }
-        catch (IOException e) {
-            log.debug("Service [{}] probe failed: {}", serviceKey, e.getMessage());
+        catch (Exception e) {
+            // Not reachable, health not yet SERVING, or no health service -> treat as unavailable
+            log.debug("Service [{}] health probe failed: {}", serviceKey, e.getMessage());
             return false;
+        }
+        finally {
+            if (channel != null) {
+                channel.shutdownNow();
+                try {
+                    channel.awaitTermination(1, TimeUnit.SECONDS);
+                }
+                catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
         }
     }
 

--- a/tracdap-services/tracdap-gateway/src/main/java/org/finos/tracdap/gateway/proxy/internal/AvailabilityHandler.java
+++ b/tracdap-services/tracdap-gateway/src/main/java/org/finos/tracdap/gateway/proxy/internal/AvailabilityHandler.java
@@ -39,7 +39,10 @@ import org.slf4j.Logger;
 import javax.annotation.Nonnull;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.net.URI;
+import java.net.http.HttpClient;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -131,9 +134,8 @@ public class AvailabilityHandler extends ChannelInboundHandlerAdapter {
         var probes = new LinkedHashMap<String, CompletableFuture<Boolean>>();
 
         for (var service : services) {
-            var serviceKey = service.serviceKey();
-            var probe = CompletableFuture.supplyAsync(() -> probeService(serviceKey));
-            probes.put(serviceKey, probe);
+            var probe = CompletableFuture.supplyAsync(() -> probeService(service));
+            probes.put(service.serviceKey(), probe);
         }
 
         // Wait for all probes to complete
@@ -163,21 +165,33 @@ public class AvailabilityHandler extends ChannelInboundHandlerAdapter {
         return sb.toString();
     }
 
-    private boolean probeService(String serviceKey) {
+    private boolean probeService(ServiceInfo service) {
 
         // A bare TCP connection only proves the service has bound its port, not that it can serve
-        // requests. Instead, issue a standard gRPC health check (grpc.health.v1.Health/Check): the
-        // service reports SERVING only once its startup sequence has fully completed.
+        // requests. Instead, probe each service using its own protocol so the answer reflects real
+        // readiness: gRPC services expose the standard gRPC health service (grpc.health.v1.Health),
+        // and HTTP services serve their own /availablez endpoint. In both cases the service only
+        // reports ready once its startup sequence (including its critical dependencies) has completed.
+
+        var serviceKey = service.serviceKey();
+
+        // Internal gateway -> service hops are plaintext (see RoutingUtils.serviceTarget), matching
+        // the previous TCP probe. Terminating TLS at the edge is handled separately by the gateway.
+        var target = RoutingUtils.serviceTarget(platformConfig, serviceKey);
+        var host = target.getHost();
+        var port = (int) target.getPort();
+
+        if (service.hasGrpc())
+            return probeGrpcHealth(serviceKey, host, port);
+        else
+            return probeHttpAvailability(serviceKey, host, port);
+    }
+
+    private boolean probeGrpcHealth(String serviceKey, String host, int port) {
 
         ManagedChannel channel = null;
 
         try {
-            var target = RoutingUtils.serviceTarget(platformConfig, serviceKey);
-            var host = target.getHost();
-            var port = (int) target.getPort();
-
-            // Internal gateway -> service hops are plaintext (see RoutingUtils.serviceTarget), matching
-            // the previous TCP probe. Terminating TLS at the edge is handled separately by the gateway.
             channel = NettyChannelBuilder.forAddress(host, port)
                     .usePlaintext()
                     .build();
@@ -193,7 +207,7 @@ public class AvailabilityHandler extends ChannelInboundHandlerAdapter {
         }
         catch (Exception e) {
             // Not reachable, health not yet SERVING, or no health service -> treat as unavailable
-            log.debug("Service [{}] health probe failed: {}", serviceKey, e.getMessage());
+            log.debug("Service [{}] gRPC health probe failed: {}", serviceKey, e.getMessage());
             return false;
         }
         finally {
@@ -206,6 +220,38 @@ public class AvailabilityHandler extends ChannelInboundHandlerAdapter {
                     Thread.currentThread().interrupt();
                 }
             }
+        }
+    }
+
+    private boolean probeHttpAvailability(String serviceKey, String host, int port) {
+
+        // HTTP services serve their own /availablez, returning "<serviceKey>=yes|no" - the same
+        // plain-text format the gateway uses. The service is ready only when the body reports "=yes".
+
+        try {
+            var client = HttpClient.newBuilder()
+                    .connectTimeout(Duration.ofMillis(PROBE_TIMEOUT_MS))
+                    .build();
+
+            var uri = URI.create("http://" + host + ":" + port + "/" + PROTOCOL);
+            var request = java.net.http.HttpRequest.newBuilder(uri)
+                    .timeout(Duration.ofMillis(PROBE_TIMEOUT_MS))
+                    .GET()
+                    .build();
+
+            var response = client.send(request, java.net.http.HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+
+            return response.statusCode() == 200 && response.body().contains("=yes");
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.debug("Service [{}] HTTP availability probe interrupted", serviceKey);
+            return false;
+        }
+        catch (Exception e) {
+            // Not reachable or not ready -> treat as unavailable
+            log.debug("Service [{}] HTTP availability probe failed: {}", serviceKey, e.getMessage());
+            return false;
         }
     }
 

--- a/tracdap-services/tracdap-gateway/src/main/java/org/finos/tracdap/gateway/proxy/internal/InternalProxyBuilder.java
+++ b/tracdap-services/tracdap-gateway/src/main/java/org/finos/tracdap/gateway/proxy/internal/InternalProxyBuilder.java
@@ -21,6 +21,7 @@ import io.netty.channel.ChannelDuplexHandler;
 import org.finos.tracdap.common.exception.ENetworkHttp;
 import org.finos.tracdap.common.exception.EUnexpected;
 import org.finos.tracdap.common.util.LoggingHelpers;
+import org.finos.tracdap.config.PlatformConfig;
 import org.finos.tracdap.config.RouteConfig;
 import org.finos.tracdap.gateway.proxy.http.HttpProtocol;
 
@@ -42,17 +43,19 @@ public class InternalProxyBuilder extends ChannelInitializer<Channel> {
     private final RouteConfig routeConfig;
     private final ChannelDuplexHandler routerLink;
     private final HttpProtocol httpProtocol;
+    private final PlatformConfig platformConfig;
 
     private final int connId;
 
     public InternalProxyBuilder(
             RouteConfig routeConfig, ChannelDuplexHandler routerLink,
-            int connId, HttpProtocol httpProtocol) {
+            int connId, HttpProtocol httpProtocol, PlatformConfig platformConfig) {
 
         this.httpProtocol = httpProtocol;
         this.routeConfig = routeConfig;
         this.routerLink = routerLink;
         this.connId = connId;
+        this.platformConfig = platformConfig;
     }
 
     @Override
@@ -96,6 +99,9 @@ public class InternalProxyBuilder extends ChannelInitializer<Channel> {
 
         if (targetProtocol.equals(HealthCheckHandler.PROTOCOL)) {
             targetPipeline.addLast(new HealthCheckHandler(httpProtocol, connId));
+        }
+        else if (targetProtocol.equals(AvailabilityHandler.PROTOCOL)) {
+            targetPipeline.addLast(new AvailabilityHandler(httpProtocol, connId, platformConfig));
         }
         else {
             var message = String.format("Internal protocol [%s] is not supported", targetProtocol);

--- a/tracdap-services/tracdap-gateway/src/main/java/org/finos/tracdap/gateway/proxy/internal/InternalProxyBuilder.java
+++ b/tracdap-services/tracdap-gateway/src/main/java/org/finos/tracdap/gateway/proxy/internal/InternalProxyBuilder.java
@@ -25,6 +25,8 @@ import org.finos.tracdap.config.PlatformConfig;
 import org.finos.tracdap.config.RouteConfig;
 import org.finos.tracdap.gateway.proxy.http.HttpProtocol;
 
+import java.net.SocketAddress;
+
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.embedded.EmbeddedChannel;
@@ -44,18 +46,21 @@ public class InternalProxyBuilder extends ChannelInitializer<Channel> {
     private final ChannelDuplexHandler routerLink;
     private final HttpProtocol httpProtocol;
     private final PlatformConfig platformConfig;
+    private final SocketAddress remoteAddress;
 
     private final int connId;
 
     public InternalProxyBuilder(
             RouteConfig routeConfig, ChannelDuplexHandler routerLink,
-            int connId, HttpProtocol httpProtocol, PlatformConfig platformConfig) {
+            int connId, HttpProtocol httpProtocol, PlatformConfig platformConfig,
+            SocketAddress remoteAddress) {
 
         this.httpProtocol = httpProtocol;
         this.routeConfig = routeConfig;
         this.routerLink = routerLink;
         this.connId = connId;
         this.platformConfig = platformConfig;
+        this.remoteAddress = remoteAddress;
     }
 
     @Override
@@ -101,7 +106,7 @@ public class InternalProxyBuilder extends ChannelInitializer<Channel> {
             targetPipeline.addLast(new HealthCheckHandler(httpProtocol, connId));
         }
         else if (targetProtocol.equals(AvailabilityHandler.PROTOCOL)) {
-            targetPipeline.addLast(new AvailabilityHandler(httpProtocol, connId, platformConfig));
+            targetPipeline.addLast(new AvailabilityHandler(httpProtocol, connId, platformConfig, remoteAddress));
         }
         else {
             var message = String.format("Internal protocol [%s] is not supported", targetProtocol);

--- a/tracdap-services/tracdap-gateway/src/main/java/org/finos/tracdap/gateway/routing/Http1Router.java
+++ b/tracdap-services/tracdap-gateway/src/main/java/org/finos/tracdap/gateway/routing/Http1Router.java
@@ -301,7 +301,8 @@ public class Http1Router extends CoreRouter {
 
                 return new InternalProxyBuilder(
                         routeConfig.getConfig(), link, connId,
-                        HttpProtocol.HTTP_1_1, platformConfig);
+                        HttpProtocol.HTTP_1_1, platformConfig,
+                        ctx.channel().remoteAddress());
 
             case HTTP:
 

--- a/tracdap-services/tracdap-gateway/src/main/java/org/finos/tracdap/gateway/routing/Http1Router.java
+++ b/tracdap-services/tracdap-gateway/src/main/java/org/finos/tracdap/gateway/routing/Http1Router.java
@@ -19,6 +19,7 @@ package org.finos.tracdap.gateway.routing;
 
 import org.finos.tracdap.common.exception.EUnexpected;
 import org.finos.tracdap.common.util.LoggingHelpers;
+import org.finos.tracdap.config.PlatformConfig;
 import org.finos.tracdap.gateway.exec.Redirect;
 import org.finos.tracdap.gateway.exec.Route;
 import org.finos.tracdap.gateway.proxy.grpc.GrpcProtocol;
@@ -55,15 +56,17 @@ public class Http1Router extends CoreRouter {
     private static final ThreadLocal<Logger> logMap = new ThreadLocal<>();
     private final Logger log = LoggingHelpers.threadLocalLogger(this, logMap);
 
+    private final PlatformConfig platformConfig;
     private final Map<Long, RequestState> requests;
 
     private long currentInboundRequest;
     private long currentOutboundRequest;
 
-    public Http1Router(List<Route> routes, List<Redirect> redirects, int connId) {
+    public Http1Router(List<Route> routes, List<Redirect> redirects, int connId, PlatformConfig platformConfig) {
 
         super(routes, redirects, connId, "HTTP/1");
 
+        this.platformConfig = platformConfig;
         this.requests = new HashMap<>();
 
         this.currentInboundRequest = -1;
@@ -298,7 +301,7 @@ public class Http1Router extends CoreRouter {
 
                 return new InternalProxyBuilder(
                         routeConfig.getConfig(), link, connId,
-                        HttpProtocol.HTTP_1_1);
+                        HttpProtocol.HTTP_1_1, platformConfig);
 
             case HTTP:
 

--- a/tracdap-services/tracdap-svc-admin/src/main/java/org/finos/tracdap/svc/admin/TracAdminService.java
+++ b/tracdap-services/tracdap-svc-admin/src/main/java/org/finos/tracdap/svc/admin/TracAdminService.java
@@ -102,7 +102,8 @@ public class TracAdminService extends TracServiceBase {
                     .forPort(servicePort)
                     .executor(executor)
                     .addService(adminApi)
-                    .addService(new MessageProcessor());
+                    .addService(new MessageProcessor())
+                    .addService(getHealthService());
 
             // Apply common concerns
             this.server = commonConcerns

--- a/tracdap-services/tracdap-svc-admin/src/test/java/org/finos/tracdap/svc/amin/api/AdminHealthCheckTest.java
+++ b/tracdap-services/tracdap-svc-admin/src/test/java/org/finos/tracdap/svc/amin/api/AdminHealthCheckTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Fintech Open Source Foundation (FINOS) under one or
+ * more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * FINOS licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.finos.tracdap.svc.amin.api;
+
+import org.finos.tracdap.common.config.ConfigKeys;
+import org.finos.tracdap.svc.admin.TracAdminService;
+import org.finos.tracdap.svc.meta.TracMetadataService;
+import org.finos.tracdap.test.helpers.PlatformTest;
+import org.finos.tracdap.test.meta.SampleMetadata;
+
+import io.grpc.health.v1.HealthCheckRequest;
+import io.grpc.health.v1.HealthCheckResponse.ServingStatus;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+
+/**
+ * Verify the admin service reports SERVING on the standard gRPC health service
+ * (grpc.health.v1.Health) once started. The probe is a bare, unauthenticated health
+ * check, matching how the gateway /availablez endpoint checks service readiness.
+ */
+class AdminHealthCheckTest {
+
+    private static final String TRAC_DYNAMIC_CONFIG = "config/trac-dynamic.yaml";
+    private static final String TRAC_DYNAMIC_RESOURCES = "config/trac-dynamic-resources.yaml";
+
+    @RegisterExtension
+    private static final PlatformTest platform = PlatformTest.forConfig(TRAC_DYNAMIC_CONFIG)
+            .runDbDeploy(true)
+            .bootstrapTenant(SampleMetadata.TEST_TENANT, TRAC_DYNAMIC_RESOURCES)
+            .startService(TracAdminService.class)
+            .startService(TracMetadataService.class)
+            .build();
+
+    @Test
+    void healthCheckReportsServing() {
+
+        var healthClient = platform.healthClientBlocking(ConfigKeys.ADMIN_SERVICE_KEY);
+        var request = HealthCheckRequest.newBuilder().setService("").build();
+
+        var response = healthClient.check(request);
+
+        Assertions.assertEquals(ServingStatus.SERVING, response.getStatus());
+    }
+}

--- a/tracdap-services/tracdap-svc-data/src/main/java/org/finos/tracdap/svc/data/TracDataService.java
+++ b/tracdap-services/tracdap-svc-data/src/main/java/org/finos/tracdap/svc/data/TracDataService.java
@@ -206,7 +206,8 @@ public class TracDataService extends TracServiceBase {
                     // Services
                     .addService(dataApi)
                     .addService(storageApi)
-                    .addService(messageProcessor);
+                    .addService(messageProcessor)
+                    .addService(getHealthService());
 
             // Apply common concerns
             this.server =  commonConcerns

--- a/tracdap-services/tracdap-svc-data/src/test/java/org/finos/tracdap/svc/data/api/DataHealthCheckTest.java
+++ b/tracdap-services/tracdap-svc-data/src/test/java/org/finos/tracdap/svc/data/api/DataHealthCheckTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Fintech Open Source Foundation (FINOS) under one or
+ * more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * FINOS licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.finos.tracdap.svc.data.api;
+
+import org.finos.tracdap.common.config.ConfigKeys;
+import org.finos.tracdap.svc.admin.TracAdminService;
+import org.finos.tracdap.svc.data.TracDataService;
+import org.finos.tracdap.svc.meta.TracMetadataService;
+import org.finos.tracdap.test.helpers.PlatformTest;
+
+import io.grpc.health.v1.HealthCheckRequest;
+import io.grpc.health.v1.HealthCheckResponse.ServingStatus;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+
+/**
+ * Verify the data service reports SERVING on the standard gRPC health service
+ * (grpc.health.v1.Health) once started. The probe is a bare, unauthenticated health
+ * check, matching how the gateway /availablez endpoint checks service readiness.
+ */
+class DataHealthCheckTest {
+
+    private static final String TRAC_DYNAMIC_CONFIG = "config/trac-dynamic.yaml";
+    private static final String TRAC_DYNAMIC_RESOURCES = "config/trac-dynamic-resources.yaml";
+    private static final String TEST_TENANT = "ACME_CORP";
+
+    @RegisterExtension
+    private static final PlatformTest platform = PlatformTest.forConfig(TRAC_DYNAMIC_CONFIG)
+            .runDbDeploy(true)
+            .bootstrapTenant(TEST_TENANT, TRAC_DYNAMIC_RESOURCES)
+            .startService(TracMetadataService.class)
+            .startService(TracDataService.class)
+            .startService(TracAdminService.class)
+            .build();
+
+    @Test
+    void healthCheckReportsServing() {
+
+        var healthClient = platform.healthClientBlocking(ConfigKeys.DATA_SERVICE_KEY);
+        var request = HealthCheckRequest.newBuilder().setService("").build();
+
+        var response = healthClient.check(request);
+
+        Assertions.assertEquals(ServingStatus.SERVING, response.getStatus());
+    }
+}

--- a/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/TracMetadataService.java
+++ b/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/TracMetadataService.java
@@ -147,7 +147,8 @@ public class TracMetadataService extends TracServiceBase {
                     .executor(executor)
                     .addService(publicApi)
                     .addService(internalApi)
-                    .addService(messageProcessor);
+                    .addService(messageProcessor)
+                    .addService(getHealthService());
 
             // Apply common concerns
             this.server = commonConcerns

--- a/tracdap-services/tracdap-svc-meta/src/test/java/org/finos/tracdap/svc/meta/api/MetadataHealthCheckTest.java
+++ b/tracdap-services/tracdap-svc-meta/src/test/java/org/finos/tracdap/svc/meta/api/MetadataHealthCheckTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Fintech Open Source Foundation (FINOS) under one or
+ * more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * FINOS licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.finos.tracdap.svc.meta.api;
+
+import org.finos.tracdap.common.config.ConfigKeys;
+import org.finos.tracdap.svc.meta.TracMetadataService;
+import org.finos.tracdap.test.helpers.PlatformTest;
+
+import io.grpc.health.v1.HealthCheckRequest;
+import io.grpc.health.v1.HealthCheckResponse.ServingStatus;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+
+/**
+ * Verify the metadata service reports SERVING on the standard gRPC health service
+ * (grpc.health.v1.Health) once started. The probe is a bare, unauthenticated health
+ * check, matching how the gateway /availablez endpoint checks service readiness.
+ */
+class MetadataHealthCheckTest {
+
+    private static final String TRAC_CONFIG_UNIT = "config/trac-unit.yaml";
+
+    @RegisterExtension
+    private static final PlatformTest platform = PlatformTest.forConfig(TRAC_CONFIG_UNIT)
+            .runDbDeploy(true)
+            .startService(TracMetadataService.class)
+            .build();
+
+    @Test
+    void healthCheckReportsServing() {
+
+        var healthClient = platform.healthClientBlocking(ConfigKeys.METADATA_SERVICE_KEY);
+        var request = HealthCheckRequest.newBuilder().setService("").build();
+
+        var response = healthClient.check(request);
+
+        Assertions.assertEquals(ServingStatus.SERVING, response.getStatus());
+    }
+}

--- a/tracdap-services/tracdap-svc-orch/src/main/java/org/finos/tracdap/svc/orch/TracOrchestratorService.java
+++ b/tracdap-services/tracdap-svc-orch/src/main/java/org/finos/tracdap/svc/orch/TracOrchestratorService.java
@@ -207,7 +207,8 @@ public class TracOrchestratorService extends TracServiceBase {
 
                     // The main service
                     .addService(new TracOrchestratorApi(registry, commonConcerns))
-                    .addService(new MessageProcessor(tenantState));
+                    .addService(new MessageProcessor(tenantState))
+                    .addService(getHealthService());
 
             // Apply common concerns
             this.server = commonConcerns

--- a/tracdap-services/tracdap-svc-orch/src/test/java/org/finos/tracdap/svc/orch/api/OrchestratorHealthCheckTest.java
+++ b/tracdap-services/tracdap-svc-orch/src/test/java/org/finos/tracdap/svc/orch/api/OrchestratorHealthCheckTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Fintech Open Source Foundation (FINOS) under one or
+ * more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * FINOS licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.finos.tracdap.svc.orch.api;
+
+import org.finos.tracdap.common.config.ConfigKeys;
+import org.finos.tracdap.svc.admin.TracAdminService;
+import org.finos.tracdap.svc.data.TracDataService;
+import org.finos.tracdap.svc.meta.TracMetadataService;
+import org.finos.tracdap.svc.orch.TracOrchestratorService;
+import org.finos.tracdap.test.helpers.PlatformTest;
+
+import io.grpc.health.v1.HealthCheckRequest;
+import io.grpc.health.v1.HealthCheckResponse.ServingStatus;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.List;
+
+
+/**
+ * Verify the orchestrator service reports SERVING on the standard gRPC health service
+ * (grpc.health.v1.Health) once started. The probe is a bare, unauthenticated health
+ * check, matching how the gateway /availablez endpoint checks service readiness.
+ */
+class OrchestratorHealthCheckTest {
+
+    private static final String TRAC_CONFIG_UNIT = "config/trac-unit.yaml";
+    private static final String TRAC_TENANTS_UNIT = "config/trac-unit-tenants.yaml";
+    private static final String TEST_TENANT = "ACME_CORP";
+
+    @RegisterExtension
+    private static final PlatformTest platform = PlatformTest.forConfig(TRAC_CONFIG_UNIT, List.of(TRAC_TENANTS_UNIT))
+            .runDbDeploy(true)
+            .addTenant(TEST_TENANT)
+            .startService(TracAdminService.class)
+            .startService(TracMetadataService.class)
+            .startService(TracDataService.class)
+            .startService(TracOrchestratorService.class)
+            .build();
+
+    @Test
+    void healthCheckReportsServing() {
+
+        var healthClient = platform.healthClientBlocking(ConfigKeys.ORCHESTRATOR_SERVICE_KEY);
+        var request = HealthCheckRequest.newBuilder().setService("").build();
+
+        var response = healthClient.check(request);
+
+        Assertions.assertEquals(ServingStatus.SERVING, response.getStatus());
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `/availablez` readiness endpoint to the gateway that reports whether each configured backend service can actually serve requests — not just whether its port is open. No authentication is required to call it. Output is one line per service:

```
metadata=yes
data=yes
orchestrator=no
```

Probes run in parallel (2s per-service deadline, 5s total). Only enabled services in `PlatformConfig` are included.

## Protocol-aware readiness

A bare TCP connect only proves a port is bound, so it reported `=yes` seconds after startup while the first real request still 503'd. The probe now checks true readiness, using each service's own protocol (keyed on `ServiceInfo.hasGrpc()`):

- **gRPC services** (metadata, data, orchestrator, admin) → standard gRPC health check (`grpc.health.v1.Health/Check`); `=yes` only when `SERVING`.
- **Non-gRPC / HTTP services** (e.g. the finTRAC auth and web-server extensions) → `GET /availablez` on the service, `=yes` only when the body reports `=yes`.

Every service registers the gRPC health service via `TracServiceBase`, which reports **NOT_SERVING until `doStartup()` completes**, SERVING after, and NOT_SERVING again on shutdown. `TracServiceBase` also exposes `isServing()` — a protocol-neutral view of that same state, for HTTP services that serve their own `/availablez` (added in the finTRAC extensions). Because `doStartup()` brings up critical dependencies, a serving service can genuinely do its job.

## A validation bug this caught

Adding per-service health tests surfaced a real defect: `ValidationInterceptor` looked every method up in the TRAC API register and threw `ETracInternal` for anything not found, so a health check failed with `UNKNOWN` before reaching the health handler. Non-TRAC methods (the gRPC health service) have no TRAC schema, so they now pass through unvalidated; registered TRAC methods are validated exactly as before (confirmed by `lib-validation` + orch `JobValidationTest`).

## Implementation

- **`AvailabilityHandler`** — protocol-aware probe: `HealthGrpc` over a plaintext channel for gRPC services, JDK `HttpClient` `GET /availablez` for the rest.
- **`TracServiceBase`** (lib-common) — owns the `HealthStatusManager`, exposes `getHealthService()` and `isServing()`, drives their lifecycle in `start()`/`stop()`.
- **`TracMetadataService` / `TracDataService` / `TracOrchestratorService` / `TracAdminService`** — register `getHealthService()` (one line each).
- **`GrpcServiceRegister` / `ValidationInterceptor`** — non-TRAC methods pass through instead of being rejected.
- **`PlatformTest`** — adds `healthClientBlocking()` (bare stub, no client concerns) for faithful tests.
- **`RouteBuilder` / `InternalProxyBuilder` / `Http1Router` / `TracPlatformGateway`** — wire `/availablez` as an internal GET route, pass `PlatformConfig` through.

## New dependencies

- `io.grpc:grpc-services` → `tracdap-lib-common` (provides `HealthStatusManager` + `grpc.health.v1` stubs; exposed transitively).
- `io.grpc:grpc-netty` → `tracdap-gateway` (client transport for the probe channel).

Both at the existing `$grpc_version`.

## Companion change

The HTTP `/availablez` endpoints on the finTRAC auth and web-server services (and the auth exemptions the probe needs) are in trac-extensions PR #103, which depends on `TracServiceBase.isServing()` from this PR — so land this one first.

## Test plan

- [x] Per-service gRPC `Health/Check` tests pass (meta, data, orch, admin)
- [x] Validation still rejects invalid TRAC requests (`lib-validation` + orch `JobValidationTest`)
- [x] CI build passes
- [x] `GET /availablez` with no auth returns the plain-text service list; not-yet-ready services show `=no`
