### PR TITLE
Exclude tracdap-ext-pypi from published packages

### DIFF
--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -202,7 +202,11 @@ jobs:
       - name: Build runtime package
         env:
           TRAC_PYTHON_BUILD_ISOLATION: false
-        run: python tracdap-runtime/python/build_runtime.py --target dist ext
+        # Build only the extension plugins that we publish.
+        # The "pypi" plugin (tracdap-ext-pypi) is intentionally excluded from publishing.
+        # Its source and tests remain in the repo and are still built/tested elsewhere
+        # (build.yaml, integration.yaml); it is simply not packaged for release.
+        run: python tracdap-runtime/python/build_runtime.py --target dist ext --plugin git http openai
 
       - name: Save artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

Stops `tracdap-ext-pypi` being built into release artifacts and published to PyPI, by restricting the packaging build to the `git`, `http` and `openai` extension plugins.

## Background

`tracdap-ext-pypi` is one of four model-repository extension plugins (`git`, `http`, `openai`, `pypi`) that were extracted from the core `tracdap-runtime` package into separate, optional wheels in #675. It lets the model runtime load models from a PyPI index or compatible proxy (Nexus/Artifactory).

It is a **new project name on PyPI**, and the `v0.10.0-beta.3` release's `publish_to_pypi` job failed on it because a PyPI Trusted Publisher (OIDC) cannot create a brand-new project. Rather than bootstrap a project for a plugin we don't currently want to publish, this PR removes it from the published set.

## Change

`.github/workflows/packaging.yaml` — the package build now runs:

```
build_runtime.py --target dist ext --plugin git http openai
```

(previously `--target dist ext`, which auto-discovered and built all four plugins).

## Scope / what is NOT changed

- The pypi plugin's **source and tests stay in the repo**. This only affects what gets packaged for release.
- It is **still built and tested** by `build.yaml` (`integration_ext`) and `integration.yaml` (`--target dist ext`), so test coverage is unchanged.
- No change to core `tracdap-runtime`, which does not depend on this plugin.

## Test plan

- [ ] Packaging workflow build step succeeds and produces `tracdap-runtime`, `tracdap-ext-git`, `tracdap-ext-http`, `tracdap-ext-openai` wheels — and **not** `tracdap-ext-pypi`.
- [ ] On the next release, `publish_to_pypi` no longer attempts to upload `tracdap-ext-pypi`.