### PR TITLE
Correct arrow CVE-2026-25087 suppression rationale (false positive)

### DIFF
--- a/dev/compliance/owasp-false-positives.xml
+++ b/dev/compliance/owasp-false-positives.xml
@@ -301,7 +301,13 @@
         <cve>CVE-2024-35255</cve>
     </suppress>
 
-    <!-- CVE-2026-25087: Apache Arrow vulnerability, no fix available at time of writing -->
+    <!-- CVE-2026-25087: FALSE POSITIVE against the Java library. This is a use-after-free in the -->
+    <!-- Apache Arrow *C++* IPC reader (pre-buffering + variadic buffers), fixed in Arrow C++ 23.0.1. -->
+    <!-- TRAC depends only on pure-Java arrow modules (arrow-vector, arrow-memory-*, arrow-format, -->
+    <!-- arrow-algorithm) - no JNI/C++-bundling modules (arrow-dataset/gandiva/c-data/orc) - so the -->
+    <!-- vulnerable C++ code is not present. A version bump does not clear the finding: arrow-java is -->
+    <!-- versioned independently of Arrow C++ (latest arrow-java is 19.0.0, there is no arrow-java -->
+    <!-- 23.0.1), and the CVE's CPE range (15.0.0-23.0.0) still covers all current arrow-java versions. -->
     <suppress>
         <packageUrl regex="true">^pkg:maven/org\.apache\.arrow/.*@.*$</packageUrl>
         <cve>CVE-2026-25087</cve>


### PR DESCRIPTION
## Summary

Corrects the rationale on the Apache Arrow **CVE-2026-25087** suppression. Comment-only change — the suppression itself is kept.

## Why

The suppression said "no fix available at time of writing", which is misleading. In fact it's a **false positive** against the Java library:

- CVE-2026-25087 (CVSS 7.0) is a use-after-free in the Apache Arrow **C++** IPC reader (pre-buffering + variadic buffers), fixed in **Arrow C++ 23.0.1**.
- TRAC depends only on **pure-Java** arrow modules — `arrow-vector`, `arrow-memory-core/netty(-buffer-patch)`, `arrow-format`, `arrow-algorithm` — with **no** JNI/C++-bundling modules (`arrow-dataset` / `gandiva` / `c-data` / `orc`). The vulnerable C++ code isn't present, so we're not exposed (confirmed against the resolved dependency set).

## Why keep the suppression (no version bump)

The entry actively matches our arrow 18.3.0 via the CVE's CPE, so removing it would turn `platform_compliance` red. And a bump can't clear it: arrow-java is now versioned independently of Arrow C++ (latest arrow-java on Maven Central is **19.0.0** — there is no arrow-java 23.0.1), and the CVE's CPE range `15.0.0–23.0.0` still covers all current arrow-java versions.

Updating Arrow itself is tracked separately as future work (it's a large jump, and Arrow is heavily used in the data codecs).

## Change

- `dev/compliance/owasp-false-positives.xml` — replace the CVE-2026-25087 comment; suppression unchanged.

## Test plan

- [ ] `platform_compliance` still passes (suppression unchanged; only the comment differs)