### PR TITLE
Publish to Sonatype Central Portal instead of decommissioned OSSRH

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,8 +122,16 @@ licenseReport {
 nexusPublishing {
     repositories {
 
-        // Publishing via Sonatype OSSRH -> Maven Central
-        sonatype()
+        // Publishing via the Sonatype Central Portal.
+        // The legacy OSSRH service (oss.sonatype.org) was decommissioned on 2025-06-30, so the
+        // default sonatype() endpoints no longer work. These URLs use the OSSRH Staging API
+        // compatibility service, which translates the Nexus 2 API used by this plugin to the
+        // Central Portal. Note: credentials must be a Central Portal user token (an old OSSRH
+        // token returns 401) - see https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/
+        sonatype {
+            nexusUrl = uri("https://ossrh-staging-api.central.sonatype.com/service/local/")
+            snapshotRepositoryUrl = uri("https://central.sonatype.com/repository/maven-snapshots/")
+        }
 
     }
 }


### PR DESCRIPTION
## Summary

Migrates the Maven Central publishing config off the decommissioned legacy OSSRH service and onto the Sonatype Central Portal, via the OSSRH Staging API compatibility endpoint. This fixes the `platform_packages` publish failure seen on the `v0.10.0-beta.3` release.

## Background

The `platform_packages` job's "Publish to Maven Central" step failed on the beta.3 release:

```
:initializeSonatypeStagingRepository FAILED
> Failed to load staging profiles, server at https://oss.sonatype.org/service/local/ responded with status code 402
```

Sonatype's legacy OSSRH service (`oss.sonatype.org`) [reached end-of-life on 2025-06-30](https://central.sonatype.org/pages/ossrh-eol/) and was decommissioned; all namespaces were migrated to the Central Publisher Portal. The build used a bare `sonatype()` block, which defaults to the now-dead OSSRH endpoints — so the Maven Central publish fails on every release (the JAR build and signing succeed; only the staging/publish step fails). This is not transient and will recur on every release until fixed.

The JVM artifacts publish is independent of the PyPI and npm publishes, which were unaffected.

## Change

`build.gradle` — point the `gradle-nexus.publish-plugin` at the [OSSRH Staging API compatibility service](https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/), which translates the Nexus 2 API the plugin speaks to the Central Portal:

```groovy
sonatype {
    nexusUrl = uri("https://ossrh-staging-api.central.sonatype.com/service/local/")
    snapshotRepositoryUrl = uri("https://central.sonatype.com/repository/maven-snapshots/")
}
```

This is the lowest-disruption migration path: it keeps the existing publish plugin, tasks and workflow steps; only the endpoints change.

## ⚠️ Required before this can publish: credential update

This change is necessary but **not sufficient on its own**. The Central Portal requires a **Central Portal user token**, generated at `central.sonatype.com`. Publishing with an old OSSRH token returns `401`. The `MAVEN_USERNAME` / `MAVEN_PASSWORD` GitHub secrets must be regenerated as a Portal user token before the next release. That is an account/secrets action outside this PR.

## Verification

- Gradle configuration evaluates cleanly with the new endpoints and the Sonatype publishing tasks still register (`./gradlew tasks --group=publishing`).
- End-to-end publish can only be verified by an actual release, since the publish step runs on the `release: published` event and needs the (updated) credentials.

## Test plan

- [ ] CI configuration / build checks pass on this PR
- [ ] Portal user token in place in GitHub secrets (prerequisite, separate)
- [ ] Next release's `platform_packages` Maven publish succeeds