### PR TITLE
Bump pyarrow to 23.0.1 (fixes CVE-2026-25087)

### DIFF
--- a/.github/workflows/compliance.yaml
+++ b/.github/workflows/compliance.yaml
@@ -140,15 +140,15 @@ jobs:
       # CVE-2019-8341 (safety id: 70612) is a vulnerability in the latest version of Jinja2, no fix is available
       # It is only pulled in as a dependency of safety check itself, it is not a dependency of the dist wheels
       #
-      # CVE-2026-0994 (safety id: 85151) in protobuf and CVE-2026-25087 (safety id: SFTY-20260217-93940) in
-      # pyarrow / Arrow C++ are both suppressed on the Java side of the platform (dev/compliance/owasp-false-positives.xml).
-      # They are not applicable to the way TRAC uses these libraries, so they are ignored here for consistency.
+      # CVE-2026-0994 (safety id: 85151) in protobuf is suppressed on the Java side of the platform
+      # (dev/compliance/owasp-false-positives.xml) and is not applicable to the way TRAC uses the library,
+      # so it is ignored here for consistency.
       - name: Safety check
         run: |
           mkdir -p build/compliance/python-runtime-safety
           cd tracdap-runtime/python
-          safety check --ignore 70612 --ignore 85151 --ignore SFTY-20260217-93940 --output text > ../../build/compliance/python-runtime-safety/python-runtime-safety-report.txt
-          safety check --ignore 70612 --ignore 85151 --ignore SFTY-20260217-93940 --output json > ../../build/compliance/python-runtime-safety/python-runtime-safety-report.json
+          safety check --ignore 70612 --ignore 85151 --output text > ../../build/compliance/python-runtime-safety/python-runtime-safety-report.txt
+          safety check --ignore 70612 --ignore 85151 --output json > ../../build/compliance/python-runtime-safety/python-runtime-safety-report.json
 
       # Always save the reports - they are especially needed when the checks have failed!
       - name: Store compliance reports

--- a/tracdap-runtime/python/requirements.txt
+++ b/tracdap-runtime/python/requirements.txt
@@ -8,7 +8,7 @@
 
 # Core data framework is based on Arrow
 # This needs to support the Python versions listed in setup.cfg
-pyarrow == 22.0.0
+pyarrow == 23.0.1
 
 # Core protobuf support for metadata / config classes
 # This should match the Java Protobuf version, if possible


### PR DESCRIPTION
## Summary

Bumps pyarrow from 22.0.0 to 23.0.1, which fixes CVE-2026-25087, and removes the temporary safety suppression that was covering it.

## Background

CVE-2026-25087 is a use-after-free in the Arrow C++ IPC reader (improper handling of IPC files), affecting pyarrow `>= 15.0.0, < 23.0.1`. When the Python runtime compliance work landed, there was no fixed release available, so the finding was suppressed in the safety scan (`--ignore SFTY-20260217-93940`) as a stopgap. pyarrow 23.0.1 is now published to PyPI and contains the fix, so this replaces the suppression with the real fix.

## Changes

- `tracdap-runtime/python/requirements.txt` — `pyarrow == 22.0.0` → `== 23.0.1`
- `.github/workflows/compliance.yaml` — remove `--ignore SFTY-20260217-93940` from the two `safety check` commands, and update the accompanying comment

The protobuf safety ignore (`85151`, CVE-2026-0994) is **retained** — that one still has no fixed release available.

## Not in scope

The Java-side OWASP suppression for CVE-2026-25087 (`org.apache.arrow.*` in `dev/compliance/owasp-false-positives.xml`) is left unchanged. Arrow Java versions independently of the pyarrow / Arrow C++ monorepo (it is on the 18.x line), and this is a C++ IPC issue — so that suppression is a separate assessment and not addressed here.

## Verification

Ran the Python runtime unit suite locally against pyarrow 23.0.1 (fresh venv, `build_runtime.py --target codegen test`):

```
Ran 458 tests in 10.688s
OK (skipped=29)
```

This includes the Arrow file storage and data round-trip / schema / codec tests, which are the paths most likely to be affected by an Arrow major-version change. CI's `python_runtime` matrix will additionally exercise this across the supported pandas / numpy / pyspark / Python combinations.

## Test plan

- [ ] `python_runtime_compliance` passes (no pyarrow finding, safety scan clean)
- [ ] `python_runtime` test matrix passes across supported combinations