### PR TITLE
Bump Netty 4.1.135.Final -> 4.1.137.Final and undici 7.28.0 -> 7.29.0

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -26,7 +26,7 @@ ext {
     license_check_plugin_version = "2.8"
 
     // Core platform technologies
-    netty_version = '4.1.135.Final'
+    netty_version = '4.1.137.Final'
     guava_version = '33.4.8-jre'
     gson_version = '2.13.1'
     proto_version = '4.31.1'

--- a/tracdap-api/packages/web/package-lock.json
+++ b/tracdap-api/packages/web/package-lock.json
@@ -1611,9 +1611,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/tracdap-api/packages/web/package.json
+++ b/tracdap-api/packages/web/package.json
@@ -32,7 +32,7 @@
   },
   "overrides": {
     "glob": "~11.1.0",
-    "undici": "~7.28.0"
+    "undici": "~7.29.0"
   },
   "scripts": {
     "tracVersion:windows": "for /f %v in ('powershell -ExecutionPolicy Bypass -File ..\\..\\..\\dev\\version.ps1') do npm version \"%v\"",


### PR DESCRIPTION
## What

Two dependency bumps, batched because the compliance checks cover both the platform and the web API — fixing only one leaves the PR unmergeable.

1. **Netty 4.1.135.Final → 4.1.137.Final** (platform)
2. **undici override ~7.28.0 → ~7.29.0** (web API)

## Netty — 18 CVEs

A compliance run against `main` (workflow dispatch, 2026-08-13) reported **342 findings** on `platform_compliance`. Every one is Netty: 19 `io.netty` artifacts at 4.1.135.Final, each matched through the shared `cpe:netty:netty:4.1.135` CPE, across **18 distinct CVEs**.

All 18 were checked individually against the GitHub advisory database. Every one is patched in **4.1.136.Final** on the 4.1 line:

| CVE | Vulnerable package |
|---|---|
| CVE-2026-44891, CVE-2026-59920 | `netty-codec-stomp` |
| CVE-2026-55831, CVE-2026-55833, CVE-2026-56745, CVE-2026-56746, CVE-2026-59898, CVE-2026-59899, CVE-2026-59921 | `netty-codec-http` |
| CVE-2026-56819, CVE-2026-59900 | `netty-codec-http2` |
| CVE-2026-55851, CVE-2026-59919 | `netty-codec-haproxy` |
| CVE-2026-56820, CVE-2026-56821, CVE-2026-56822 | `netty-handler-ssl-ocsp` |
| CVE-2026-56817 | `netty-codec-xml` |
| CVE-2026-59901 | `netty-codec` |

4.1.137.Final is the current 4.1.x release. Several of the listed packages are not on the platform classpath at all — the CPE match tags every netty artifact regardless of which carries the flaw — so the version bump is what clears the findings.

**Verified:** `platform_compliance` passes on this branch, down from 342 findings.

## undici — 5 CVEs

`web_api_compliance` flagged undici 7.28.0:

| CVE | Severity | Fixed in |
|---|---|---|
| CVE-2026-13697 | high | 7.29.0 |
| CVE-2026-14643 | medium | 7.29.0 |
| CVE-2026-15157 | medium | 7.29.0 |
| CVE-2026-16728 | medium | 7.29.0 |
| CVE-2026-16729 | medium | 7.29.0 |

All five are patched in 7.29.0 on the 7.x line. undici was already pinned as an explicit `overrides` entry, but at `~7.28.0`, which cannot reach 7.29.0 — so the existing range is moved rather than a new pin introduced.

`package-lock.json` was regenerated with `--package-lock-only`; the only change is the undici entry, since the scan reads the lock file rather than `package.json`.

## Scope

One line in `gradle/versions.gradle`, one line in the web `package.json` overrides, and the corresponding lock entry. No source changes.

## Verification

Relying on this PR's CI. `platform_compliance` has already been observed passing; `web_api_compliance` is what the undici commit addresses.

The same netty bump was applied to a downstream project earlier today, clearing its three overlapping findings with compile and unit tests passing and no source changes.
