### PR TITLE
Scope the CVE-2026-33117 suppression to the mis-matched Azure artifacts

### DIFF
--- a/dev/compliance/owasp-false-positives.xml
+++ b/dev/compliance/owasp-false-positives.xml
@@ -313,9 +313,19 @@
         <cve>CVE-2026-25087</cve>
     </suppress>
 
-    <!-- CVE-2026-33117: Azure SDK for Java, no fix available at time of writing -->
+    <!-- CVE-2026-33117: FALSE POSITIVE against the artifacts listed below. The vulnerability is an -->
+    <!-- incorrect authentication tag comparison in the local cryptography path of the Azure SDK for -->
+    <!-- Java Key Vault Keys library (azure-security-keyvault-keys), fixed in 4.10.6. TRAC does not -->
+    <!-- depend on azure-security-keyvault-keys, so the vulnerable code is not present. -->
+    <!-- NVD files the CVE under the generic CPE microsoft:azure_sdk_for_java with the range -->
+    <!-- "up to (excluding) 4.10.6", so OWASP matches every com.azure artifact whose own version -->
+    <!-- number happens to sort below 4.10.6 - here azure-core, azure-core-http-netty, -->
+    <!-- azure-identity and azure-json. The storage artifacts are 12.x and so are not matched. -->
+    <!-- This is deliberately scoped to those four artifacts rather than all of com.azure: a blanket -->
+    <!-- rule would silently hide the real vulnerability if azure-security-keyvault-keys below -->
+    <!-- 4.10.6 were ever pulled in. -->
     <suppress>
-        <packageUrl regex="true">^pkg:maven/com\.azure/.*@.*$</packageUrl>
+        <packageUrl regex="true">^pkg:maven/com\.azure/azure-(core|core-http-netty|identity|json)@.*$</packageUrl>
         <cve>CVE-2026-33117</cve>
     </suppress>
 


### PR DESCRIPTION
## What

Scopes the CVE-2026-33117 suppression to the four Azure artifacts that OWASP actually mis-matches, and replaces the suppression comment, which was wrong on both of its claims.

## Why

CVE-2026-33117 is an incorrect authentication tag comparison in the local cryptography path of the Azure SDK for Java Key Vault Keys library (`azure-security-keyvault-keys`), CVSS 9.1 critical, fixed in 4.10.6. TRAC does not depend on that artifact - it appears nowhere in the aggregate OWASP report and nowhere in the source tree - so the vulnerable code is not present.

NVD files the CVE under the generic CPE `cpe:2.3:a:microsoft:azure_sdk_for_java` with the range up to (excluding) 4.10.6. OWASP therefore matches every `com.azure` artifact whose own version number happens to sort below 4.10.6. In the current dependency set that is exactly four: `azure-core` 1.55.4, `azure-core-http-netty` 1.15.12, `azure-identity` 1.16.2 and `azure-json` 1.5.0. The storage artifacts are 12.x and sit above the boundary, so they are never matched.

The previous rule covered all of `com.azure` and gave the reason as no fix available at time of writing. A fix does exist (4.10.6), and the actual reason is that the vulnerable package is absent. More importantly, a blanket rule would silently hide a genuine 9.1 finding if `azure-security-keyvault-keys` below 4.10.6 were ever pulled in.

## Verification

- ODC evaluates `<packageUrl regex="true">` with `java.util.regex.Pattern`, compiled with `CASE_INSENSITIVE` and applied via `matcher(text).matches()` - a full match. Confirmed in `PropertyType.matches()` in dependency-check core.
- The narrowed pattern was tested against the real package URLs under that exact construction. It matches the four artifacts above, and does not match `azure-security-keyvault-keys` at either 4.9.0 or 4.10.5, nor any of the storage, avro or xml artifacts.
- The suppression file is well-formed XML.

Behaviour is unchanged for the current dependency set: the same four findings remain suppressed, and no previously reported finding becomes visible or hidden.