### PR TITLE
Pin npm to the 11 line for release publishing

### DIFF
--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -402,8 +402,12 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: ${{ env.NPM_REGISTRY_URL }}
 
+      # Pin to the npm 11 line rather than @latest: npm 12.0.0 fails to publish
+      # with "Cannot find module 'sigstore'" when generating build provenance,
+      # which broke the 0.10.0 release. Track the last-good major explicitly so a
+      # broken npm release cannot silently break publishing again.
       - name: Update NPM
-        run: npm install -g npm@latest && npm --version
+        run: npm install -g npm@11 && npm --version
 
       - name: Fetch web API package
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Problem

The `publish_to_npm` job in the 0.10.0 release failed with:

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'sigstore'
npm error - .../npm/node_modules/libnpmpublish/lib/provenance.js
```

The `Update NPM` step ran `npm install -g npm@latest`, which now resolves to **npm 12.0.0**. That release fails while generating build provenance during `npm publish` because it can't load its own bundled `sigstore` module. As a result nothing was published to npm (the registry still tops out at `0.10.0-rc.1`). The RC.1 release a week earlier passed because `@latest` was still on the npm 11 line.

PyPI and the GitHub release assets published fine — only npm was affected.

## Fix

Pin the updater to the last-good major: `npm install -g npm@11`. This keeps us off broken new npm majors while still picking up patch/minor fixes within npm 11. When npm 12 is fixed we can revisit.

## Note

This also needs to reach the `v0.10.0` release, whose workflow runs off the tagged commit — so the tag will be moved to include this fix and the release re-published to complete the npm upload.