### PR TITLE
Bump Log4j to 2.26.1 (clears CVE-2026-34477/78/79/80, CVE-2025-68161)

### DIFF
--- a/dev/compliance/owasp-false-positives.xml
+++ b/dev/compliance/owasp-false-positives.xml
@@ -313,17 +313,6 @@
         <cve>CVE-2026-33117</cve>
     </suppress>
 
-    <!-- CVE-2026-34477, CVE-2026-34478, CVE-2026-34479, CVE-2026-34480, CVE-2025-68161: Log4j 2.x -->
-    <!-- No fix available at time of writing -->
-    <suppress>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.logging\.log4j/.*@.*$</packageUrl>
-        <cve>CVE-2026-34477</cve>
-        <cve>CVE-2026-34478</cve>
-        <cve>CVE-2026-34479</cve>
-        <cve>CVE-2026-34480</cve>
-        <cve>CVE-2025-68161</cve>
-    </suppress>
-
     <!-- CVE-2026-42582: Netty 4.1.x, no fix available at time of writing -->
     <suppress>
         <packageUrl regex="true">^pkg:maven/io\.netty/netty\-.*@.*$</packageUrl>

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -43,7 +43,7 @@ ext {
 
     // Util libraries
     slf4j_version = '2.0.17'
-    log4j_version = '2.25.1'
+    log4j_version = '2.26.1'
     commons_cli_version = "1.9.0"
     uuid_generator_version = "5.1.1"
 


### PR DESCRIPTION
## Summary

Bumps Log4j 2.25.1 → 2.26.1 and removes the corresponding suppression. These five Log4j Core / 1.2-api advisories were suppressed as "no fix available at time of writing" — that's no longer true; all are fixed in the 2.x line.

## Vulnerabilities cleared (all medium severity)

| CVE | Issue | Fixed in |
|---|---|---|
| CVE-2025-68161 | TLS hostname not verified in Socket Appender | 2.25.3 |
| CVE-2026-34477 | `verifyHostName` silently ignored in TLS config | 2.25.4 |
| CVE-2026-34478 | Rfc5424Layout log injection | 2.25.4 |
| CVE-2026-34480 | XmlLayout silent log event loss | 2.25.4 |
| CVE-2026-34479 | log4j-1.2-api XML layout silent loss | 2.25.4 |

## Change

- `gradle/versions.gradle` — `log4j_version` 2.25.1 → **2.26.1** (latest stable 2.x; verified OSV-clean). This also aligns tracdap with trac-extensions, which is already on the 2.26 line.
- `dev/compliance/owasp-false-positives.xml` — remove the Log4j suppression block (no longer needed).

Verified: `log4j-core` / `log4j-api` resolve to 2.26.1.

## Context

Part of clearing the medium-severity findings from the Docker Hub scan for a clean customer-facing bill of health. (The remaining `jackson-databind` CVE-2026-54515 still has no fixed 2.x release and stays suppressed — handled separately.)

## Test plan

- [ ] `platform_compliance` passes with the suppression removed
- [ ] `platform_build` passes (Log4j 2.x is compatible within the major line)