### PR TITLE
Remove dead protobuf-java CVE-2026-0994 suppression (Python CVE, not Java)

### DIFF
--- a/dev/compliance/owasp-false-positives.xml
+++ b/dev/compliance/owasp-false-positives.xml
@@ -313,12 +313,6 @@
         <cve>CVE-2026-33117</cve>
     </suppress>
 
-    <!-- CVE-2026-0994: protobuf-java, no fix available at time of writing -->
-    <suppress>
-        <packageUrl regex="true">^pkg:maven/com\.google\.protobuf/protobuf\-java.*@.*$</packageUrl>
-        <cve>CVE-2026-0994</cve>
-    </suppress>
-
     <!-- CVE-2026-56876: extract-zip, no fixed release available (2.0.1 is the latest). -->
     <!-- It is a build-only transitive dependency of owasp-dependency-check (the compliance tool -->
     <!-- itself), used to extract the dependency-check CLI from a trusted GitHub release archive. -->


### PR DESCRIPTION
## Summary

Removes the OWASP suppression for `protobuf-java` **CVE-2026-0994** — a false positive against the Java library, and (verified) a zero-match.

## Why it's safe

CVE-2026-0994 (CVSS 7.5) is a DoS in the **Python** protobuf — `protobuf.json_format.ParseDict` bypasses the recursion-depth limit on nested `google.protobuf.Any` messages. It is specific to the Python implementation; **protobuf-java is not affected**.

**Confirmed zero-match:** the platform OWASP report does not associate CVE-2026-0994 with any `protobuf-java` dependency (0 occurrences), whereas genuinely-matching suppressions still appear (arrow CVE-2026-25087 ×6, azure CVE-2026-33117 ×8). So this entry suppresses nothing.

## Change

- `dev/compliance/owasp-false-positives.xml` — remove the CVE-2026-0994 block.

No dependency change on the Java side. The **Python-runtime** protobuf is a separate concern and is being tracked independently (the Python side could be in scope for this CVE; `python_runtime_compliance` is currently green).

## Test plan

- [ ] `platform_compliance` still passes (the removed rule was a zero-match)