### PR TITLE
CVE 2026 25087: remove suppression for Apache Arrow

### DIFF
--- a/dev/compliance/owasp-false-positives.xml
+++ b/dev/compliance/owasp-false-positives.xml
@@ -308,11 +308,11 @@
     <!-- vulnerable C++ code is not present. A version bump does not clear the finding: arrow-java is -->
     <!-- versioned independently of Arrow C++ (latest arrow-java is 19.0.0, there is no arrow-java -->
     <!-- 23.0.1), and the CVE's CPE range (15.0.0-23.0.0) still covers all current arrow-java versions. -->
-    <suppress>
+<!--     <suppress>
         <packageUrl regex="true">^pkg:maven/org\.apache\.arrow/.*@.*$</packageUrl>
         <cve>CVE-2026-25087</cve>
     </suppress>
-
+ -->
     <!-- CVE-2026-33117: FALSE POSITIVE against the artifacts listed below. The vulnerability is an -->
     <!-- incorrect authentication tag comparison in the local cryptography path of the Azure SDK for -->
     <!-- Java Key Vault Keys library (azure-security-keyvault-keys), fixed in 4.10.6. TRAC does not -->

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -34,7 +34,7 @@ ext {
     gapi_version = '2.60.0'
 
     // Data technologies
-    arrow_version = '25.0.1'
+    arrow_version = '18.3.0'
     jackson_version = '2.21.5'
     jackson_databind_version = '2.21.5'
     // jackson-annotations versions independently of core/databind and dropped its

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -34,7 +34,7 @@ ext {
     gapi_version = '2.60.0'
 
     // Data technologies
-    arrow_version = '18.3.0'
+    arrow_version = '25.0.1'
     jackson_version = '2.21.5'
     jackson_databind_version = '2.21.5'
     // jackson-annotations versions independently of core/databind and dropped its


### PR DESCRIPTION
Originally the Java-only version of Apache Arrow was wrongly triggering the CVE checker.  This was because its definition was too loose.  Let's see if that's changed.