### PR TITLE
Bump Jackson to 2.21.4 (jackson-databind CVEs)

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -35,8 +35,8 @@ ext {
 
     // Data technologies
     arrow_version = '18.3.0'
-    jackson_version = '2.19.2'
-    jackson_databind_version = '2.19.2'
+    jackson_version = '2.21.4'
+    jackson_databind_version = '2.21.4'
 
     // Util libraries
     slf4j_version = '2.0.17'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -37,6 +37,9 @@ ext {
     arrow_version = '18.3.0'
     jackson_version = '2.21.4'
     jackson_databind_version = '2.21.4'
+    // jackson-annotations versions independently of core/databind and dropped its
+    // patch number from Jackson 2.20 onwards (see jackson-bom), so it is 2.21 not 2.21.4
+    jackson_annotations_version = '2.21'
 
     // Util libraries
     slf4j_version = '2.0.17'

--- a/tracdap-libs/tracdap-lib-data/build.gradle
+++ b/tracdap-libs/tracdap-lib-data/build.gradle
@@ -50,7 +50,7 @@ dependencies {
 
     // Jackson used for implementations of formats included as standard
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: "$jackson_version"
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: "$jackson_databind_version"
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: "$jackson_annotations_version"
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "$jackson_databind_version"
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-csv', version: "$jackson_version"
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: "$jackson_databind_version"

--- a/tracdap-libs/tracdap-lib-data/src/main/java/org/finos/tracdap/common/codec/text/consumers/JsonBigIntConsumer.java
+++ b/tracdap-libs/tracdap-lib-data/src/main/java/org/finos/tracdap/common/codec/text/consumers/JsonBigIntConsumer.java
@@ -32,7 +32,7 @@ public class JsonBigIntConsumer extends BaseJsonConsumer<BigIntVector> {
     @Override
     public boolean consumeElement(JsonParser parser) throws IOException {
 
-        long value = parser.getLongValue();
+        long value = JsonParsing.parseLong(parser);
         vector.set(currentIndex++, value);
         return true;
     }

--- a/tracdap-libs/tracdap-lib-data/src/main/java/org/finos/tracdap/common/codec/text/consumers/JsonIntConsumer.java
+++ b/tracdap-libs/tracdap-lib-data/src/main/java/org/finos/tracdap/common/codec/text/consumers/JsonIntConsumer.java
@@ -32,7 +32,7 @@ public class JsonIntConsumer extends BaseJsonConsumer<IntVector> {
     @Override
     public boolean consumeElement(JsonParser parser) throws IOException {
 
-        int value =  parser.getIntValue();
+        int value = JsonParsing.parseInt(parser);
         vector.set(currentIndex++, value);
         return true;
     }

--- a/tracdap-libs/tracdap-lib-data/src/main/java/org/finos/tracdap/common/codec/text/consumers/JsonParsing.java
+++ b/tracdap-libs/tracdap-lib-data/src/main/java/org/finos/tracdap/common/codec/text/consumers/JsonParsing.java
@@ -24,6 +24,7 @@ import org.finos.tracdap.common.metadata.MetadataCodec;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -61,6 +62,104 @@ public class JsonParsing {
         }
 
         throw new JsonParseException(parser, "Invalid boolean value", parser.currentLocation());
+    }
+
+    // Integer parsing helpers
+    //
+    // These accept both numeric tokens (VALUE_NUMBER_INT / VALUE_NUMBER_FLOAT) and string tokens.
+    // String tokens must be handled because the CSV parser presents typed columns as strings
+    // (jackson-dataformat-csv stopped emitting numeric tokens for schema NUMBER columns in 2.21).
+    // This mirrors the handling already used for floating point and decimal values below.
+
+    public static byte parseByte(JsonParser parser) throws IOException {
+
+        var token = parser.currentToken();
+
+        try {
+            if (token == VALUE_NUMBER_INT || token == JsonToken.VALUE_NUMBER_FLOAT)
+                return parser.getByteValue();
+            else if (token == JsonToken.VALUE_STRING)
+                return Byte.parseByte(parser.getValueAsString());
+            else
+                throw integerParseError(parser, token);
+        }
+        catch (NumberFormatException e) {
+            throw new JsonParseException(parser, e.getMessage(), parser.currentLocation(), e);
+        }
+    }
+
+    public static short parseShort(JsonParser parser) throws IOException {
+
+        var token = parser.currentToken();
+
+        try {
+            if (token == VALUE_NUMBER_INT || token == JsonToken.VALUE_NUMBER_FLOAT)
+                return parser.getShortValue();
+            else if (token == JsonToken.VALUE_STRING)
+                return Short.parseShort(parser.getValueAsString());
+            else
+                throw integerParseError(parser, token);
+        }
+        catch (NumberFormatException e) {
+            throw new JsonParseException(parser, e.getMessage(), parser.currentLocation(), e);
+        }
+    }
+
+    public static int parseInt(JsonParser parser) throws IOException {
+
+        var token = parser.currentToken();
+
+        try {
+            if (token == VALUE_NUMBER_INT || token == JsonToken.VALUE_NUMBER_FLOAT)
+                return parser.getIntValue();
+            else if (token == JsonToken.VALUE_STRING)
+                return Integer.parseInt(parser.getValueAsString());
+            else
+                throw integerParseError(parser, token);
+        }
+        catch (NumberFormatException e) {
+            throw new JsonParseException(parser, e.getMessage(), parser.currentLocation(), e);
+        }
+    }
+
+    public static long parseLong(JsonParser parser) throws IOException {
+
+        var token = parser.currentToken();
+
+        try {
+            if (token == VALUE_NUMBER_INT || token == JsonToken.VALUE_NUMBER_FLOAT)
+                return parser.getLongValue();
+            else if (token == JsonToken.VALUE_STRING)
+                return Long.parseLong(parser.getValueAsString());
+            else
+                throw integerParseError(parser, token);
+        }
+        catch (NumberFormatException e) {
+            throw new JsonParseException(parser, e.getMessage(), parser.currentLocation(), e);
+        }
+    }
+
+    public static BigInteger parseBigInteger(JsonParser parser) throws IOException {
+
+        var token = parser.currentToken();
+
+        try {
+            if (token == VALUE_NUMBER_INT || token == JsonToken.VALUE_NUMBER_FLOAT)
+                return parser.getBigIntegerValue();
+            else if (token == JsonToken.VALUE_STRING)
+                return new BigInteger(parser.getValueAsString());
+            else
+                throw integerParseError(parser, token);
+        }
+        catch (NumberFormatException e) {
+            throw new JsonParseException(parser, e.getMessage(), parser.currentLocation(), e);
+        }
+    }
+
+    private static JsonParseException integerParseError(JsonParser parser, JsonToken token) {
+
+        var msg = "Parsing failed: Expected an integer value, got [" + token.name() + "]";
+        return new JsonParseException(parser, msg, parser.currentLocation());
     }
 
     public static float parseFloat4(JsonParser parser) throws IOException {

--- a/tracdap-libs/tracdap-lib-data/src/main/java/org/finos/tracdap/common/codec/text/consumers/JsonSmallIntConsumer.java
+++ b/tracdap-libs/tracdap-lib-data/src/main/java/org/finos/tracdap/common/codec/text/consumers/JsonSmallIntConsumer.java
@@ -32,7 +32,7 @@ public class JsonSmallIntConsumer extends BaseJsonConsumer<SmallIntVector> {
     @Override
     public boolean consumeElement(JsonParser parser) throws IOException {
 
-        short value = parser.getShortValue();
+        short value = JsonParsing.parseShort(parser);
         vector.set(currentIndex++, value);
         return true;
     }

--- a/tracdap-libs/tracdap-lib-data/src/main/java/org/finos/tracdap/common/codec/text/consumers/JsonTinyIntConsumer.java
+++ b/tracdap-libs/tracdap-lib-data/src/main/java/org/finos/tracdap/common/codec/text/consumers/JsonTinyIntConsumer.java
@@ -32,7 +32,7 @@ public class JsonTinyIntConsumer extends BaseJsonConsumer<TinyIntVector> {
     @Override
     public boolean consumeElement(JsonParser parser) throws IOException {
 
-        byte value = parser.getByteValue();
+        byte value = JsonParsing.parseByte(parser);
         vector.set(currentIndex++, value);
         return true;
     }

--- a/tracdap-libs/tracdap-lib-data/src/main/java/org/finos/tracdap/common/codec/text/consumers/JsonUInt1Consumer.java
+++ b/tracdap-libs/tracdap-lib-data/src/main/java/org/finos/tracdap/common/codec/text/consumers/JsonUInt1Consumer.java
@@ -33,7 +33,7 @@ public class JsonUInt1Consumer extends BaseJsonConsumer<UInt1Vector> {
     @Override
     public boolean consumeElement(JsonParser parser) throws IOException {
 
-        int value = parser.getIntValue();
+        int value = JsonParsing.parseInt(parser);
 
         if (value < 0 || value > 0xFF) {
             throw new EDataCorruption("Value out of range for UINT1: " + value);

--- a/tracdap-libs/tracdap-lib-data/src/main/java/org/finos/tracdap/common/codec/text/consumers/JsonUInt2Consumer.java
+++ b/tracdap-libs/tracdap-lib-data/src/main/java/org/finos/tracdap/common/codec/text/consumers/JsonUInt2Consumer.java
@@ -33,7 +33,7 @@ public class JsonUInt2Consumer extends BaseJsonConsumer<UInt2Vector> {
     @Override
     public boolean consumeElement(JsonParser parser) throws IOException {
 
-        int value = parser.getIntValue();
+        int value = JsonParsing.parseInt(parser);
 
         if (value < 0 || value > 0xFFFF) {
             throw new EDataCorruption("Value out of range for UINT2: " + value);

--- a/tracdap-libs/tracdap-lib-data/src/main/java/org/finos/tracdap/common/codec/text/consumers/JsonUInt4Consumer.java
+++ b/tracdap-libs/tracdap-lib-data/src/main/java/org/finos/tracdap/common/codec/text/consumers/JsonUInt4Consumer.java
@@ -33,7 +33,7 @@ public class JsonUInt4Consumer extends BaseJsonConsumer<UInt4Vector> {
     @Override
     public boolean consumeElement(JsonParser parser) throws IOException {
 
-        long value = parser.getLongValue();
+        long value = JsonParsing.parseLong(parser);
 
         if (value < 0 || value > 0xFFFFFFFFL) {
             throw new EDataCorruption("Value out of range for UINT4: " + value);

--- a/tracdap-libs/tracdap-lib-data/src/main/java/org/finos/tracdap/common/codec/text/consumers/JsonUInt8Consumer.java
+++ b/tracdap-libs/tracdap-lib-data/src/main/java/org/finos/tracdap/common/codec/text/consumers/JsonUInt8Consumer.java
@@ -37,7 +37,7 @@ public class JsonUInt8Consumer extends BaseJsonConsumer<UInt8Vector> {
     @Override
     public boolean consumeElement(JsonParser parser) throws IOException {
 
-        BigInteger value = parser.getBigIntegerValue();
+        BigInteger value = JsonParsing.parseBigInteger(parser);
 
         if (value.compareTo(MIN_VALUE) < 0 || value.compareTo(MAX_UINT64) > 0) {
             throw new EDataCorruption("Value out of range for UINT8: " + value);

--- a/tracdap-libs/tracdap-lib-test/build.gradle
+++ b/tracdap-libs/tracdap-lib-test/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     // Jackson uses runtime class resolution
     // Make sure classes needed for config parsing are always on the runtime classpath for tests
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: "$jackson_version"
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: "$jackson_databind_version"
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: "$jackson_annotations_version"
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "$jackson_databind_version"
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: "$jackson_version"
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-csv', version: "$jackson_version"

--- a/tracdap-services/tracdap-svc-orch/build.gradle
+++ b/tracdap-services/tracdap-svc-orch/build.gradle
@@ -73,7 +73,7 @@ dependencies {
     }
 
     // gRPC testing requires Jackson annotations
-    testImplementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: "$jackson_databind_version"
+    testImplementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: "$jackson_annotations_version"
 }
 
 // Add any plugin dependencies enabled at build time


### PR DESCRIPTION
## Summary

Bumps Jackson from 2.19.2 to 2.21.4 to clear three `jackson-databind` vulnerabilities flagged by `platform_compliance`, with follow-up changes to keep the build resolving and to preserve CSV/text parsing behaviour under the new Jackson.

## Vulnerabilities

`jackson-databind@2.19.2` is affected by:

| CVE | Issue |
|---|---|
| CVE-2026-54512 | PolymorphicTypeValidator bypass via generic type parameters |
| CVE-2026-54513 | Array subtype allowlist bypass in BasicPolymorphicTypeValidator |
| CVE-2026-54514 | SSRF — eager DNS resolution on `InetSocketAddress` deserialization |

All three are patched in **2.21.4** on the Jackson 2.x line. These are newly published advisories against an existing pinned dependency, so `platform_compliance` started failing on current branches (not specific to any one PR).

## Changes

**1. Bump Jackson to 2.21.4** (`gradle/versions.gradle`)
Bump both `jackson_version` and `jackson_databind_version` `2.19.2 → 2.21.4`. The two vars drive the `jackson-bom` plus the individual core/databind/dataformat pins.

**2. Pin `jackson-annotations` to 2.21** (`gradle/versions.gradle` + three build files)
From Jackson 2.20 onwards the annotations module dropped its patch number (per the jackson-bom), so there is no `jackson-annotations:2.21.4` — only `2.21`. Three build files pinned annotations explicitly to `$jackson_databind_version`, which broke dependency resolution after the bump. Added a dedicated `jackson_annotations_version = '2.21'` and used it in `tracdap-lib-test`, `tracdap-lib-data` and `tracdap-svc-orch`.

**3. Preserve integer parsing behaviour in the CSV/text decoder** (`tracdap-lib-data` text consumers)
Jackson 2.21's `jackson-dataformat-csv` no longer emits numeric tokens for schema `NUMBER` columns — it presents them as **string** (`VALUE_STRING`) tokens. The integer text consumers called strict numeric accessors directly (`getIntValue`/`getLongValue`/`getShortValue`/`getByteValue`/`getBigIntegerValue`), which throw "not numeric" on a string token, breaking CSV decoding of integer columns (`RestDataApiTest` CSV round-trips failed with `DATA_LOSS`).

Added integer parse helpers in `JsonParsing` (`parseByte/parseShort/parseInt/parseLong/parseBigInteger`) that accept both numeric and string tokens — mirroring the existing float and decimal helpers, which already tolerated string tokens — and routed the integer consumers through them (`Int`, `BigInt`, `SmallInt`, `TinyInt`, `UInt1/2/4/8`). Floats, decimals and booleans already handled string tokens, so only the integer path needed changing.

## Verification

- `tracdap-lib-data` test suite: **669/669 pass** (covers JSON + CSV round-trips for all numeric types — confirms the shared JSON path is unaffected)
- `tracdap-gateway` test suite: **28/28 pass** (was 4 failing on the `RestDataApiTest` CSV cases)

## Test plan

- [ ] `platform_compliance` passes (no jackson-databind findings)
- [ ] `platform_build` passes (build resolves; CSV/text codec behaviour preserved)
- [ ] Integration / end-to-end pass