### PR TITLE
Add priorModel support to ImportModelJob

### DIFF
--- a/tracdap-api/tracdap-metadata/src/main/proto/tracdap/metadata/job.proto
+++ b/tracdap-api/tracdap-metadata/src/main/proto/tracdap/metadata/job.proto
@@ -173,6 +173,8 @@ message ImportModelJob {
   string path = 3;
 
   repeated TagUpdate modelAttrs = 6;
+
+  optional TagSelector priorModel = 9;
 }
 
 /**

--- a/tracdap-runtime/python/src/tracdap/rt/_impl/exec/graph_builder.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_impl/exec/graph_builder.py
@@ -162,10 +162,16 @@ class GraphBuilder:
 
     def build_import_model_job(self, job_def: _meta.JobDefinition, job_push_id: NodeId) -> GraphSection:
 
-        # TRAC object ID for the new model
-        model_id = self._allocate_id(_meta.ObjectType.MODEL)
-
         import_details = job_def.importModel
+
+        # When saving as a new version, reuse the prior model's object ID with an incremented version;
+        # otherwise allocate a fresh ID (mirrors the prior-output pattern in _build_data_output)
+        if import_details.priorModel is not None:
+            prior_header = _util.get_job_mapping(import_details.priorModel, self._job_config)
+            model_id = _util.new_object_version(prior_header)
+        else:
+            model_id = self._allocate_id(_meta.ObjectType.MODEL)
+
         import_scope = self._job_key
 
         # Graph node ID for the import operation

--- a/tracdap-runtime/python/test/tracdap_test/rt/jobs/test_core_jobs.py
+++ b/tracdap-runtime/python/test/tracdap_test/rt/jobs/test_core_jobs.py
@@ -86,6 +86,35 @@ class CoreJobsTest(unittest.TestCase):
                 rt.submit_job(job_config)
                 rt.wait_for_job(job_id)
 
+    def test_import_model_job_new_version(self):
+
+        prior_model_id = util.new_object_id(meta.ObjectType.MODEL)
+        prior_model_selector = util.selector_for(prior_model_id)
+
+        job_id = util.new_object_id(meta.ObjectType.JOB)
+
+        job_def = meta.JobDefinition(
+            jobType=meta.JobType.IMPORT_MODEL,
+            importModel=meta.ImportModelJob(
+                language="python",
+                repository="unit_test_repo",
+                package="trac-example-models",
+                version=self.commit_hash,
+                entryPoint="tutorial.using_data.PnlAggregation",
+                path="examples/models/python/src",
+                priorModel=prior_model_selector))
+
+        job_config = cfg.JobConfig(job_id, job_def)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+
+            trac_runtime = runtime.TracRuntime(self.sys_config, scratch_dir=tmpdir)
+            trac_runtime.pre_start()
+
+            with trac_runtime as rt:
+                rt.submit_job(job_config)
+                rt.wait_for_job(job_id)
+
     def test_run_model_job(self):
 
         job_id, job_config = self._build_run_model_job_config()

--- a/tracdap-services/tracdap-svc-orch/src/main/java/org/finos/tracdap/svc/orch/jobs/ImportModelJob.java
+++ b/tracdap-services/tracdap-svc-orch/src/main/java/org/finos/tracdap/svc/orch/jobs/ImportModelJob.java
@@ -37,7 +37,10 @@ public class ImportModelJob implements IJobLogic {
     @Override
     public List<TagSelector> requiredMetadata(JobDefinition job) {
 
-        // No extra metadata needed for an import_model job
+        var importModel = job.getImportModel();
+
+        if (importModel.hasPriorModel())
+            return List.of(importModel.getPriorModel());
 
         return List.of();
     }
@@ -99,7 +102,10 @@ public class ImportModelJob implements IJobLogic {
     @Override
     public Map<ObjectType, Integer> expectedOutputs(JobDefinition job, MetadataBundle metadata) {
 
-        // Allocate a single ID for the new model
+        // When saving as a new version, no fresh ID is needed — the runtime will increment the prior version
+        if (job.getImportModel().hasPriorModel())
+            return Map.of();
+
         return Map.of(ObjectType.MODEL, 1);
     }
 

--- a/tracdap-services/tracdap-svc-orch/src/test/java/org/finos/tracdap/svc/orch/api/JobValidationTest.java
+++ b/tracdap-services/tracdap-svc-orch/src/test/java/org/finos/tracdap/svc/orch/api/JobValidationTest.java
@@ -166,6 +166,39 @@ public class JobValidationTest {
     }
 
     @Test
+    public void importModel_priorModelOk() {
+
+        var modelTags = List.of(TagUpdate.newBuilder()
+                .setAttrName("model_key")
+                .setValue(MetadataCodec.encodeValue("import_model_prior_model_ok"))
+                .build());
+
+        var priorModelSelector = createBasicModel(
+                SampleData.BASIC_TABLE_SCHEMA,
+                SampleData.BASIC_TABLE_SCHEMA_V2,
+                modelTags);
+
+        var job = JobDefinition.newBuilder()
+                .setJobType(JobType.IMPORT_MODEL)
+                .setImportModel(ImportModelJob.newBuilder()
+                        .setLanguage("python")
+                        .setRepository("UNIT_TEST_REPO")
+                        .setVersion("v2.0.0")
+                        .setPath("src/")
+                        .setEntryPoint("acme.models.test_model.BasicTestModel")
+                        .setPriorModel(priorModelSelector));
+
+        var request = JobRequest.newBuilder()
+                .setTenant(TEST_TENANT)
+                .setJob(job)
+                .build();
+
+        var response = orchClient.validateJob(request);
+
+        Assertions.assertEquals(JobStatusCode.VALIDATED, response.getStatusCode());
+    }
+
+    @Test
     public void importModel_missingResources() {
 
         var job = JobDefinition.newBuilder()

--- a/tracdap-services/tracdap-svc-orch/src/test/java/org/finos/tracdap/svc/orch/jobs/ImportModelTest.java
+++ b/tracdap-services/tracdap-svc-orch/src/test/java/org/finos/tracdap/svc/orch/jobs/ImportModelTest.java
@@ -17,8 +17,11 @@
 
 package org.finos.tracdap.svc.orch.jobs;
 
+import org.finos.tracdap.api.*;
 import org.finos.tracdap.common.metadata.MetadataCodec;
+import org.finos.tracdap.common.metadata.MetadataUtil;
 import org.finos.tracdap.metadata.*;
+import org.finos.tracdap.metadata.ImportModelJob;
 import org.finos.tracdap.svc.admin.TracAdminService;
 import org.finos.tracdap.svc.data.TracDataService;
 import org.finos.tracdap.svc.meta.TracMetadataService;
@@ -106,6 +109,78 @@ public abstract class ImportModelTest {
         Assertions.assertTrue(modelDef.getParametersMap().containsKey("eur_usd_rate"));
         Assertions.assertTrue(modelDef.getInputsMap().containsKey("customer_loans"));
         Assertions.assertTrue(modelDef.getOutputsMap().containsKey("profit_by_region"));
+    }
+
+    @Test
+    void importModelAsNewVersion() throws Exception {
+
+        log.info("Running IMPORT_MODEL job as new version...");
+
+        var modelVersion = GitHelpers.getCurrentCommit();
+        var modelStub = ModelDefinition.newBuilder()
+                .setLanguage("python")
+                .setRepository(useTracRepo())
+                .setPath("examples/models/python/src")
+                .setEntryPoint("tutorial.schema_files.PnlAggregationSchemas")
+                .setVersion(modelVersion)
+                .build();
+
+        var modelAttrs = List.of(TagUpdate.newBuilder()
+                .setAttrName("e2e_test_model")
+                .setValue(MetadataCodec.encodeValue("import_model_as_new_version:schema_files"))
+                .build());
+
+        var jobAttrs = List.of(TagUpdate.newBuilder()
+                .setAttrName("e2e_test_job")
+                .setValue(MetadataCodec.encodeValue("import_model_as_new_version:schema_files"))
+                .build());
+
+        // Import version 1
+        var modelV1Tag = Helpers.doModelImport(platform, TEST_TENANT, modelStub, modelAttrs, jobAttrs);
+        var modelV1Header = modelV1Tag.getHeader();
+        Assertions.assertEquals(1, modelV1Header.getObjectVersion());
+
+        // Import version 2 — same entry point, priorModel set to v1
+        var orchClient = platform.orchClientBlocking();
+        var metaClient = platform.metaClientBlocking();
+
+        var importModelV2 = ImportModelJob.newBuilder()
+                .setLanguage(modelStub.getLanguage())
+                .setRepository(modelStub.getRepository())
+                .setPath(modelStub.getPath())
+                .setEntryPoint(modelStub.getEntryPoint())
+                .setVersion(modelStub.getVersion())
+                .setPriorModel(MetadataUtil.selectorFor(modelV1Header))
+                .addAllModelAttrs(modelAttrs)
+                .build();
+
+        var jobV2Request = JobRequest.newBuilder()
+                .setTenant(TEST_TENANT)
+                .setJob(JobDefinition.newBuilder()
+                        .setJobType(JobType.IMPORT_MODEL)
+                        .setImportModel(importModelV2))
+                .addAllJobAttrs(jobAttrs)
+                .build();
+
+        var jobV2Id = Helpers.startJob(orchClient, jobV2Request).getJobId();
+        Helpers.waitForJob(orchClient, TEST_TENANT, jobV2Id);
+
+        // Read version 2 directly and verify it is a new version of the same object
+        var v2Selector = TagSelector.newBuilder()
+                .setObjectType(ObjectType.MODEL)
+                .setObjectId(modelV1Header.getObjectId())
+                .setObjectVersion(2)
+                .setLatestTag(true)
+                .build();
+
+        var modelV2Tag = metaClient.readObject(MetadataReadRequest.newBuilder()
+                .setTenant(TEST_TENANT)
+                .setSelector(v2Selector)
+                .build());
+
+        Assertions.assertEquals(modelV1Header.getObjectId(), modelV2Tag.getHeader().getObjectId());
+        Assertions.assertEquals(2, modelV2Tag.getHeader().getObjectVersion());
+        Assertions.assertEquals(modelStub.getEntryPoint(), modelV2Tag.getDefinition().getModel().getEntryPoint());
     }
 
     // Let other tests in this suite use this to import models


### PR DESCRIPTION
Allows an existing model object to be updated to a new version via an IMPORT_MODEL job, rather than always creating a new object. When the optional `priorModel` selector is set on the job definition, the orchestrator loads the prior model's metadata (instead of allocating a fresh object ID), and the runtime builds a new-version rather than a new-object.

Changes:
- job.proto: add optional TagSelector priorModel = 9 to ImportModelJob
- ImportModelJob.java (orchestrator): requiredMetadata() returns the prior selector when set; expectedOutputs() returns an empty map so no fresh ID is allocated
- graph_builder.py (runtime): branch on priorModel to call new_object_version() instead of _allocate_id()
- Tests: unit tests in JobValidationTest and test_core_jobs.py; E2E integration test in ImportModelTest