### PR TITLE
Bump protobufjs to 7.6.5 (CVE-2026-59877)

### DIFF
--- a/tracdap-api/packages/web/package-lock.json
+++ b/tracdap-api/packages/web/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "grpc-web": "~2.0.2",
-        "protobufjs": "~7.6.3"
+        "protobufjs": "~7.6.5"
       },
       "devDependencies": {
         "license-checker-rseidelsohn": "^4.4.2",
@@ -151,12 +151,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
@@ -1160,9 +1154,9 @@
       "dev": true
     },
     "node_modules/protobufjs": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.3.tgz",
-      "integrity": "sha512-+k0vdJKNdW+Vu+dYe8tZA/VvQb6XKNWexC6URwBFXxNnjLJz9nQJCemGyNgRAWD+B7+nGNc9qMPGwcD7s4nzUw==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -1172,7 +1166,6 @@
         "@protobufjs/eventemitter": "^1.1.1",
         "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.1",

--- a/tracdap-api/packages/web/package.json
+++ b/tracdap-api/packages/web/package.json
@@ -38,7 +38,7 @@
     "tracVersion:windows": "for /f %v in ('powershell -ExecutionPolicy Bypass -File ..\\..\\..\\dev\\version.ps1') do npm version \"%v\"",
     "tracVersion:posix": "npm version `../../../dev/version.sh`",
     "buildApi": "node api_builder.js",
-    "compliance-owasp": "owasp-dependency-check --project \"tracdap-web-api\" --suppression ../../../dev/compliance/owasp-false-positives.xml --failOnCVSS 4 --data ../../../build/compliance-cache/nvd_web_api --out ../../../build/compliance/web-api-owasp/",
+    "compliance-owasp": "owasp-dependency-check --project \"tracdap-web-api\" --disableNodeAudit --suppression ../../../dev/compliance/owasp-false-positives.xml --failOnCVSS 4 --data ../../../build/compliance-cache/nvd_web_api --out ../../../build/compliance/web-api-owasp/",
     "compliance-licenses": "license-checker-rseidelsohn --onlyAllow \"MIT; Apache-2.0; BSD; BSD-3-Clause; ISC; BSD-2-Clause; Unlicense; WTFPL; Python-2.0; BlueOak-1.0.0\" --excludePackages \"spdx-exceptions;spdx-license-ids\" --json --out ../../../build/compliance/web-api-licenses/license-report.json",
     "compliance-audit": "npm audit --omit dev > ../../../build/compliance/web-api-npm-audit/npm-audit.txt",
     "pbtsTask": "pbts -o tracdap.d.ts tracdap.js"

--- a/tracdap-api/packages/web/package.json
+++ b/tracdap-api/packages/web/package.json
@@ -23,7 +23,7 @@
   "main": "tracdap.js",
   "dependencies": {
     "grpc-web": "~2.0.2",
-    "protobufjs": "~7.6.3"
+    "protobufjs": "~7.6.5"
   },
   "devDependencies": {
     "protobufjs-cli": "~1.3.3",


### PR DESCRIPTION
Two related web API compliance fixes. Both were needed together for `web_api_compliance` to pass, so they landed in this one PR (the standalone NodeAudit PR #720 was superseded by this merge and closed).

## 1. Bump protobufjs to 7.6.5 (CVE-2026-59877)

`web_api_compliance` (OWASP dependency check, NVD analyzer) flagged **protobufjs 7.6.3 → CVE-2026-59877** (CVSS 7.5, CWE-835): a malformed `.proto` with a premature option declaration causes an infinite loop in `parse` / `Root.load` / `Root.loadSync` — a DoS. Fixed in protobufjs **7.6.5** (also `>= 8.0.0, < 8.6.6`).

- `package.json`: `protobufjs` `~7.6.3` → `~7.6.5` (patch bump, within the existing range)
- `package-lock.json`: refreshed — resolves protobufjs to 7.6.5; `@protobufjs/inquire` drops out of the tree (7.6.5 no longer depends on it)

## 2. Disable OWASP NodeAuditAnalyzer (npm retired its legacy audit endpoint)

Separately, `web_api_compliance` also failed with `Failed to read results from the NPM Audit API (NodeAuditAnalyzer)` (exit 14) — **not a vulnerability**. npm permanently **retired** its legacy audit endpoints (`/-/npm/v1/security/audits` and `/audits/quick`) on **2026-07-15**; they now return **HTTP 410 Gone**, directing callers to the bulk advisory endpoint. OWASP dependency-check's `NodeAuditAnalyzer` still calls the retired endpoint. Tracked upstream in [dependency-check#8422](https://github.com/dependency-check/DependencyCheck/issues/8422).

- `package.json`: add `--disableNodeAudit` to the `compliance-owasp` script

**Coverage impact (reviewed):** OWASP has two Node analyzers; only `NodeAuditAnalyzer` is disabled. CVE/NVD detection (`NodePackageAnalyzer` → NVD) stays enabled — that is what flags the protobufjs CVE above. npm advisory (GHSA) coverage for runtime deps is still provided by the dedicated `compliance-audit` step (`npm audit --omit dev`), which uses the current bulk endpoint. The only reduction is GHSA advisories with no matching CVE affecting **dev-only** dependencies, which are not shipped in the published package. A weekly watcher tracks dependency-check releases so `--disableNodeAudit` can be removed once the analyzer is fixed.

## Result

`web_api_compliance` passes with both fixes present (verified on the branch before merge): the NodeAudit exit-14 tooling error is gone, and the protobufjs CVE is resolved with NVD/CVE gating still active.