### PR TITLE
Bump protobuf to 6.33.5 (fixes CVE-2026-0994)

### DIFF
--- a/.github/workflows/compliance.yaml
+++ b/.github/workflows/compliance.yaml
@@ -139,16 +139,12 @@ jobs:
 
       # CVE-2019-8341 (safety id: 70612) is a vulnerability in the latest version of Jinja2, no fix is available
       # It is only pulled in as a dependency of safety check itself, it is not a dependency of the dist wheels
-      #
-      # CVE-2026-0994 (safety id: 85151) in protobuf is suppressed on the Java side of the platform
-      # (dev/compliance/owasp-false-positives.xml) and is not applicable to the way TRAC uses the library,
-      # so it is ignored here for consistency.
       - name: Safety check
         run: |
           mkdir -p build/compliance/python-runtime-safety
           cd tracdap-runtime/python
-          safety check --ignore 70612 --ignore 85151 --output text > ../../build/compliance/python-runtime-safety/python-runtime-safety-report.txt
-          safety check --ignore 70612 --ignore 85151 --output json > ../../build/compliance/python-runtime-safety/python-runtime-safety-report.json
+          safety check --ignore 70612 --output text > ../../build/compliance/python-runtime-safety/python-runtime-safety-report.txt
+          safety check --ignore 70612 --output json > ../../build/compliance/python-runtime-safety/python-runtime-safety-report.json
 
       # Always save the reports - they are especially needed when the checks have failed!
       - name: Store compliance reports

--- a/tracdap-runtime/python/requirements.txt
+++ b/tracdap-runtime/python/requirements.txt
@@ -12,7 +12,7 @@ pyarrow == 23.0.1
 
 # Core protobuf support for metadata / config classes
 # This should match the Java Protobuf version, if possible
-protobuf == 6.33.0
+protobuf == 6.33.5
 
 # PyYAML is used to load config supplied in YAML format
 pyyaml == 6.0.3


### PR DESCRIPTION
## Summary

Bumps the Python `protobuf` package from 6.33.0 to 6.33.5, which fixes CVE-2026-0994, and removes the temporary safety suppression that was covering it.

## Background

CVE-2026-0994 (JSON recursion depth bypass) affects the Python protobuf package `>= 6.30.0rc1, <= 6.33.4`. When the Python runtime compliance work landed, no fixed release was available, so the finding was suppressed in the safety scan (`--ignore 85151`) as a stopgap. protobuf 6.33.5 is now published to PyPI and contains the fix, so this replaces the suppression with the real fix.

## Changes

- `tracdap-runtime/python/requirements.txt` — `protobuf == 6.33.0` → `== 6.33.5`
- `.github/workflows/compliance.yaml` — remove `--ignore 85151` from the two `safety check` commands, and drop the accompanying comment

With the pyarrow suppression already removed (#709, merged), the safety scan now ignores only the Jinja2 dev-tool finding (`70612`).

The bump stays on the 6.33.x line, so it does not change the relationship to the Java protobuf runtime (`proto_version`).

## Not in scope

The Java-side OWASP suppression for CVE-2026-0994 (`protobuf-java` in `dev/compliance/owasp-false-positives.xml`) is left unchanged. The GitHub advisory lists **only** the Python (PIP) package as affected, so the `protobuf-java` finding is a separate assessment (most likely NVD/CPE noise) and is not addressed here.

## Verification

Ran the Python runtime unit suite locally against protobuf 6.33.5 (fresh venv, `build_runtime.py --target codegen test`):

```
Ran 458 tests in 11.963s
OK (skipped=29)
```

## Test plan

- [ ] `python_runtime_compliance` passes (no protobuf finding, safety scan clean)
- [ ] `python_runtime` test matrix passes