### PR TITLE
Suppress jackson-databind CVE-2026-54515 (no fixed release available)

### DIFF
--- a/dev/compliance/owasp-false-positives.xml
+++ b/dev/compliance/owasp-false-positives.xml
@@ -342,4 +342,14 @@
         <cve>CVE-2026-0994</cve>
     </suppress>
 
+    <!-- CVE-2026-54515: jackson-databind case-insensitive deserialization can bypass per-property -->
+    <!-- @JsonIgnoreProperties. Fixed in 2.21.5, which is not yet published to Maven Central; the next -->
+    <!-- available release (2.22.0) is also affected per NVD. TRAC does not use @JsonIgnoreProperties -->
+    <!-- or polymorphic / default typing, so this is not reachable in our usage. -->
+    <!-- Time-boxed: remove this suppression and bump jackson-databind to 2.21.5+ once it is released. -->
+    <suppress until="2026-08-15Z">
+        <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
+        <cve>CVE-2026-54515</cve>
+    </suppress>
+
 </suppressions>


### PR DESCRIPTION
## Summary

Adds a time-boxed OWASP suppression for jackson-databind CVE-2026-54515, which is currently failing `platform_compliance` on `main` (and therefore on PR #698 and any other branch). There is no fixed Jackson 2.x release available to bump to yet, so a suppression is the only way to unblock the compliance gate for now.

> Note: this PR originally bumped Jackson to 2.22.0. That was dropped — see "Why not just bump?" below. The branch now contains only the suppression; Jackson stays at 2.21.4.

## Vulnerability

CVE-2026-54515 — *jackson-databind case-insensitive deserialization can bypass per-property `@JsonIgnoreProperties`*.

## Why not just bump?

The advisory lists the fix as **2.21.5**, but that has **not been published to Maven Central**. The other "patched" versions are unavailable or unsuitable:

| Version | Status |
|---|---|
| `2.18.9` | not on Maven Central (404) |
| `2.21.5` | not on Maven Central (404) |
| `2.22.0` | **also affected** — NVD lists an exact-version CPE for `jackson-databind:2.22.0` (it was branched before the fix) |
| `3.1.4` | Jackson 3.x — major upgrade, not a quick fix |

So there is no fixed 2.x release to move to right now.

## Why a suppression is justified

CVE-2026-54515 requires the use of per-property `@JsonIgnoreProperties` with case-insensitive deserialization. TRAC's source uses **none** of `@JsonIgnoreProperties`, `@JsonTypeInfo`, `@JsonSubTypes`, `activateDefaultTyping` or `PolymorphicTypeValidator`, so the vulnerable code path is not reachable in our usage. This follows the existing "no fix available" convention already documented in `dev/compliance/owasp-false-positives.xml`.

## Change

`dev/compliance/owasp-false-positives.xml` — add a suppression for `CVE-2026-54515` scoped to `jackson-databind`, with `until="2026-08-15Z"` so it auto-expires and forces a revisit. The accompanying comment records that it should be removed and Jackson bumped to 2.21.5+ once that release is available.

## Test plan

- [ ] `platform_compliance` passes
- [ ] Once jackson-databind 2.21.5 (or a fixed 2.x) is on Maven Central: remove the suppression and bump