### PR TITLE
Remove dead netty CVE-2026-42582 suppression (false positive against 4.1.x)

### DIFF
--- a/dev/compliance/owasp-false-positives.xml
+++ b/dev/compliance/owasp-false-positives.xml
@@ -313,12 +313,6 @@
         <cve>CVE-2026-33117</cve>
     </suppress>
 
-    <!-- CVE-2026-42582: Netty 4.1.x, no fix available at time of writing -->
-    <suppress>
-        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-.*@.*$</packageUrl>
-        <cve>CVE-2026-42582</cve>
-    </suppress>
-
     <!-- CVE-2026-0994: protobuf-java, no fix available at time of writing -->
     <suppress>
         <packageUrl regex="true">^pkg:maven/com\.google\.protobuf/protobuf\-java.*@.*$</packageUrl>


### PR DESCRIPTION
## Summary

Removes the OWASP suppression for netty **CVE-2026-42582** — it's a false positive against our netty version and, verified below, suppresses nothing.

## Why it's safe

CVE-2026-42582 (CVSS 7.5) is a DoS in Netty's **HTTP/3 QPACK decoder**:
- Affected: **4.2.0.Alpha1 – 4.2.12.Final** (the 4.2.x line), fixed in **4.2.13.Final**.
- TRAC uses **4.1.135.Final** — the 4.1.x line, which does not include the 4.2.x HTTP/3 QPACK decoder, and we depend on no netty HTTP/3 / QUIC codec. Not affected.

The suppression was added as "Netty 4.1.x, no fix available" when the advisory was less precise; NVD has since scoped it to 4.2.x.

**Confirmed zero-match:** the platform OWASP report does not associate CVE-2026-42582 with any netty dependency (0 occurrences), whereas genuinely-matching suppressions still appear (arrow CVE-2026-25087 ×6, azure CVE-2026-33117 ×8). So this entry suppresses nothing and is dead.

## Change

- `dev/compliance/owasp-false-positives.xml` — remove the CVE-2026-42582 block. The separate netty CVE-2023-4586 suppression is left untouched.

No dependency change — we are not vulnerable, and 4.1.x is the correct line to stay on (4.2.x is the affected one).

## Test plan

- [ ] `platform_compliance` still passes (the removed rule was a zero-match, so no new finding should surface)