### PR TITLE
Make PyPI publish idempotent (skip-existing)

### DIFF
--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -362,6 +362,11 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: tracdap_python_dist/
+          # Skip any distributions already present on PyPI rather than failing the
+          # whole upload. This makes the publish idempotent and lets a re-run (or a
+          # release that re-publishes some unchanged packages) complete instead of
+          # aborting on the first "file already exists" error.
+          skip-existing: true
 
   publish_to_npm:
 


### PR DESCRIPTION
## Summary

Adds `skip-existing: true` to the `publish_to_pypi` step in `packaging.yaml`, so the PyPI upload skips distributions that are already published instead of failing on the first `file already exists` error.

## Why

`pypa/gh-action-pypi-publish` (via twine) uploads all wheels in one go and, by default, aborts the entire step on the first conflict. This bit us on `v0.10.0-beta.3`:

- `tracdap-ext-git`, `tracdap-ext-http`, `tracdap-ext-openai` published successfully.
- The upload then failed creating the brand-new `tracdap-ext-pypi` project (PyPI Trusted Publishers cannot create a first-time project until a pending publisher is registered).
- Because twine aborts on the first failure, `tracdap-runtime` (later in the alphabetical order) never uploaded either.

With those three packages now already on PyPI, **any re-run or subsequent release would abort on the first one** before reaching the packages that still need publishing. `skip-existing: true` makes the step idempotent so it can complete.

## Change

`.github/workflows/packaging.yaml` — `publish_to_pypi` step:

```yaml
        with:
          packages-dir: tracdap_python_dist/
          skip-existing: true
```

## Test plan

- [ ] On the next release, `publish_to_pypi` skips already-published packages and uploads only the new ones, completing without error.