### PR TITLE
Update pip-audit in compliance workflow

### DIFF
--- a/.github/workflows/compliance.yaml
+++ b/.github/workflows/compliance.yaml
@@ -166,11 +166,12 @@ jobs:
           name: compliance-reports-python
           path: build/compliance/**
 
-      # Run pip-audit: see https://github.com/marketplace/actions/gh-action-pip-audit
       - name: Pip-audit Dependency Check
-        uses: pypa/gh-action-pip-audit@v1.1.0
-        with:
-          inputs: ./tracdap-runtime/python/requirements.txt ./tracdap-runtime/python/requirements_extensions.txt ./tracdap-runtime/python/requirements_plugins.txt
+        env:
+          PIP_AUDIT_PROGRESS_SPINNER: "off"
+        run: |
+          pip install pip-audit
+          pip-audit
 
   web_api_compliance:
 


### PR DESCRIPTION
Use latest pip-audit directly from pip instead of the ancient (yet recommended...) GitHub actions workflow.  

This should fix the msgpack vuln Docker Hub flagged.