### PR TITLE
Bump dulwich to 1.2.5 (CVE-2026-42305, CVE-2026-42563)

### DIFF
--- a/tracdap-runtime/python-ext/plugins/git/requirements.txt
+++ b/tracdap-runtime/python-ext/plugins/git/requirements.txt
@@ -1,3 +1,3 @@
 tracdap-runtime == 0.10.*
-dulwich ~= 0.24.0
+dulwich ~= 1.2.5
 urllib3 >= 2.2.0


### PR DESCRIPTION
## Summary

Bumps dulwich from the 0.24.x line to 1.2.5 in the git model repository plugin (`tracdap-ext-git`), clearing two high-severity advisories. This turned out to be a drop-in bump with no plugin code changes required.

## Vulnerabilities

| CVE | Issue | Fixed in |
|---|---|---|
| CVE-2026-42305 | Arbitrary file write via NTFS-hostile tree entries (Windows only) | 1.2.5 |
| CVE-2026-42563 | Command injection via merge driver path | 1.2.5 |

### Reachability

Neither is actually reachable in TRAC's usage, so this is defence-in-depth / clean-scan rather than a critical fix:
- The git plugin only **fetches and checks out** a specific ref (`_do_python_checkout`) — it never performs a `git merge`, so the merge-driver command injection (CVE-2026-42563) is not exercised.
- CVE-2026-42305 is Windows/NTFS-specific; TRAC container images are Linux.

## Change

`tracdap-runtime/python-ext/plugins/git/requirements.txt` — `dulwich ~= 0.24.0` → `dulwich ~= 1.2.5`. No code changes.

## Why it's drop-in

dulwich went 0.x → 1.x, but the specific APIs the plugin uses have compatible signatures in 1.2.5 (verified by inspection):
- `Repo.init(path)`, `repo.get_config()`, `config.set(...)` / `write_to_path()`
- `HttpGitClient(base_url, config=, pool_manager=, username=, password=)` — all kwargs still present
- `client.fetch(path, target, determine_wants, depth=)` → `FetchPackResult` with `.refs`
- `build_index_from_tree(root_path, index_path, object_store, tree_id)`
- `repo[b"HEAD"] = ...` / `repo[b"HEAD"].tree`, `repo.index_path()`, `repo.object_store`

## Verification

Ran the git plugin integration tests against dulwich 1.2.5 (native git + dulwich checkout from `github.com/finos/tracdap`, plus the failure-path tests):

```
Ran 6 tests in 14.866s
OK
```

The dulwich (`_do_python_checkout`) path cloned and checked out successfully.

## Test plan

- [ ] `python_runtime_compliance` passes (no dulwich findings)
- [ ] `integration_ext` git tests pass in CI