### PR TITLE
Bump lodash to 4.18.1 in examples/apps/javascript

### DIFF
--- a/examples/apps/javascript/package-lock.json
+++ b/examples/apps/javascript/package-lock.json
@@ -296,9 +296,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",


### PR DESCRIPTION
## Summary

Bumps the transitive `lodash` dependency in the JavaScript example app from 4.17.21 to 4.18.1. This is a manual replacement for dependabot's #691, which could no longer be auto-rebased (its lockfile conflicted with `main` after the ws bump, and dependabot won't rebase an edited PR).

## Vulnerabilities addressed

lodash 4.17.21 is affected by advisories fixed in 4.18.0:
- Code injection via `_.template` import key names
- Prototype pollution via array path bypass in `_.unset`
- Prototype pollution in `_.unset` / `_.omit`

## Change

`examples/apps/javascript/package-lock.json` only — lodash is a transitive dependency (pulled in via the app's direct deps), and its allowed range already permits 4.18.1, so this is a lockfile-only update (`npm update lodash --package-lock-only`). No `package.json` or source changes.

## Scope / risk

- Examples app only — not part of the shipped product.
- 4.17 → 4.18 is a compatible minor bump.

## Test plan

- [ ] CI passes (note: any `int-cloud-storage` GCP failures are unrelated flakes — this change only touches a JS example lockfile)