### PR TITLE
Disable publishing TRAC Java artifacts to Maven Central

### DIFF
--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -153,8 +153,14 @@ jobs:
           GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
           GPG_KEY_PASSPHRASE: ${{ secrets.GPG_KEY_PASSPHRASE }}
 
+      # Publishing to Maven Central is disabled - TRAC Java artifacts are no longer published there.
+      # The step is retained (rather than deleted) so it can be re-enabled easily if that changes:
+      # restore the condition to
+      #   if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
+      # The "Build Maven artifacts" step above is kept, so the artifacts are still built and signed
+      # (publishToMavenLocal) on every release to catch packaging regressions - they are just not published.
       - name: Publish to Maven Central
-        if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
+        if: false
         run: |
           mkdir -p ~/.gnupg/
           printf "$GPG_KEY_BASE64" | base64 --decode > ~/.gnupg/keyring.gpg


### PR DESCRIPTION
## Summary

Stops publishing TRAC's Java artifacts to Maven Central, by gating off the "Publish to Maven Central" step in the packaging workflow.

## Background

The `platform_packages` job publishes all `org.finos.tracdap.*` modules to Maven Central via Sonatype on each release. This publish is no longer needed. It has also been failing since Sonatype decommissioned the legacy OSSRH service (the reason behind the now-superseded #704).

## Change

`.github/workflows/packaging.yaml` — set the "Publish to Maven Central" step's condition to `if: false` (it was `github.event_name == 'release' && github.event.action == 'published'`).

The step is disabled rather than deleted so it can be re-enabled trivially by restoring the original condition. The preceding "Build Maven artifacts" step (`publishToMavenLocal`) is kept, so the artifacts are still built and signed on every release to catch packaging regressions — they are simply not published externally.

## Scope

- This disables publishing for **all** TRAC Java modules to Maven Central.
- No change to the PyPI or npm publishing paths.
- No change to the GitHub release artifacts (platform / sandbox / plugins / api-packages bundles are still attached to releases).

## Follow-ups

- **#704** (OSSRH → Central Portal migration) becomes moot and should be closed if this is merged.
- The `MAVEN_USERNAME` / `MAVEN_PASSWORD` / `GPG_KEY_*` secrets are no longer used by the publish step; they can be removed from the repo secrets at your discretion (left in place here since secret management is outside the workflow file).

## Test plan

- [ ] Packaging workflow runs on this PR without attempting a Maven Central publish
- [ ] Next release: `platform_packages` completes without the Maven publish failure