### PR TITLE
Sync setup.cfg security pins with requirements (pyarrow, protobuf, azure-core)

### DIFF
--- a/tracdap-runtime/python/setup.cfg
+++ b/tracdap-runtime/python/setup.cfg
@@ -77,8 +77,8 @@ package_dir =
 python_requires = >= 3.10
 
 install_requires =
-    protobuf == 6.33.0
-    pyarrow == 22.0.0
+    protobuf == 6.33.5
+    pyarrow == 23.0.1
     pyyaml == 6.0.3
     certifi >= 2025.1.31
 
@@ -114,7 +114,7 @@ gcp =
     gcsfs == 2024.3.1
 
 azure =
-    azure-core == 1.35.0
+    azure-core == 1.38.0
     azure-identity == 1.23.1
     azure-storage-blob == 12.26.0
     adlfs == 2024.12.0


### PR DESCRIPTION
## Summary

Brings the `tracdap-runtime` wheel's dependency pins in `setup.cfg` back into line with the requirements files. Three security bumps had been applied to `requirements.txt` / `requirements_plugins.txt` but not to `setup.cfg`, so the **released runtime was still bundling the vulnerable versions**.

## The gap

Release artifacts (the published wheel, and the runtime installed into the Docker image / distribution) resolve dependencies from the wheel's `install_requires` — i.e. `setup.cfg` — **not** `requirements.txt`. Those had drifted:

| Package | setup.cfg (was) | requirements | CVE |
|---|---|---|---|
| protobuf | 6.33.0 | 6.33.5 | CVE-2026-0994 |
| pyarrow | 22.0.0 | 23.0.1 | CVE-2026-25087 |
| azure-core | 1.35.0 | 1.38.0 | CVE-2026-21226 |

`python_runtime_compliance` never flagged this because it installs from `requirements.txt` (which had the fixes). The gap only shows up in a scan of a built artifact — e.g. Docker Hub reporting `pyarrow-22.0.0.dist-info` / `protobuf-6.33.0.dist-info` in a runtime built off up-to-date source.

## Change

`tracdap-runtime/python/setup.cfg`:
- `protobuf` 6.33.0 → 6.33.5
- `pyarrow` 22.0.0 → 23.0.1
- `azure-core` (azure extra) 1.35.0 → 1.38.0

Verified: `setup.cfg` and the requirements files now have **zero** version mismatches on shared `==` pins.

## Follow-up worth considering

`requirements.txt` says "development … (and the two should match)", but nothing enforces it. A small CI check that diffs the `==` pins in `setup.cfg` against the requirements files would prevent this class of drift (where a security fix lands in one but not the other). Happy to add it separately if wanted.

## Test plan

- [ ] `python_runtime` / `python_runtime_compliance` pass
- [ ] A runtime built from this commit bundles pyarrow 23.0.1 / protobuf 6.33.5 / azure-core 1.38.0