### PR TITLE
Fix import-model version validator and add prior-must-be-latest guard

### DIFF
--- a/tracdap-libs/tracdap-lib-test/src/main/java/org/finos/tracdap/test/helpers/GitHelpers.java
+++ b/tracdap-libs/tracdap-lib-test/src/main/java/org/finos/tracdap/test/helpers/GitHelpers.java
@@ -39,4 +39,22 @@ public class GitHelpers {
             proc.destroy();
         }
     }
+
+    public static String getPriorCommit() throws Exception {
+
+        var pb = new ProcessBuilder();
+        pb.command("git", "rev-parse", "HEAD~1");
+
+        var proc = pb.start();
+
+        try {
+            proc.waitFor(10, TimeUnit.SECONDS);
+
+            var procResult = proc.getInputStream().readAllBytes();
+            return new String(procResult, StandardCharsets.UTF_8).strip();
+        }
+        finally {
+            proc.destroy();
+        }
+    }
 }

--- a/tracdap-libs/tracdap-lib-test/src/main/java/org/finos/tracdap/test/meta/SampleMetadata.java
+++ b/tracdap-libs/tracdap-lib-test/src/main/java/org/finos/tracdap/test/meta/SampleMetadata.java
@@ -410,6 +410,7 @@ public class SampleMetadata {
         return origDef.toBuilder()
                 .setModel(origDef.getModel()
                 .toBuilder()
+                .setVersion("trac-test-repo-1.2.4-RC1")
                 .putParameters("param3", ModelParameter.newBuilder().setParamType(TypeSystem.descriptor(BasicType.DATE)).build()))
                 .build();
     }

--- a/tracdap-libs/tracdap-lib-validation/src/main/java/org/finos/tracdap/common/validation/version/CommonValidators.java
+++ b/tracdap-libs/tracdap-lib-validation/src/main/java/org/finos/tracdap/common/validation/version/CommonValidators.java
@@ -71,6 +71,22 @@ public class CommonValidators {
         return ctx;
     }
 
+    public static ValidationContext mustChange(Object current, Object prior, ValidationContext ctx) {
+
+        var equal = Objects.equals(prior, current);
+
+        if (equal) {
+
+            var err = String.format(
+                    "Value of [%s] must change between versions: prior = [%s], new = [%s]",
+                    ctx.fieldName(), displayValue(prior), displayValue(current));
+
+            return ctx.error(err);
+        }
+
+        return ctx;
+    }
+
     public static ValidationContext equalOrGreater(Integer current, Integer prior, ValidationContext ctx) {
 
         if (current < prior) {

--- a/tracdap-libs/tracdap-lib-validation/src/main/java/org/finos/tracdap/common/validation/version/ModelVersionValidator.java
+++ b/tracdap-libs/tracdap-lib-validation/src/main/java/org/finos/tracdap/common/validation/version/ModelVersionValidator.java
@@ -82,7 +82,7 @@ public class ModelVersionValidator {
                 .pop();
 
         ctx = ctx.push(MD_VERSION)
-                .apply(CommonValidators::exactMatch)
+                .apply(CommonValidators::mustChange)
                 .pop();
 
         ctx = ctx.push(MD_PATH)

--- a/tracdap-libs/tracdap-lib-validation/src/test/java/org/finos/tracdap/common/validation/version/ModelVersionValidationTest.java
+++ b/tracdap-libs/tracdap-lib-validation/src/test/java/org/finos/tracdap/common/validation/version/ModelVersionValidationTest.java
@@ -71,12 +71,37 @@ class ModelVersionValidationTest extends BaseValidatorTest {
     }
 
     @Test
+    void versionChangesCommit() {
+
+        var modelV1 = SampleMetadata.dummyModelDef();
+
+        var modelV2 = modelV1.toBuilder()
+                .setModel(modelV1.getModel().toBuilder()
+                .setVersion("trac-test-repo-1.2.4-RC1"))
+                .build();
+
+        expectValidVersion(modelV2, modelV1);
+    }
+
+    @Test
+    void versionSameCommit() {
+
+        var modelV1 = SampleMetadata.dummyModelDef();
+
+        // Version field unchanged — importing the same commit as a new version is not allowed
+        var modelV2 = modelV1.toBuilder().build();
+
+        expectInvalidVersion(modelV2, modelV1);
+    }
+
+    @Test
     void versionAddsParameter() {
 
         var modelV1 = SampleMetadata.dummyModelDef();
 
         var modelV2 = modelV1.toBuilder()
                 .setModel(modelV1.getModel().toBuilder()
+                .setVersion("trac-test-repo-1.2.4-RC1")
                 .putParameters("a_new_parameter", ModelParameter.newBuilder()
                         .setParamType(TypeSystem.descriptor(BasicType.BOOLEAN))
                         .setLabel("A new parameter not in the prior version")
@@ -98,6 +123,7 @@ class ModelVersionValidationTest extends BaseValidatorTest {
 
         var modelV2 = modelV1.toBuilder()
                 .setModel(modelV1.getModel().toBuilder()
+                .setVersion("trac-test-repo-1.2.4-RC1")
                 .putParameters("param1", param1V2))
                 .build();
 
@@ -120,6 +146,7 @@ class ModelVersionValidationTest extends BaseValidatorTest {
 
         var modelV2 = modelV1.toBuilder()
                 .setModel(modelV1.getModel().toBuilder()
+                .setVersion("trac-test-repo-1.2.4-RC1")
                 .putInputs("an_extra_input", newInput))
                 .build();
 
@@ -142,6 +169,7 @@ class ModelVersionValidationTest extends BaseValidatorTest {
 
         var modelV2 = modelV1.toBuilder()
                 .setModel(modelV1.getModel().toBuilder()
+                .setVersion("trac-test-repo-1.2.4-RC1")
                 .putInputs("input1", input1V2))
                 .build();
 
@@ -164,6 +192,7 @@ class ModelVersionValidationTest extends BaseValidatorTest {
 
         var modelV2 = modelV1.toBuilder()
                 .setModel(modelV1.getModel().toBuilder()
+                .setVersion("trac-test-repo-1.2.4-RC1")
                 .putInputs("input1", input1V2))
                 .build();
 
@@ -186,6 +215,7 @@ class ModelVersionValidationTest extends BaseValidatorTest {
 
         var modelV2 = modelV1.toBuilder()
                 .setModel(modelV1.getModel().toBuilder()
+                .setVersion("trac-test-repo-1.2.4-RC1")
                 .putOutputs("an_extra_output", newOutput))
                 .build();
 
@@ -208,6 +238,7 @@ class ModelVersionValidationTest extends BaseValidatorTest {
 
         var modelV2 = modelV1.toBuilder()
                 .setModel(modelV1.getModel().toBuilder()
+                .setVersion("trac-test-repo-1.2.4-RC1")
                 .putOutputs("output1", output1V2))
                 .build();
 
@@ -230,6 +261,7 @@ class ModelVersionValidationTest extends BaseValidatorTest {
 
         var modelV2 = modelV1.toBuilder()
                 .setModel(modelV1.getModel().toBuilder()
+                .setVersion("trac-test-repo-1.2.4-RC1")
                 .putOutputs("output1", output1V2))
                 .build();
 

--- a/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/services/MetadataWriteService.java
+++ b/tracdap-services/tracdap-svc-meta/src/main/java/org/finos/tracdap/svc/meta/services/MetadataWriteService.java
@@ -28,6 +28,7 @@ import org.finos.tracdap.common.metadata.UuidFactory;
 import org.finos.tracdap.common.metadata.store.IMetadataStore;
 import org.finos.tracdap.common.metadata.store.MetadataBatchUpdate;
 import org.finos.tracdap.common.metadata.tag.ObjectUpdateLogic;
+import org.finos.tracdap.common.exception.EVersionValidation;
 import org.finos.tracdap.common.validation.Validator;
 import org.finos.tracdap.metadata.*;
 
@@ -228,6 +229,16 @@ public class MetadataWriteService {
 
             // TODO: Apply the version validator in bulk across a batch of updates
             // Will need an update in the validator, currently 50 object updates -> 50 separate validation passes
+
+            if (!priorVersion.getHeader().getIsLatestObject()) {
+
+                var err = String.format(
+                        "Cannot create a new version from a superseded object: prior version [%d] is not the latest version of [%s]",
+                        priorVersion.getHeader().getObjectVersion(),
+                        priorVersion.getHeader().getObjectId());
+
+                throw new EVersionValidation(err);
+            }
 
             validator.validateVersion(
                     request.getDefinition(),

--- a/tracdap-services/tracdap-svc-meta/src/test/java/org/finos/tracdap/svc/meta/api/MetadataWriteApiTest.java
+++ b/tracdap-services/tracdap-svc-meta/src/test/java/org/finos/tracdap/svc/meta/api/MetadataWriteApiTest.java
@@ -786,7 +786,8 @@ abstract class MetadataWriteApiTest {
         var CHANGING_ATTRS = List.of(
                 "trac_schema_field_count",
                 "trac_file_name",
-                "trac_file_size");
+                "trac_file_size",
+                "trac_model_version");
 
         for (var attr : expectedTag.getAttrsMap().keySet()) {
 
@@ -837,6 +838,37 @@ abstract class MetadataWriteApiTest {
     @Test
     void updateObject_badVersionIncrememnt() {
 
+        // Attempt to create a new version from a prior that is no longer the latest.
+        // After v1 → v2 succeeds, v1 is superseded (isLatestObject = false).
+        // Trying to write v3 using v1 as the prior must be rejected before the store is touched.
+
+        var v1SavedTag = updateObject_prepareV1(ObjectType.CUSTOM);
+        var v1Selector = selectorForTag(v1SavedTag);
+
+        var v2Obj = SampleMetadata.dummyVersionForType(v1SavedTag.getDefinition());
+        var v2WriteRequest = MetadataWriteRequest.newBuilder()
+                .setTenant(TEST_TENANT)
+                .setObjectType(ObjectType.CUSTOM)
+                .setPriorVersion(v1Selector)
+                .setDefinition(v2Obj)
+                .build();
+
+        assertDoesNotThrow(() -> internalApi.updateObject(v2WriteRequest));
+
+        // v1 is now superseded — any attempt to use it as a prior must be rejected
+        var v3Obj = SampleMetadata.dummyVersionForType(v2Obj);
+        var v3FromV1Request = MetadataWriteRequest.newBuilder()
+                .setTenant(TEST_TENANT)
+                .setObjectType(ObjectType.CUSTOM)
+                .setPriorVersion(v1Selector)
+                .setDefinition(v3Obj)
+                .build();
+
+        var error = assertThrows(StatusRuntimeException.class, () -> internalApi.updateObject(v3FromV1Request));
+        assertEquals(Status.Code.FAILED_PRECONDITION, error.getStatus().getCode());
+
+        var error2 = assertThrows(StatusRuntimeException.class, () -> publicApi.updateObject(v3FromV1Request));
+        assertEquals(Status.Code.FAILED_PRECONDITION, error2.getStatus().getCode());
     }
 
     // For the remaining corner and error cases around versions, we use the CUSTOM object type
@@ -1037,13 +1069,15 @@ abstract class MetadataWriteApiTest {
 
         assertDoesNotThrow(() -> internalApi.updateObject(v2WriteRequest));
 
-        // Trying to create V2 a second time is an error
+        // Trying to create V2 a second time is an error — v1 is now superseded so the
+        // prior-must-be-latest guard fires before the store is touched (FAILED_PRECONDITION,
+        // not ALREADY_EXISTS from the store)
 
         var error = assertThrows(StatusRuntimeException.class, () -> internalApi.updateObject(v2WriteRequest));
-        assertEquals(Status.Code.ALREADY_EXISTS, error.getStatus().getCode());
+        assertEquals(Status.Code.FAILED_PRECONDITION, error.getStatus().getCode());
 
         var error2 = assertThrows(StatusRuntimeException.class, () -> publicApi.updateObject(v2WriteRequest));
-        assertEquals(Status.Code.ALREADY_EXISTS, error2.getStatus().getCode());
+        assertEquals(Status.Code.FAILED_PRECONDITION, error2.getStatus().getCode());
     }
 
     @Test

--- a/tracdap-services/tracdap-svc-orch/src/test/java/org/finos/tracdap/svc/orch/jobs/ImportModelTest.java
+++ b/tracdap-services/tracdap-svc-orch/src/test/java/org/finos/tracdap/svc/orch/jobs/ImportModelTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.function.Executable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -135,12 +136,14 @@ public abstract class ImportModelTest {
                 .setValue(MetadataCodec.encodeValue("import_model_as_new_version:schema_files"))
                 .build());
 
-        // Import version 1
-        var modelV1Tag = Helpers.doModelImport(platform, TEST_TENANT, modelStub, modelAttrs, jobAttrs);
+        // Import version 1 — use the prior commit so v1 and v2 have distinct commit SHAs
+        var priorCommit = GitHelpers.getPriorCommit();
+        var modelV1Stub = modelStub.toBuilder().setVersion(priorCommit).build();
+        var modelV1Tag = Helpers.doModelImport(platform, TEST_TENANT, modelV1Stub, modelAttrs, jobAttrs);
         var modelV1Header = modelV1Tag.getHeader();
         Assertions.assertEquals(1, modelV1Header.getObjectVersion());
 
-        // Import version 2 — same entry point, priorModel set to v1
+        // Import version 2 — same entry point but current commit, priorModel set to v1
         var orchClient = platform.orchClientBlocking();
         var metaClient = platform.metaClientBlocking();
 
@@ -149,7 +152,7 @@ public abstract class ImportModelTest {
                 .setRepository(modelStub.getRepository())
                 .setPath(modelStub.getPath())
                 .setEntryPoint(modelStub.getEntryPoint())
-                .setVersion(modelStub.getVersion())
+                .setVersion(modelStub.getVersion())  // current commit — differs from v1
                 .setPriorModel(MetadataUtil.selectorFor(modelV1Header))
                 .addAllModelAttrs(modelAttrs)
                 .build();
@@ -181,6 +184,140 @@ public abstract class ImportModelTest {
         Assertions.assertEquals(modelV1Header.getObjectId(), modelV2Tag.getHeader().getObjectId());
         Assertions.assertEquals(2, modelV2Tag.getHeader().getObjectVersion());
         Assertions.assertEquals(modelStub.getEntryPoint(), modelV2Tag.getDefinition().getModel().getEntryPoint());
+    }
+
+    @Test
+    void importModelSameCommitRejected() throws Exception {
+
+        log.info("Running IMPORT_MODEL new-version job with same commit — expecting failure...");
+
+        var modelVersion = GitHelpers.getCurrentCommit();
+        var modelStub = ModelDefinition.newBuilder()
+                .setLanguage("python")
+                .setRepository(useTracRepo())
+                .setPath("examples/models/python/src")
+                .setEntryPoint("tutorial.schema_files.PnlAggregationSchemas")
+                .setVersion(modelVersion)
+                .build();
+
+        var modelAttrs = List.of(TagUpdate.newBuilder()
+                .setAttrName("e2e_test_model")
+                .setValue(MetadataCodec.encodeValue("import_model_same_commit_rejected:schema_files"))
+                .build());
+
+        var jobAttrs = List.of(TagUpdate.newBuilder()
+                .setAttrName("e2e_test_job")
+                .setValue(MetadataCodec.encodeValue("import_model_same_commit_rejected:schema_files"))
+                .build());
+
+        // Import version 1
+        var modelV1Tag = Helpers.doModelImport(platform, TEST_TENANT, modelStub, modelAttrs, jobAttrs);
+        var modelV1Header = modelV1Tag.getHeader();
+
+        // Attempt version 2 with the same commit SHA — must be rejected
+        var orchClient = platform.orchClientBlocking();
+
+        var importModelV2 = ImportModelJob.newBuilder()
+                .setLanguage(modelStub.getLanguage())
+                .setRepository(modelStub.getRepository())
+                .setPath(modelStub.getPath())
+                .setEntryPoint(modelStub.getEntryPoint())
+                .setVersion(modelStub.getVersion())  // same commit as v1
+                .setPriorModel(MetadataUtil.selectorFor(modelV1Header))
+                .addAllModelAttrs(modelAttrs)
+                .build();
+
+        var jobV2Request = JobRequest.newBuilder()
+                .setTenant(TEST_TENANT)
+                .setJob(JobDefinition.newBuilder()
+                        .setJobType(JobType.IMPORT_MODEL)
+                        .setImportModel(importModelV2))
+                .addAllJobAttrs(jobAttrs)
+                .build();
+
+        var jobV2Id = Helpers.startJob(orchClient, jobV2Request).getJobId();
+
+        Executable waitForV2 = () -> Helpers.waitForJob(orchClient, TEST_TENANT, jobV2Id);
+        Assertions.assertThrows(RuntimeException.class, waitForV2);
+    }
+
+    @Test
+    void importModelNonLatestPriorRejected() throws Exception {
+
+        log.info("Running IMPORT_MODEL new-version job with non-latest prior — expecting failure...");
+
+        var modelVersion = GitHelpers.getCurrentCommit();
+        var priorCommit = GitHelpers.getPriorCommit();
+
+        var modelAttrs = List.of(TagUpdate.newBuilder()
+                .setAttrName("e2e_test_model")
+                .setValue(MetadataCodec.encodeValue("import_model_non_latest_prior_rejected:schema_files"))
+                .build());
+
+        var jobAttrs = List.of(TagUpdate.newBuilder()
+                .setAttrName("e2e_test_job")
+                .setValue(MetadataCodec.encodeValue("import_model_non_latest_prior_rejected:schema_files"))
+                .build());
+
+        // Import version 1
+        var modelV1Stub = ModelDefinition.newBuilder()
+                .setLanguage("python")
+                .setRepository(useTracRepo())
+                .setPath("examples/models/python/src")
+                .setEntryPoint("tutorial.schema_files.PnlAggregationSchemas")
+                .setVersion(priorCommit)
+                .build();
+
+        var modelV1Tag = Helpers.doModelImport(platform, TEST_TENANT, modelV1Stub, modelAttrs, jobAttrs);
+        var modelV1Header = modelV1Tag.getHeader();
+
+        // Import version 2 successfully (priorModel = v1)
+        var orchClient = platform.orchClientBlocking();
+
+        var importModelV2 = ImportModelJob.newBuilder()
+                .setLanguage(modelV1Stub.getLanguage())
+                .setRepository(modelV1Stub.getRepository())
+                .setPath(modelV1Stub.getPath())
+                .setEntryPoint(modelV1Stub.getEntryPoint())
+                .setVersion(modelVersion)
+                .setPriorModel(MetadataUtil.selectorFor(modelV1Header))
+                .addAllModelAttrs(modelAttrs)
+                .build();
+
+        var jobV2Request = JobRequest.newBuilder()
+                .setTenant(TEST_TENANT)
+                .setJob(JobDefinition.newBuilder()
+                        .setJobType(JobType.IMPORT_MODEL)
+                        .setImportModel(importModelV2))
+                .addAllJobAttrs(jobAttrs)
+                .build();
+
+        var jobV2Id = Helpers.startJob(orchClient, jobV2Request).getJobId();
+        Helpers.waitForJob(orchClient, TEST_TENANT, jobV2Id);
+
+        // Now attempt version 3 using v1 (not v2, the latest) as priorModel — must be rejected
+        var importModelV3FromV1 = ImportModelJob.newBuilder()
+                .setLanguage(modelV1Stub.getLanguage())
+                .setRepository(modelV1Stub.getRepository())
+                .setPath(modelV1Stub.getPath())
+                .setEntryPoint(modelV1Stub.getEntryPoint())
+                .setVersion(priorCommit + "-alt")  // distinct version string
+                .setPriorModel(MetadataUtil.selectorFor(modelV1Header))  // v1, not the latest v2
+                .addAllModelAttrs(modelAttrs)
+                .build();
+
+        var jobV3Request = JobRequest.newBuilder()
+                .setTenant(TEST_TENANT)
+                .setJob(JobDefinition.newBuilder()
+                        .setJobType(JobType.IMPORT_MODEL)
+                        .setImportModel(importModelV3FromV1))
+                .addAllJobAttrs(jobAttrs)
+                .build();
+
+        var jobV3Id = Helpers.startJob(orchClient, jobV3Request).getJobId();
+
+        Executable waitForV3 = () -> Helpers.waitForJob(orchClient, TEST_TENANT, jobV3Id);
+        Assertions.assertThrows(RuntimeException.class, waitForV3);
     }
 
     // Let other tests in this suite use this to import models


### PR DESCRIPTION
                                                                                                                                                                      
Problem                                                                                                                                                                       
---                                                                                                                                                                                     
ModelVersionValidator required the version field (git commit SHA) to be identical between versions of the same model object (exactMatch). This blocked the core use case of the priorModel feature: importing a new commit as a new model version.                                                                                                        
                                                                                                                                                                                
The bug was introduced in #467 before the import-as-new-version path existed, so it was never triggered in practice. PR #698 was the first time model versioning was actually used, which is when the failure surfaced as FAILED_PRECONDITION: Version compatibility check failed for [ObjectDefinition].                                                   
                                                                                                                                                                                
mustChange is the correct constraint: loading the same entry point from the same commit always produces an identical resolved schema and run method, so two model versions at the same commit would be meaningless. Any meaningful change to what a model does — whether code or referenced schema files — requires a new commit.                           

                                                                                                                                                                             
Changes                                                                                                                                                                       
---   
                                                                                                                                                                                
*Validator fix*                                                                                                                                                               
- CommonValidators: add mustChange — inverse of exactMatch, fails if values are equal                                                                                         
- ModelVersionValidator: change version field from exactMatch to mustChange                                                                                                   
                                                                                                                                                                                
*Prior-must-be-latest guard *                                                                                                                                                  
- MetadataWriteService.processNewVersions: reject any attempt to create a new version from a non-latest prior object, producing FAILED_PRECONDITION before the store is touched. Previously fell through to an opaque ALREADY_EXISTS store constraint.                                                                                                
                                                                                                                                                                                
*Test fixes*                                                                                                                                                               
- ModelVersionValidationTest: add versionChangesCommit (valid) and versionSameCommit (invalid); update the 8 existing content-change tests to also change the version field                                  
- MetadataWriteApiTest: fill empty updateObject_badVersionIncrememnt; update updateObject_superseded to expect FAILED_PRECONDITION; add trac_model_version to CHANGING_ATTRS  
- ImportModelTest: fix importModelAsNewVersion to use distinct commits; add importModelSameCommitRejected and importModelNonLatestPriorRejected E2E negative tests            
- GitHelpers: add getPriorCommit() (HEAD~1)                                                                                                                                   
- SampleMetadata: update nextModelDef to change the version field                                                                                                             
                                                                                                                                                                                
*Note* - ModelVersionValidator is only reachable via the import model job — the sole mechanism for creating or versioning MODEL objects. Confirmed by tracing all callers of validateVersion and all updateObject callers for MODEL type.