### PR TITLE
pip-audit as part of runtime compliance checks

### DIFF
--- a/.github/workflows/compliance.yaml
+++ b/.github/workflows/compliance.yaml
@@ -162,6 +162,8 @@ jobs:
 
       # Run pippaudit: see https://github.com/marketplace/actions/gh-action-pip-audit
       - uses: pypa/gh-action-pip-audit@v1.1.0
+        with:
+          inputs: ./tracdap-runtime/python/requirements.txt ./tracdap-runtime/python/requirements_extensions.txt ./tracdap-runtime/python/requirements_plugins.txt
 
   web_api_compliance:
 

--- a/.github/workflows/compliance.yaml
+++ b/.github/workflows/compliance.yaml
@@ -149,7 +149,7 @@ jobs:
         run: |
           mkdir -p build/compliance/python-runtime-safety
           cd tracdap-runtime/python
-          safety check --ignore 70612 --output text > ../../build/compliance/python-runtime-safety/python-runtime-safety-report.txt
+          c --ignore 70612 --output text > ../../build/compliance/python-runtime-safety/python-runtime-safety-report.txt
           safety check --ignore 70612 --output json > ../../build/compliance/python-runtime-safety/python-runtime-safety-report.json
 
       # Always save the reports - they are especially needed when the checks have failed!
@@ -159,6 +159,9 @@ jobs:
         with:
           name: compliance-reports-python
           path: build/compliance/**
+
+      # Run pippaudit: see https://github.com/marketplace/actions/gh-action-pip-audit
+      - uses: pypa/gh-action-pip-audit@v1.1.0
 
   web_api_compliance:
 

--- a/.github/workflows/compliance.yaml
+++ b/.github/workflows/compliance.yaml
@@ -149,7 +149,7 @@ jobs:
         run: |
           mkdir -p build/compliance/python-runtime-safety
           cd tracdap-runtime/python
-          c --ignore 70612 --output text > ../../build/compliance/python-runtime-safety/python-runtime-safety-report.txt
+          safety check --ignore 70612 --output text > ../../build/compliance/python-runtime-safety/python-runtime-safety-report.txt
           safety check --ignore 70612 --output json > ../../build/compliance/python-runtime-safety/python-runtime-safety-report.json
 
       # Always save the reports - they are especially needed when the checks have failed!


### PR DESCRIPTION
This adds [pip-audit](https://github.com/marketplace/actions/gh-action-pip-audit) as a compliance check for the Python runtime.  It may pick up vulnerabilities more reliably than 'safety', although a summary isn't saved to disk.