### PR TITLE
Correct CVE-2026-54515 jackson-databind suppression rationale

### DIFF
--- a/dev/compliance/owasp-false-positives.xml
+++ b/dev/compliance/owasp-false-positives.xml
@@ -326,11 +326,13 @@
     </suppress>
 
     <!-- CVE-2026-54515: jackson-databind case-insensitive deserialization can bypass per-property -->
-    <!-- @JsonIgnoreProperties. Fixed in 2.21.5, which is not yet published to Maven Central; the next -->
-    <!-- available release (2.22.0) is also affected per NVD. TRAC does not use @JsonIgnoreProperties -->
-    <!-- or polymorphic / default typing, so this is not reachable in our usage. -->
-    <!-- Time-boxed: remove this suppression and bump jackson-databind to 2.21.5+ once it is released. -->
-    <suppress until="2026-08-15Z">
+    <!-- @JsonIgnoreProperties. There is no fixed 2.x release: 2.21.5 and 2.22.1 are both still listed -->
+    <!-- as affected by the revised advisory, and the only patched line is Jackson 3.x (tools.jackson -->
+    <!-- 3.1.4+), which requires a Java 17 baseline and a group/package migration across TRAC. -->
+    <!-- Not reachable in our usage regardless: TRAC does not use @JsonIgnoreProperties or polymorphic / -->
+    <!-- default typing (the only databind use reads into plain Object in ConfigParser). Revisit if a -->
+    <!-- fixed 2.x release appears or as part of a future Jackson 3.x / Java 17 migration. -->
+    <suppress>
         <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
         <cve>CVE-2026-54515</cve>
     </suppress>


### PR DESCRIPTION
The existing suppression for CVE-2026-54515 (jackson-databind) was written on the assumption that 2.21.5 would fix it, and time-boxed itself to 2026-08-15 pending that release.

That premise turned out to be wrong:

- **2.21.5 is now published and is still listed as affected**, as is 2.22.1 — there is **no fixed jackson-databind 2.x release**.
- The only patched line is **Jackson 3.x** (`tools.jackson` 3.1.4+), which requires a **Java 17 baseline** and a group-id / package migration across TRAC — not something to take as a security patch.
- The vulnerability is **not reachable in TRAC's usage** regardless: we don't use `@JsonIgnoreProperties` or polymorphic / default typing. The only non-test databind use is `ConfigParser`, which reads into plain `Object`.

This PR just corrects the comment to reflect that reality and drops the misleading `until="2026-08-15Z"` date, since there's no imminent 2.x fix to wait for. The suppression itself is unchanged.

No functional / dependency change.