### PR TITLE
Add CI guard for setup.cfg / requirements dependency pin drift

### DIFF
--- a/.github/workflows/compliance.yaml
+++ b/.github/workflows/compliance.yaml
@@ -118,6 +118,12 @@ jobs:
       - name: PIP Upgrade
         run: python -m pip install --upgrade pip
 
+      # The compliance checks below install from requirements.txt, but release artifacts install
+      # from setup.cfg's install_requires. This check fails if the two have drifted, so a security
+      # fix cannot land in one without the other (which would ship a vulnerable version undetected).
+      - name: Check dependency pin consistency
+        run: python tracdap-runtime/python/check_dependency_pins.py
+
       # Make sure to check compliance on both core and plugin dependencies
       - name: Install dependencies
         run: |

--- a/tracdap-runtime/python/check_dependency_pins.py
+++ b/tracdap-runtime/python/check_dependency_pins.py
@@ -1,0 +1,116 @@
+# Licensed to the Fintech Open Source Foundation (FINOS) under one or
+# more contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright ownership.
+# FINOS licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Check that the exact (==) dependency pins declared in setup.cfg match the
+corresponding pins in the requirements files.
+
+setup.cfg's install_requires (and the extras) is what the published
+tracdap-runtime wheel declares, and therefore what gets installed into
+release artifacts. requirements.txt / requirements_plugins.txt are used for
+development and CI. If a version is bumped in one but not the other (for
+example a security fix applied to requirements.txt only), the release
+artifact silently ships the old version - and the compliance checks, which
+install from requirements.txt, will not notice.
+
+This script fails if any package pinned with '==' in both setup.cfg and the
+requirements files has mismatched versions.
+"""
+
+import configparser
+import pathlib
+import re
+import sys
+
+HERE = pathlib.Path(__file__).parent
+
+SETUP_CFG = HERE.joinpath("setup.cfg")
+REQUIREMENTS_FILES = [
+    HERE.joinpath("requirements.txt"),
+    HERE.joinpath("requirements_plugins.txt"),
+]
+
+PIN_PATTERN = re.compile(r"^\s*([A-Za-z0-9_.\-]+)\s*==\s*([0-9][^\s#;,]*)")
+
+
+def normalize(name):
+    return name.lower().replace("_", "-")
+
+
+def parse_pins(lines):
+    pins = {}
+    for line in lines:
+        match = PIN_PATTERN.match(line)
+        if match:
+            pins[normalize(match.group(1))] = match.group(2)
+    return pins
+
+
+def setup_cfg_pins():
+
+    cfg = configparser.ConfigParser()
+    cfg.read(SETUP_CFG)
+
+    lines = []
+
+    if cfg.has_option("options", "install_requires"):
+        lines += cfg.get("options", "install_requires").splitlines()
+
+    if cfg.has_section("options.extras_require"):
+        for _, value in cfg.items("options.extras_require"):
+            lines += value.splitlines()
+
+    return parse_pins(lines)
+
+
+def requirements_pins():
+
+    pins = {}
+    for req_file in REQUIREMENTS_FILES:
+        if req_file.exists():
+            pins.update(parse_pins(req_file.read_text().splitlines()))
+    return pins
+
+
+def main():
+
+    setup_pins = setup_cfg_pins()
+    req_pins = requirements_pins()
+
+    mismatches = []
+    for pkg, setup_version in sorted(setup_pins.items()):
+        req_version = req_pins.get(pkg)
+        if req_version is not None and req_version != setup_version:
+            mismatches.append((pkg, setup_version, req_version))
+
+    if mismatches:
+        print("Dependency pin mismatch between setup.cfg and the requirements files:")
+        print()
+        print(f"  {'package':24} {'setup.cfg':16} {'requirements':16}")
+        print(f"  {'-' * 24} {'-' * 16} {'-' * 16}")
+        for pkg, setup_version, req_version in mismatches:
+            print(f"  {pkg:24} {setup_version:16} {req_version:16}")
+        print()
+        print("setup.cfg governs the versions installed into release artifacts, so it")
+        print("must be kept in sync with the requirements files. Update the mismatched")
+        print("pins so both agree.")
+        return 1
+
+    print(f"Dependency pins are consistent ({len(setup_pins)} pins checked in setup.cfg).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds a CI check that fails when the exact (`==`) dependency pins in `setup.cfg` drift from those in the requirements files, so the class of gap fixed in #714 can't recur silently.

## Why

Release artifacts install dependency versions from the runtime wheel's `install_requires` (i.e. `setup.cfg`) — that's what ends up in `/opt/trac/runtime/<ver>/...`. The `python_runtime_compliance` check, however, installs from `requirements.txt`. So when a version is bumped in one file but not the other, the release ships the old version and **no CI check notices** — exactly what happened with the pyarrow, protobuf and azure-core security fixes (they were applied to the requirements files but not `setup.cfg`, and the built runtime kept shipping the vulnerable versions).

## Change

- **`tracdap-runtime/python/check_dependency_pins.py`** — parses the `==` pins from `setup.cfg` (`install_requires` + all extras) and from `requirements.txt` / `requirements_plugins.txt`, and exits non-zero if any package pinned in both has mismatched versions. Stdlib only (configparser); no dependencies to install.
- **`.github/workflows/compliance.yaml`** — runs it early in the `python_runtime_compliance` job (before installing dependencies, so it fails fast).

## Verification (local)

- Passes on current `main` (post-#714): `Dependency pins are consistent (15 pins checked in setup.cfg).`
- Injecting a drift (pyarrow 23.0.1 → 22.0.0 in setup.cfg) makes it fail with a clear table and a non-zero exit; reverting restores the pass.

Example failure output:
```
Dependency pin mismatch between setup.cfg and the requirements files:

  package                  setup.cfg        requirements
  ------------------------ ---------------- ----------------
  pyarrow                  22.0.0           23.0.1
```

## Test plan

- [ ] `python_runtime_compliance` passes (pins are currently in sync)