### PR TITLE
Bump jackson to 2.21.5 (clears CVE-2026-54515)

### DIFF
--- a/dev/compliance/owasp-false-positives.xml
+++ b/dev/compliance/owasp-false-positives.xml
@@ -325,18 +325,6 @@
         <cve>CVE-2026-0994</cve>
     </suppress>
 
-    <!-- CVE-2026-54515: jackson-databind case-insensitive deserialization can bypass per-property -->
-    <!-- @JsonIgnoreProperties. There is no fixed 2.x release: 2.21.5 and 2.22.1 are both still listed -->
-    <!-- as affected by the revised advisory, and the only patched line is Jackson 3.x (tools.jackson -->
-    <!-- 3.1.4+), which requires a Java 17 baseline and a group/package migration across TRAC. -->
-    <!-- Not reachable in our usage regardless: TRAC does not use @JsonIgnoreProperties or polymorphic / -->
-    <!-- default typing (the only databind use reads into plain Object in ConfigParser). Revisit if a -->
-    <!-- fixed 2.x release appears or as part of a future Jackson 3.x / Java 17 migration. -->
-    <suppress>
-        <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
-        <cve>CVE-2026-54515</cve>
-    </suppress>
-
     <!-- CVE-2026-56876: extract-zip, no fixed release available (2.0.1 is the latest). -->
     <!-- It is a build-only transitive dependency of owasp-dependency-check (the compliance tool -->
     <!-- itself), used to extract the dependency-check CLI from a trusted GitHub release archive. -->

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -35,8 +35,8 @@ ext {
 
     // Data technologies
     arrow_version = '18.3.0'
-    jackson_version = '2.21.4'
-    jackson_databind_version = '2.21.4'
+    jackson_version = '2.21.5'
+    jackson_databind_version = '2.21.5'
     // jackson-annotations versions independently of core/databind and dropped its
     // patch number from Jackson 2.20 onwards (see jackson-bom), so it is 2.21 not 2.21.4
     jackson_annotations_version = '2.21'


### PR DESCRIPTION
## Summary

Bumps jackson `2.21.4 → 2.21.5` and removes the CVE-2026-54515 suppression, which is now fixable.

**CVE-2026-54515** (jackson-databind — case-insensitive deserialization can bypass per-property `@JsonIgnoreProperties`) was previously suppressed as "no fixed 2.x release" — at the time the advisory listed both 2.21.5 and 2.22.1 as still affected, with only Jackson 3.x patched. The advisory has since been corrected: **2.21.5 is the fix** for the 2.19–2.21 line. Confirmed clean via OSV (2.21.5 reports no vulnerabilities).

## Change

- `gradle/versions.gradle` — `jackson_version` and `jackson_databind_version` `2.21.4 → 2.21.5`. `jackson_annotations_version` stays `2.21` (it versions independently).
- `dev/compliance/owasp-false-positives.xml` — remove the CVE-2026-54515 suppression.

Verified: `jackson-core` / `jackson-databind` resolve to 2.21.5; `jackson-annotations` unchanged at 2.21.

## Context

Found while re-checking the earlier "no fix available" suppressions for newly-shipped fixes. The other suppressed 2026 CVEs (netty, protobuf-java, arrow, extract-zip) are NVD-sourced and not tracked by OSV, so they need separate NVD checks — not covered here.

## Test plan

- [ ] `platform_compliance` passes with the suppression removed
- [ ] `platform_build` passes on jackson 2.21.5