### PR TITLE
Fix/release 0.10 compliance workflow

### DIFF
--- a/.github/workflows/compliance.yaml
+++ b/.github/workflows/compliance.yaml
@@ -143,6 +143,12 @@ jobs:
           pip-licenses --format=html --ignore-packages $IGNORE_LICENSE > ../../build/compliance/python-runtime-licenses/python-runtime-licenses.html
           pip-licenses --allow-only="$ALLOWED_LICENSES" --ignore-packages $IGNORE_LICENSE
 
+      # Not strictly necessary but very helpful for figuring out the source of transitive dependencies
+      - name: Dump Python dependency tree
+        run: |
+          pip install pipdeptree
+          pipdeptree
+
       # CVE-2019-8341 (safety id: 70612) is a vulnerability in the latest version of Jinja2, no fix is available
       # It is only pulled in as a dependency of safety check itself, it is not a dependency of the dist wheels
       - name: Safety check

--- a/.github/workflows/compliance.yaml
+++ b/.github/workflows/compliance.yaml
@@ -166,11 +166,12 @@ jobs:
           name: compliance-reports-python
           path: build/compliance/**
 
-      # Run pip-audit: see https://github.com/marketplace/actions/gh-action-pip-audit
       - name: Pip-audit Dependency Check
-        uses: pypa/gh-action-pip-audit@v1.1.0
-        with:
-          inputs: ./tracdap-runtime/python/requirements.txt ./tracdap-runtime/python/requirements_extensions.txt ./tracdap-runtime/python/requirements_plugins.txt
+        env:
+          PIP_AUDIT_PROGRESS_SPINNER: "off"
+        run: |
+          pip install pip-audit
+          pip-audit
 
   web_api_compliance:
 


### PR DESCRIPTION
Description: Brings release/0.10 up to date with the 2 commits main has gained since the last sync (#739), both to the compliance/pip-audit workflow.                                                                                                                                                                                                  
                                                                                                                                                                                
- Compliance workflow: dump Python dependency tree (#740)                                                                                                                     
- Use recent pip-audit instead of the ancient (yet recommended...) GitHub Actions workflow. This should fix the msgpack vuln Docker Hub flagged (#741)                                                                                                                                                                             
                                                                                                                                                                                
Cherry-picked directly onto release/0.10 rather than merged, so this branch's content is identical to main (verified: matching tree hash) while its history stays release/0.10 + these 2 commits — a clean, minimal diff to review.                                                                                                                                                                           
    