### PR TITLE
Feature/data import and export

### DIFF
--- a/examples/models/python/src/tutorial/data_import.py
+++ b/examples/models/python/src/tutorial/data_import.py
@@ -173,11 +173,14 @@ class SimpleDataImport(trac.TracDataImport):
         storage = ctx.get_file_storage(storage_key)
 
         storage_file = ctx.get_parameter("source_file")
+        file_stat = storage.stat(storage_file)
 
         with storage.read_byte_stream(storage_file) as file_stream:
 
             dataset = pd.read_parquet(file_stream)
             ctx.put_pandas_table("customer_loans", dataset)
+
+        ctx.set_source_metadata("customer_loans", storage_key, file_stat)
 
 
 if __name__ == "__main__":

--- a/tracdap-libs/tracdap-lib-common/src/main/java/org/finos/tracdap/common/metadata/MetadataConstants.java
+++ b/tracdap-libs/tracdap-lib-common/src/main/java/org/finos/tracdap/common/metadata/MetadataConstants.java
@@ -97,6 +97,7 @@ public class MetadataConstants {
     public static final String TRAC_MODEL_VERSION = "trac_model_version";
     public static final String TRAC_MODEL_ENTRY_POINT = "trac_model_entry_point";
     public static final String TRAC_MODEL_PATH = "trac_model_path";
+    public static final String TRAC_MODEL_TYPE = "trac_model_type";
 
     public static final String TRAC_CONFIG_CLASS = "trac_config_class";
     public static final String TRAC_CONFIG_KEY = "trac_config_key";

--- a/tracdap-libs/tracdap-lib-meta/src/main/java/org/finos/tracdap/common/metadata/tag/ObjectUpdateLogic.java
+++ b/tracdap-libs/tracdap-lib-meta/src/main/java/org/finos/tracdap/common/metadata/tag/ObjectUpdateLogic.java
@@ -302,6 +302,11 @@ public class ObjectUpdateLogic {
                     .build());
         }
 
+        modelAttrs.add(TagUpdate.newBuilder()
+                .setAttrName(MetadataConstants.TRAC_MODEL_TYPE)
+                .setValue(MetadataCodec.encodeValue(tracModel.getModelType().name()))
+                .build());
+
         return modelAttrs;
     }
 

--- a/tracdap-libs/tracdap-lib-meta/src/test/java/org/finos/tracdap/common/metadata/tag/ObjectUpdateLogicTest.java
+++ b/tracdap-libs/tracdap-lib-meta/src/test/java/org/finos/tracdap/common/metadata/tag/ObjectUpdateLogicTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Fintech Open Source Foundation (FINOS) under one or
+ * more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * FINOS licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.finos.tracdap.common.metadata.tag;
+
+import org.finos.tracdap.metadata.*;
+import org.finos.tracdap.common.metadata.MetadataCodec;
+import org.finos.tracdap.common.metadata.MetadataConstants;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.stream.Collectors;
+import java.util.Map;
+
+
+class ObjectUpdateLogicTest {
+
+    @Test
+    void structuredModelAttrs_standardModel() {
+
+        var modelDef = ModelDefinition.newBuilder()
+                .setLanguage("python")
+                .setRepository("UNIT_TEST_REPO")
+                .setVersion("v1.0.0")
+                .setEntryPoint("acme.models.test_model.BasicTestModel")
+                .setModelType(ModelType.STANDARD_MODEL)
+                .build();
+
+        var attrs = attrsByName(ObjectUpdateLogic.structuredModelAttrs(modelDef));
+
+        assertEquals("STANDARD_MODEL", MetadataCodec.decodeStringValue(attrs.get(MetadataConstants.TRAC_MODEL_TYPE)));
+    }
+
+    @Test
+    void structuredModelAttrs_dataImportModel() {
+
+        var modelDef = ModelDefinition.newBuilder()
+                .setLanguage("python")
+                .setRepository("UNIT_TEST_REPO")
+                .setVersion("v1.0.0")
+                .setEntryPoint("acme.models.test_model.BasicDataImportModel")
+                .setModelType(ModelType.DATA_IMPORT_MODEL)
+                .build();
+
+        var attrs = attrsByName(ObjectUpdateLogic.structuredModelAttrs(modelDef));
+
+        assertEquals("DATA_IMPORT_MODEL", MetadataCodec.decodeStringValue(attrs.get(MetadataConstants.TRAC_MODEL_TYPE)));
+    }
+
+    @Test
+    void structuredModelAttrs_dataExportModel() {
+
+        var modelDef = ModelDefinition.newBuilder()
+                .setLanguage("python")
+                .setRepository("UNIT_TEST_REPO")
+                .setVersion("v1.0.0")
+                .setEntryPoint("acme.models.test_model.BasicDataExportModel")
+                .setModelType(ModelType.DATA_EXPORT_MODEL)
+                .build();
+
+        var attrs = attrsByName(ObjectUpdateLogic.structuredModelAttrs(modelDef));
+
+        assertEquals("DATA_EXPORT_MODEL", MetadataCodec.decodeStringValue(attrs.get(MetadataConstants.TRAC_MODEL_TYPE)));
+    }
+
+    private static Map<String, Value> attrsByName(java.util.List<TagUpdate> attrs) {
+
+        return attrs.stream().collect(Collectors.toMap(TagUpdate::getAttrName, TagUpdate::getValue));
+    }
+}

--- a/tracdap-libs/tracdap-lib-test/src/main/java/org/finos/tracdap/test/helpers/PlatformTest.java
+++ b/tracdap-libs/tracdap-lib-test/src/main/java/org/finos/tracdap/test/helpers/PlatformTest.java
@@ -670,7 +670,7 @@ public class PlatformTest implements BeforeAllCallback, AfterAllCallback {
 
                 var tracRtDistDir = tracRepoDir.resolve(TRAC_RUNTIME_DIST_DIR);
 
-                var corePackages = List.of(pythonExe, "-m", "pip", "install", "pandas", "polars");
+                var corePackages = List.of(pythonExe, "-m", "pip", "install", "pandas", "polars", "pytz");
                 var pipInstall = new ArrayList<>(corePackages);
 
                 try (var tracRtWheels = Files.find(tracRtDistDir, 1, (file, attrs) -> file.toString().endsWith(".whl"))) {

--- a/tracdap-libs/tracdap-lib-test/src/main/resources/config/trac-e2e-tenants.yaml
+++ b/tracdap-libs/tracdap-lib-test/src/main/resources/config/trac-e2e-tenants.yaml
@@ -53,3 +53,9 @@ tenants:
           host: api.github.com
           port: 443
           tls: true
+
+      TEST_EXTERNAL_STORAGE:
+        resourceType: EXTERNAL_STORAGE
+        protocol: LOCAL
+        properties:
+          rootPath: ${TRAC_DIR}/external_storage

--- a/tracdap-libs/tracdap-lib-test/src/main/resources/config/trac-unit-tenants.yaml
+++ b/tracdap-libs/tracdap-lib-test/src/main/resources/config/trac-unit-tenants.yaml
@@ -48,3 +48,12 @@ tenants:
           unit-test.property: repo-value.2
         properties:
           repoUrl: ${TRAC_LOCAL_REPO}
+
+      UNIT_TEST_EXTERNAL_STORAGE:
+        resourceType: EXTERNAL_STORAGE
+        protocol: LOCAL
+        publicProperties:
+          unit_test_property: storage_value_3
+          unit-test.property: storage-value.3
+        properties:
+          rootPath: ${TRAC_STORAGE_DIR}

--- a/tracdap-libs/tracdap-lib-validation/src/main/java/org/finos/tracdap/common/validation/consistency/JobConsistencyValidator.java
+++ b/tracdap-libs/tracdap-lib-validation/src/main/java/org/finos/tracdap/common/validation/consistency/JobConsistencyValidator.java
@@ -68,10 +68,16 @@ public class JobConsistencyValidator {
 
     private static final Descriptors.Descriptor IMPORT_DATA_JOB;
     private static final Descriptors.FieldDescriptor IDJ_MODEL;
+    private static final Descriptors.FieldDescriptor IDJ_PARAMETERS;
+    private static final Descriptors.FieldDescriptor IDJ_INPUTS;
+    private static final Descriptors.FieldDescriptor IDJ_PRIOR_OUTPUTS;
     private static final Descriptors.FieldDescriptor IDJ_STORAGE_ACCESS;
 
     private static final Descriptors.Descriptor EXPORT_DATA_JOB;
     private static final Descriptors.FieldDescriptor EDJ_MODEL;
+    private static final Descriptors.FieldDescriptor EDJ_PARAMETERS;
+    private static final Descriptors.FieldDescriptor EDJ_INPUTS;
+    private static final Descriptors.FieldDescriptor EDJ_PRIOR_OUTPUTS;
     private static final Descriptors.FieldDescriptor EDJ_STORAGE_ACCESS;
 
     static {
@@ -102,10 +108,16 @@ public class JobConsistencyValidator {
 
         IMPORT_DATA_JOB = ImportDataJob.getDescriptor();
         IDJ_MODEL = field(IMPORT_DATA_JOB, ImportDataJob.MODEL_FIELD_NUMBER);
+        IDJ_PARAMETERS = field(IMPORT_DATA_JOB, ImportDataJob.PARAMETERS_FIELD_NUMBER);
+        IDJ_INPUTS = field(IMPORT_DATA_JOB, ImportDataJob.INPUTS_FIELD_NUMBER);
+        IDJ_PRIOR_OUTPUTS = field(IMPORT_DATA_JOB, ImportDataJob.PRIOROUTPUTS_FIELD_NUMBER);
         IDJ_STORAGE_ACCESS = field(IMPORT_DATA_JOB, ImportDataJob.STORAGEACCESS_FIELD_NUMBER);
 
         EXPORT_DATA_JOB = ExportDataJob.getDescriptor();
         EDJ_MODEL = field(EXPORT_DATA_JOB, ExportDataJob.MODEL_FIELD_NUMBER);
+        EDJ_PARAMETERS = field(EXPORT_DATA_JOB, ExportDataJob.PARAMETERS_FIELD_NUMBER);
+        EDJ_INPUTS = field(EXPORT_DATA_JOB, ExportDataJob.INPUTS_FIELD_NUMBER);
+        EDJ_PRIOR_OUTPUTS = field(EXPORT_DATA_JOB, ExportDataJob.PRIOROUTPUTS_FIELD_NUMBER);
         EDJ_STORAGE_ACCESS = field(EXPORT_DATA_JOB, ExportDataJob.STORAGEACCESS_FIELD_NUMBER);
     }
 
@@ -223,6 +235,8 @@ public class JobConsistencyValidator {
     }
 
     @Validator
+    // Suppression is needed because validator method reference accepts a generic type (Map)
+    @SuppressWarnings("unchecked")
     public static ValidationContext importDataJob(ImportDataJob job, ValidationContext ctx) {
 
         var metadata = ctx.getMetadataBundle();
@@ -244,6 +258,19 @@ public class JobConsistencyValidator {
             ctx = ctx.push(IDJ_MODEL).error(message).pop();
         }
 
+        ctx.pushMap(IDJ_PARAMETERS, ImportDataJob::getParametersMap)
+                .apply(JobConsistencyValidator::runModelParameters, Map.class, modelDef.getParametersMap())
+                .pop();
+
+        ctx.pushMap(IDJ_INPUTS, ImportDataJob::getInputsMap)
+                .apply(JobConsistencyValidator::runModelInputs, Map.class, modelDef.getInputsMap())
+                .pop();
+
+        // Prior outputs are optional, however any provided must be valid
+        ctx.pushMap(IDJ_PRIOR_OUTPUTS, ImportDataJob::getPriorOutputsMap)
+                .apply(JobConsistencyValidator::runModelPriorOutputs, Map.class, modelDef.getOutputsMap())
+                .pop();
+
         ctx = ctx.pushRepeated(IDJ_STORAGE_ACCESS)
                 .applyRepeated(JobConsistencyValidator::storageAccessIsExternalStorage)
                 .pop();
@@ -252,6 +279,8 @@ public class JobConsistencyValidator {
     }
 
     @Validator
+    // Suppression is needed because validator method reference accepts a generic type (Map)
+    @SuppressWarnings("unchecked")
     public static ValidationContext exportDataJob(ExportDataJob job, ValidationContext ctx) {
 
         var metadata = ctx.getMetadataBundle();
@@ -272,6 +301,19 @@ public class JobConsistencyValidator {
 
             ctx = ctx.push(EDJ_MODEL).error(message).pop();
         }
+
+        ctx.pushMap(EDJ_PARAMETERS, ExportDataJob::getParametersMap)
+                .apply(JobConsistencyValidator::runModelParameters, Map.class, modelDef.getParametersMap())
+                .pop();
+
+        ctx.pushMap(EDJ_INPUTS, ExportDataJob::getInputsMap)
+                .apply(JobConsistencyValidator::runModelInputs, Map.class, modelDef.getInputsMap())
+                .pop();
+
+        // Prior outputs are optional, however any provided must be valid
+        ctx.pushMap(EDJ_PRIOR_OUTPUTS, ExportDataJob::getPriorOutputsMap)
+                .apply(JobConsistencyValidator::runModelPriorOutputs, Map.class, modelDef.getOutputsMap())
+                .pop();
 
         ctx = ctx.pushRepeated(EDJ_STORAGE_ACCESS)
                 .applyRepeated(JobConsistencyValidator::storageAccessIsExternalStorage)

--- a/tracdap-libs/tracdap-lib-validation/src/main/java/org/finos/tracdap/common/validation/consistency/JobConsistencyValidator.java
+++ b/tracdap-libs/tracdap-lib-validation/src/main/java/org/finos/tracdap/common/validation/consistency/JobConsistencyValidator.java
@@ -66,6 +66,14 @@ public class JobConsistencyValidator {
     private static final Descriptors.FieldDescriptor RFJ_PRIOR_OUTPUTS;
     private static final Descriptors.FieldDescriptor RFJ_RESOURCES;
 
+    private static final Descriptors.Descriptor IMPORT_DATA_JOB;
+    private static final Descriptors.FieldDescriptor IDJ_MODEL;
+    private static final Descriptors.FieldDescriptor IDJ_STORAGE_ACCESS;
+
+    private static final Descriptors.Descriptor EXPORT_DATA_JOB;
+    private static final Descriptors.FieldDescriptor EDJ_MODEL;
+    private static final Descriptors.FieldDescriptor EDJ_STORAGE_ACCESS;
+
     static {
 
         JOB_DEFINITION = JobDefinition.getDescriptor();
@@ -91,6 +99,14 @@ public class JobConsistencyValidator {
         RFJ_OUTPUTS = field(RUN_FLOW_JOB, RunFlowJob.OUTPUTS_FIELD_NUMBER);
         RFJ_PRIOR_OUTPUTS = field(RUN_FLOW_JOB, RunFlowJob.PRIOROUTPUTS_FIELD_NUMBER);
         RFJ_RESOURCES = field(RUN_FLOW_JOB, RunFlowJob.RESOURCES_FIELD_NUMBER);
+
+        IMPORT_DATA_JOB = ImportDataJob.getDescriptor();
+        IDJ_MODEL = field(IMPORT_DATA_JOB, ImportDataJob.MODEL_FIELD_NUMBER);
+        IDJ_STORAGE_ACCESS = field(IMPORT_DATA_JOB, ImportDataJob.STORAGEACCESS_FIELD_NUMBER);
+
+        EXPORT_DATA_JOB = ExportDataJob.getDescriptor();
+        EDJ_MODEL = field(EXPORT_DATA_JOB, ExportDataJob.MODEL_FIELD_NUMBER);
+        EDJ_STORAGE_ACCESS = field(EXPORT_DATA_JOB, ExportDataJob.STORAGEACCESS_FIELD_NUMBER);
     }
 
     @Validator
@@ -202,6 +218,80 @@ public class JobConsistencyValidator {
         ctx.pushMap(RFJ_OUTPUTS, RunFlowJob::getOutputsMap)
                 .apply(JobConsistencyValidator::runFlowOutputs, Map.class, graph)
                 .pop();
+
+        return ctx;
+    }
+
+    @Validator
+    public static ValidationContext importDataJob(ImportDataJob job, ValidationContext ctx) {
+
+        var metadata = ctx.getMetadataBundle();
+        var modelObj = metadata.getObject(job.getModel());
+
+        if (modelObj == null) {
+            var message = "Required metadata is not available for [" + MetadataUtil.objectKey(job.getModel()) + "]";
+            return ctx.push(IDJ_MODEL).error(message).pop();
+        }
+
+        var modelDef = modelObj.getModel();
+
+        if (modelDef.getModelType() != ModelType.DATA_IMPORT_MODEL) {
+
+            var message = String.format(
+                    "Model [%s] is not a data import model (expected %s, got %s)",
+                    MetadataUtil.objectKey(job.getModel()), ModelType.DATA_IMPORT_MODEL, modelDef.getModelType());
+
+            ctx = ctx.push(IDJ_MODEL).error(message).pop();
+        }
+
+        ctx = ctx.pushRepeated(IDJ_STORAGE_ACCESS)
+                .applyRepeated(JobConsistencyValidator::storageAccessIsExternalStorage)
+                .pop();
+
+        return ctx;
+    }
+
+    @Validator
+    public static ValidationContext exportDataJob(ExportDataJob job, ValidationContext ctx) {
+
+        var metadata = ctx.getMetadataBundle();
+        var modelObj = metadata.getObject(job.getModel());
+
+        if (modelObj == null) {
+            var message = "Required metadata is not available for [" + MetadataUtil.objectKey(job.getModel()) + "]";
+            return ctx.push(EDJ_MODEL).error(message).pop();
+        }
+
+        var modelDef = modelObj.getModel();
+
+        if (modelDef.getModelType() != ModelType.DATA_EXPORT_MODEL) {
+
+            var message = String.format(
+                    "Model [%s] is not a data export model (expected %s, got %s)",
+                    MetadataUtil.objectKey(job.getModel()), ModelType.DATA_EXPORT_MODEL, modelDef.getModelType());
+
+            ctx = ctx.push(EDJ_MODEL).error(message).pop();
+        }
+
+        ctx = ctx.pushRepeated(EDJ_STORAGE_ACCESS)
+                .applyRepeated(JobConsistencyValidator::storageAccessIsExternalStorage)
+                .pop();
+
+        return ctx;
+    }
+
+    private static ValidationContext storageAccessIsExternalStorage(String resourceName, ValidationContext ctx) {
+
+        var resource = ctx.getResourceBundle().getResource(resourceName, false);
+
+        if (resource == null)
+            return ctx.error(String.format("Resource is not available for [%s]", resourceName));
+
+        if (resource.getResourceType() != ResourceType.EXTERNAL_STORAGE) {
+            return ctx.error(String.format(
+                    "Resource [%s] is the wrong type (expected %s, got %s)",
+                    resourceName, ResourceType.EXTERNAL_STORAGE, resource.getResourceType()));
+        }
 
         return ctx;
     }

--- a/tracdap-libs/tracdap-lib-validation/src/main/java/org/finos/tracdap/common/validation/static_/JobValidator.java
+++ b/tracdap-libs/tracdap-lib-validation/src/main/java/org/finos/tracdap/common/validation/static_/JobValidator.java
@@ -287,6 +287,8 @@ public class JobValidator {
         return importOrExportJob(ctx, EDJ_PARAMETERS, EDJ_INPUTS, EDJ_OUTPUTS, EDJ_PRIOR_OUTPUTS, EDJ_STORAGE_ACCESS);
     }
 
+    // Duplicates runModelOrFlow's parameters/inputs/outputs/priorOutputs validation blocks
+    // (not shared with RunModelJob/RunFlowJob)
     private static ValidationContext importOrExportJob(
             ValidationContext ctx,
             Descriptors.FieldDescriptor parameters,

--- a/tracdap-libs/tracdap-lib-validation/src/main/java/org/finos/tracdap/common/validation/static_/JobValidator.java
+++ b/tracdap-libs/tracdap-lib-validation/src/main/java/org/finos/tracdap/common/validation/static_/JobValidator.java
@@ -61,6 +61,7 @@ public class JobValidator {
     private static final Descriptors.FieldDescriptor RMJ_OUTPUTS;
     private static final Descriptors.FieldDescriptor RMJ_PRIOR_OUTPUTS;
     private static final Descriptors.FieldDescriptor RMJ_RESOURCES;
+    private static final Descriptors.FieldDescriptor RMJ_OUTPUT_ATTRS;
 
     private static final Descriptors.Descriptor RUN_FLOW_JOB;
     private static final Descriptors.FieldDescriptor RFJ_FLOW;
@@ -70,6 +71,7 @@ public class JobValidator {
     private static final Descriptors.FieldDescriptor RFJ_OUTPUTS;
     private static final Descriptors.FieldDescriptor RFJ_PRIOR_OUTPUTS;
     private static final Descriptors.FieldDescriptor RFJ_RESOURCES;
+    private static final Descriptors.FieldDescriptor RFJ_OUTPUT_ATTRS;
 
     private static final Descriptors.Descriptor IMPORT_DATA_JOB;
     private static final Descriptors.FieldDescriptor IDJ_MODEL;
@@ -78,6 +80,9 @@ public class JobValidator {
     private static final Descriptors.FieldDescriptor IDJ_OUTPUTS;
     private static final Descriptors.FieldDescriptor IDJ_PRIOR_OUTPUTS;
     private static final Descriptors.FieldDescriptor IDJ_STORAGE_ACCESS;
+    private static final Descriptors.FieldDescriptor IDJ_IMPORTS;
+    private static final Descriptors.FieldDescriptor IDJ_OUTPUT_ATTRS;
+    private static final Descriptors.FieldDescriptor IDJ_IMPORT_ATTRS;
 
     private static final Descriptors.Descriptor EXPORT_DATA_JOB;
     private static final Descriptors.FieldDescriptor EDJ_MODEL;
@@ -86,6 +91,8 @@ public class JobValidator {
     private static final Descriptors.FieldDescriptor EDJ_OUTPUTS;
     private static final Descriptors.FieldDescriptor EDJ_PRIOR_OUTPUTS;
     private static final Descriptors.FieldDescriptor EDJ_STORAGE_ACCESS;
+    private static final Descriptors.FieldDescriptor EDJ_EXPORTS;
+    private static final Descriptors.FieldDescriptor EDJ_OUTPUT_ATTRS;
 
     static {
 
@@ -108,6 +115,7 @@ public class JobValidator {
         RMJ_OUTPUTS = field(RUN_MODEL_JOB, RunModelJob.OUTPUTS_FIELD_NUMBER);
         RMJ_PRIOR_OUTPUTS = field(RUN_MODEL_JOB, RunModelJob.PRIOROUTPUTS_FIELD_NUMBER);
         RMJ_RESOURCES = field(RUN_MODEL_JOB, RunModelJob.RESOURCES_FIELD_NUMBER);
+        RMJ_OUTPUT_ATTRS = field(RUN_MODEL_JOB, RunModelJob.OUTPUTATTRS_FIELD_NUMBER);
 
         RUN_FLOW_JOB = RunFlowJob.getDescriptor();
         RFJ_FLOW = field(RUN_FLOW_JOB, RunFlowJob.FLOW_FIELD_NUMBER);
@@ -117,6 +125,7 @@ public class JobValidator {
         RFJ_OUTPUTS = field(RUN_FLOW_JOB, RunFlowJob.OUTPUTS_FIELD_NUMBER);
         RFJ_PRIOR_OUTPUTS = field(RUN_FLOW_JOB, RunFlowJob.PRIOROUTPUTS_FIELD_NUMBER);
         RFJ_RESOURCES = field(RUN_FLOW_JOB, RunFlowJob.RESOURCES_FIELD_NUMBER);
+        RFJ_OUTPUT_ATTRS = field(RUN_FLOW_JOB, RunFlowJob.OUTPUTATTRS_FIELD_NUMBER);
 
         IMPORT_DATA_JOB = ImportDataJob.getDescriptor();
         IDJ_MODEL = field(IMPORT_DATA_JOB, ImportDataJob.MODEL_FIELD_NUMBER);
@@ -125,6 +134,9 @@ public class JobValidator {
         IDJ_OUTPUTS = field(IMPORT_DATA_JOB, ImportDataJob.OUTPUTS_FIELD_NUMBER);
         IDJ_PRIOR_OUTPUTS = field(IMPORT_DATA_JOB, ImportDataJob.PRIOROUTPUTS_FIELD_NUMBER);
         IDJ_STORAGE_ACCESS = field(IMPORT_DATA_JOB, ImportDataJob.STORAGEACCESS_FIELD_NUMBER);
+        IDJ_IMPORTS = field(IMPORT_DATA_JOB, ImportDataJob.IMPORTS_FIELD_NUMBER);
+        IDJ_OUTPUT_ATTRS = field(IMPORT_DATA_JOB, ImportDataJob.OUTPUTATTRS_FIELD_NUMBER);
+        IDJ_IMPORT_ATTRS = field(IMPORT_DATA_JOB, ImportDataJob.IMPORTATTRS_FIELD_NUMBER);
 
         EXPORT_DATA_JOB = ExportDataJob.getDescriptor();
         EDJ_MODEL = field(EXPORT_DATA_JOB, ExportDataJob.MODEL_FIELD_NUMBER);
@@ -133,6 +145,8 @@ public class JobValidator {
         EDJ_OUTPUTS = field(EXPORT_DATA_JOB, ExportDataJob.OUTPUTS_FIELD_NUMBER);
         EDJ_PRIOR_OUTPUTS = field(EXPORT_DATA_JOB, ExportDataJob.PRIOROUTPUTS_FIELD_NUMBER);
         EDJ_STORAGE_ACCESS = field(EXPORT_DATA_JOB, ExportDataJob.STORAGEACCESS_FIELD_NUMBER);
+        EDJ_EXPORTS = field(EXPORT_DATA_JOB, ExportDataJob.EXPORTS_FIELD_NUMBER);
+        EDJ_OUTPUT_ATTRS = field(EXPORT_DATA_JOB, ExportDataJob.OUTPUTATTRS_FIELD_NUMBER);
     }
 
     @Validator
@@ -192,7 +206,9 @@ public class JobValidator {
                 .apply(ObjectIdValidator::selectorType, TagSelector.class, ObjectType.MODEL)
                 .pop();
 
-        return runModelOrFlow(ctx, RMJ_PARAMETERS, RMJ_INPUTS, RMJ_OUTPUTS, RMJ_PRIOR_OUTPUTS, RMJ_RESOURCES);
+        ctx = runModelOrFlow(ctx, RMJ_PARAMETERS, RMJ_INPUTS, RMJ_OUTPUTS, RMJ_PRIOR_OUTPUTS, RMJ_RESOURCES);
+
+        return outputAttrs(ctx, RMJ_OUTPUT_ATTRS);
     }
 
     @Validator
@@ -212,7 +228,9 @@ public class JobValidator {
                 .applyMapValues(ObjectIdValidator::fixedObjectVersion, TagSelector.class)
                 .pop();
 
-        return runModelOrFlow(ctx, RFJ_PARAMETERS, RFJ_INPUTS, RFJ_OUTPUTS, RFJ_PRIOR_OUTPUTS, RFJ_RESOURCES);
+        ctx = runModelOrFlow(ctx, RFJ_PARAMETERS, RFJ_INPUTS, RFJ_OUTPUTS, RFJ_PRIOR_OUTPUTS, RFJ_RESOURCES);
+
+        return outputAttrs(ctx, RFJ_OUTPUT_ATTRS);
     }
 
     public static ValidationContext runModelOrFlow(
@@ -263,6 +281,14 @@ public class JobValidator {
         return ctx;
     }
 
+    private static ValidationContext outputAttrs(ValidationContext ctx, Descriptors.FieldDescriptor outputAttrs) {
+
+        return ctx.pushRepeated(outputAttrs)
+                .applyRepeated(TagUpdateValidator::tagUpdate, TagUpdate.class)
+                .applyRepeated(TagUpdateValidator::reservedAttrs, TagUpdate.class, false)
+                .pop();
+    }
+
     @Validator
     public static ValidationContext importDataJob(ImportDataJob msg, ValidationContext ctx) {
 
@@ -272,7 +298,23 @@ public class JobValidator {
                 .apply(ObjectIdValidator::selectorType, TagSelector.class, ObjectType.MODEL)
                 .pop();
 
-        return importOrExportJob(ctx, IDJ_PARAMETERS, IDJ_INPUTS, IDJ_OUTPUTS, IDJ_PRIOR_OUTPUTS, IDJ_STORAGE_ACCESS);
+        ctx = importOrExportJob(ctx, IDJ_PARAMETERS, IDJ_INPUTS, IDJ_OUTPUTS, IDJ_PRIOR_OUTPUTS, IDJ_STORAGE_ACCESS);
+
+        ctx = outputAttrs(ctx, IDJ_OUTPUT_ATTRS);
+
+        if (msg.getImportsCount() > 0) {
+            ctx = ctx.pushMap(IDJ_IMPORTS)
+                    .error("The imports field is not currently supported and must be empty")
+                    .pop();
+        }
+
+        if (msg.getImportAttrsCount() > 0) {
+            ctx = ctx.pushRepeated(IDJ_IMPORT_ATTRS)
+                    .error("The importAttrs field is not currently supported and must be empty")
+                    .pop();
+        }
+
+        return ctx;
     }
 
     @Validator
@@ -284,7 +326,17 @@ public class JobValidator {
                 .apply(ObjectIdValidator::selectorType, TagSelector.class, ObjectType.MODEL)
                 .pop();
 
-        return importOrExportJob(ctx, EDJ_PARAMETERS, EDJ_INPUTS, EDJ_OUTPUTS, EDJ_PRIOR_OUTPUTS, EDJ_STORAGE_ACCESS);
+        ctx = importOrExportJob(ctx, EDJ_PARAMETERS, EDJ_INPUTS, EDJ_OUTPUTS, EDJ_PRIOR_OUTPUTS, EDJ_STORAGE_ACCESS);
+
+        ctx = outputAttrs(ctx, EDJ_OUTPUT_ATTRS);
+
+        if (msg.getExportsCount() > 0) {
+            ctx = ctx.pushMap(EDJ_EXPORTS)
+                    .error("The exports field is not currently supported and must be empty")
+                    .pop();
+        }
+
+        return ctx;
     }
 
     // Duplicates runModelOrFlow's parameters/inputs/outputs/priorOutputs validation blocks

--- a/tracdap-libs/tracdap-lib-validation/src/main/java/org/finos/tracdap/common/validation/static_/JobValidator.java
+++ b/tracdap-libs/tracdap-lib-validation/src/main/java/org/finos/tracdap/common/validation/static_/JobValidator.java
@@ -36,7 +36,9 @@ public class JobValidator {
     private static final Map<JobDefinition.JobDetailsCase, JobType> JOB_DETAILS_CASE_MAPPING = Map.ofEntries(
             Map.entry(JobDefinition.JobDetailsCase.RUNMODEL, JobType.RUN_MODEL),
             Map.entry(JobDefinition.JobDetailsCase.RUNFLOW, JobType.RUN_FLOW),
-            Map.entry(JobDefinition.JobDetailsCase.IMPORTMODEL, JobType.IMPORT_MODEL));
+            Map.entry(JobDefinition.JobDetailsCase.IMPORTMODEL, JobType.IMPORT_MODEL),
+            Map.entry(JobDefinition.JobDetailsCase.IMPORTDATA, JobType.IMPORT_DATA),
+            Map.entry(JobDefinition.JobDetailsCase.EXPORTDATA, JobType.EXPORT_DATA));
 
     private static final List<ObjectType> ALLOWED_IO_TYPES = List.of(ObjectType.DATA, ObjectType.FILE);
 
@@ -69,6 +71,22 @@ public class JobValidator {
     private static final Descriptors.FieldDescriptor RFJ_PRIOR_OUTPUTS;
     private static final Descriptors.FieldDescriptor RFJ_RESOURCES;
 
+    private static final Descriptors.Descriptor IMPORT_DATA_JOB;
+    private static final Descriptors.FieldDescriptor IDJ_MODEL;
+    private static final Descriptors.FieldDescriptor IDJ_PARAMETERS;
+    private static final Descriptors.FieldDescriptor IDJ_INPUTS;
+    private static final Descriptors.FieldDescriptor IDJ_OUTPUTS;
+    private static final Descriptors.FieldDescriptor IDJ_PRIOR_OUTPUTS;
+    private static final Descriptors.FieldDescriptor IDJ_STORAGE_ACCESS;
+
+    private static final Descriptors.Descriptor EXPORT_DATA_JOB;
+    private static final Descriptors.FieldDescriptor EDJ_MODEL;
+    private static final Descriptors.FieldDescriptor EDJ_PARAMETERS;
+    private static final Descriptors.FieldDescriptor EDJ_INPUTS;
+    private static final Descriptors.FieldDescriptor EDJ_OUTPUTS;
+    private static final Descriptors.FieldDescriptor EDJ_PRIOR_OUTPUTS;
+    private static final Descriptors.FieldDescriptor EDJ_STORAGE_ACCESS;
+
     static {
 
         JOB_DEFINITION = JobDefinition.getDescriptor();
@@ -99,6 +117,22 @@ public class JobValidator {
         RFJ_OUTPUTS = field(RUN_FLOW_JOB, RunFlowJob.OUTPUTS_FIELD_NUMBER);
         RFJ_PRIOR_OUTPUTS = field(RUN_FLOW_JOB, RunFlowJob.PRIOROUTPUTS_FIELD_NUMBER);
         RFJ_RESOURCES = field(RUN_FLOW_JOB, RunFlowJob.RESOURCES_FIELD_NUMBER);
+
+        IMPORT_DATA_JOB = ImportDataJob.getDescriptor();
+        IDJ_MODEL = field(IMPORT_DATA_JOB, ImportDataJob.MODEL_FIELD_NUMBER);
+        IDJ_PARAMETERS = field(IMPORT_DATA_JOB, ImportDataJob.PARAMETERS_FIELD_NUMBER);
+        IDJ_INPUTS = field(IMPORT_DATA_JOB, ImportDataJob.INPUTS_FIELD_NUMBER);
+        IDJ_OUTPUTS = field(IMPORT_DATA_JOB, ImportDataJob.OUTPUTS_FIELD_NUMBER);
+        IDJ_PRIOR_OUTPUTS = field(IMPORT_DATA_JOB, ImportDataJob.PRIOROUTPUTS_FIELD_NUMBER);
+        IDJ_STORAGE_ACCESS = field(IMPORT_DATA_JOB, ImportDataJob.STORAGEACCESS_FIELD_NUMBER);
+
+        EXPORT_DATA_JOB = ExportDataJob.getDescriptor();
+        EDJ_MODEL = field(EXPORT_DATA_JOB, ExportDataJob.MODEL_FIELD_NUMBER);
+        EDJ_PARAMETERS = field(EXPORT_DATA_JOB, ExportDataJob.PARAMETERS_FIELD_NUMBER);
+        EDJ_INPUTS = field(EXPORT_DATA_JOB, ExportDataJob.INPUTS_FIELD_NUMBER);
+        EDJ_OUTPUTS = field(EXPORT_DATA_JOB, ExportDataJob.OUTPUTS_FIELD_NUMBER);
+        EDJ_PRIOR_OUTPUTS = field(EXPORT_DATA_JOB, ExportDataJob.PRIOROUTPUTS_FIELD_NUMBER);
+        EDJ_STORAGE_ACCESS = field(EXPORT_DATA_JOB, ExportDataJob.STORAGEACCESS_FIELD_NUMBER);
     }
 
     @Validator
@@ -229,6 +263,76 @@ public class JobValidator {
         return ctx;
     }
 
+    @Validator
+    public static ValidationContext importDataJob(ImportDataJob msg, ValidationContext ctx) {
+
+        ctx = ctx.push(IDJ_MODEL)
+                .apply(CommonValidators::required)
+                .apply(ObjectIdValidator::tagSelector, TagSelector.class)
+                .apply(ObjectIdValidator::selectorType, TagSelector.class, ObjectType.MODEL)
+                .pop();
+
+        return importOrExportJob(ctx, IDJ_PARAMETERS, IDJ_INPUTS, IDJ_OUTPUTS, IDJ_PRIOR_OUTPUTS, IDJ_STORAGE_ACCESS);
+    }
+
+    @Validator
+    public static ValidationContext exportDataJob(ExportDataJob msg, ValidationContext ctx) {
+
+        ctx = ctx.push(EDJ_MODEL)
+                .apply(CommonValidators::required)
+                .apply(ObjectIdValidator::tagSelector, TagSelector.class)
+                .apply(ObjectIdValidator::selectorType, TagSelector.class, ObjectType.MODEL)
+                .pop();
+
+        return importOrExportJob(ctx, EDJ_PARAMETERS, EDJ_INPUTS, EDJ_OUTPUTS, EDJ_PRIOR_OUTPUTS, EDJ_STORAGE_ACCESS);
+    }
+
+    private static ValidationContext importOrExportJob(
+            ValidationContext ctx,
+            Descriptors.FieldDescriptor parameters,
+            Descriptors.FieldDescriptor inputs,
+            Descriptors.FieldDescriptor outputs,
+            Descriptors.FieldDescriptor priorOutputs,
+            Descriptors.FieldDescriptor storageAccess) {
+
+        ctx = ctx.pushMap(parameters)
+                .applyMapKeys(CommonValidators::identifier)
+                .applyMapKeys(CommonValidators::notTracReserved)
+                .applyMapValues(TypeSystemValidator::value, Value.class)
+                .pop();
+
+        ctx = ctx.pushMap(inputs)
+                .applyMapKeys(CommonValidators::identifier)
+                .applyMapKeys(CommonValidators::notTracReserved)
+                .applyMapValues(ObjectIdValidator::tagSelector, TagSelector.class)
+                .applyMapValues(ObjectIdValidator::selectorType, TagSelector.class, ALLOWED_IO_TYPES)
+                .applyMapValues(ObjectIdValidator::fixedObjectVersion, TagSelector.class)
+                .pop();
+
+        ctx = ctx.pushMap(outputs)
+                .applyMapKeys(CommonValidators::identifier)
+                .applyMapKeys(CommonValidators::notTracReserved)
+                .applyMapValues(ObjectIdValidator::tagSelector, TagSelector.class)
+                .applyMapValues(ObjectIdValidator::selectorType, TagSelector.class, ALLOWED_IO_TYPES)
+                .applyMapValues(ObjectIdValidator::fixedObjectVersion, TagSelector.class)
+                .pop();
+
+        ctx = ctx.pushMap(priorOutputs)
+                .applyMapKeys(CommonValidators::identifier)
+                .applyMapKeys(CommonValidators::notTracReserved)
+                .applyMapValues(ObjectIdValidator::tagSelector, TagSelector.class)
+                .applyMapValues(ObjectIdValidator::selectorType, TagSelector.class, ALLOWED_IO_TYPES)
+                .applyMapValues(ObjectIdValidator::fixedObjectVersion, TagSelector.class)
+                .pop();
+
+        ctx = ctx.pushRepeated(storageAccess)
+                .applyRepeated(CommonValidators::identifier)
+                .applyRepeated(CommonValidators::notTracReserved)
+                .pop();
+
+        return ctx;
+    }
+
     private static ValidationContext jobMatchesType(ValidationContext ctx) {
 
         var job = (JobDefinition) ctx.parentMsg();
@@ -255,6 +359,12 @@ public class JobValidator {
         if (msg.getJobType() == JobType.RUN_MODEL)
             ctx = ctx.apply(JobValidator::outputsMustBeEmpty, RunModelJob.class);
 
+        else if (msg.getJobType() == JobType.IMPORT_DATA)
+            ctx = ctx.apply(JobValidator::outputsMustBeEmpty, ImportDataJob.class);
+
+        else if (msg.getJobType() == JobType.EXPORT_DATA)
+            ctx = ctx.apply(JobValidator::outputsMustBeEmpty, ExportDataJob.class);
+
         return ctx.pop();
     }
 
@@ -263,6 +373,30 @@ public class JobValidator {
         if (msg.getOutputsCount() > 0) {
 
             ctx = ctx.push(RMJ_OUTPUTS)
+                    .error("Outputs must be empty, they cannot be specified explicitly when submitting a job")
+                    .pop();
+        }
+
+        return ctx;
+    }
+
+    private static ValidationContext outputsMustBeEmpty(ImportDataJob msg, ValidationContext ctx) {
+
+        if (msg.getOutputsCount() > 0) {
+
+            ctx = ctx.pushMap(IDJ_OUTPUTS)
+                    .error("Outputs must be empty, they cannot be specified explicitly when submitting a job")
+                    .pop();
+        }
+
+        return ctx;
+    }
+
+    private static ValidationContext outputsMustBeEmpty(ExportDataJob msg, ValidationContext ctx) {
+
+        if (msg.getOutputsCount() > 0) {
+
+            ctx = ctx.pushMap(EDJ_OUTPUTS)
                     .error("Outputs must be empty, they cannot be specified explicitly when submitting a job")
                     .pop();
         }

--- a/tracdap-runtime/python/src/tracdap/rt/_impl/core/data.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_impl/core/data.py
@@ -67,6 +67,7 @@ class DataSpec:
     context_key: tp.Optional[str] = None
 
     metadata: tp.Optional[_api.RuntimeMetadata] = None
+    attrs: tp.List[_meta.TagUpdate] = dc.field(default_factory=list)
 
     @staticmethod
     def create_data_spec(
@@ -137,6 +138,7 @@ class DataItem:
     table: tp.Optional[pa.Table] = None
 
     metadata: tp.Optional[_api.RuntimeMetadata] = None
+    attrs: tp.List[_meta.TagUpdate] = dc.field(default_factory=list)
 
     def is_empty(self) -> bool:
         return self.content is None
@@ -177,6 +179,9 @@ class DataItem:
     def with_metadata(self, metadata: _api.RuntimeMetadata) -> "DataItem":
         return dc.replace(self, metadata=metadata)
 
+    def with_attrs(self, attrs: tp.List[_meta.TagUpdate]) -> "DataItem":
+        return dc.replace(self, attrs=[*self.attrs, *attrs])
+
 
 @dc.dataclass(frozen=True)
 class DataView:
@@ -190,6 +195,7 @@ class DataView:
     file_item: tp.Optional[DataItem] = None
 
     metadata: tp.Optional[_api.RuntimeMetadata] = None
+    attrs: tp.List[_meta.TagUpdate] = dc.field(default_factory=list)
 
     @staticmethod
     def create_empty(object_type: _meta.ObjectType = _meta.ObjectType.DATA) -> "DataView":
@@ -229,6 +235,9 @@ class DataView:
 
     def with_metadata(self, metadata: _api.RuntimeMetadata) -> "DataView":
         return dc.replace(self, metadata=metadata)
+
+    def with_attrs(self, attrs: tp.List[_meta.TagUpdate]) -> "DataView":
+        return dc.replace(self, attrs=[*self.attrs, *attrs])
 
     def get_metadata(self) -> tp.Optional[_api.RuntimeMetadata]:
         if self.metadata:
@@ -460,7 +469,7 @@ class DataMapping:
         deltas = [*prior_deltas, item]
         parts = {**view.parts, part: deltas}
 
-        return DataView(view.object_type, view.trac_schema, view.arrow_schema, parts=parts)
+        return DataView(view.object_type, view.trac_schema, view.arrow_schema, parts=parts, attrs=view.attrs)
 
     @classmethod
     def view_to_arrow(cls, view: DataView, part: DataPartKey) -> pa.Table:

--- a/tracdap-runtime/python/src/tracdap/rt/_impl/exec/context.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_impl/exec/context.py
@@ -615,13 +615,43 @@ class TracDataContextImpl(TracContextImpl, _eapi.TracDataContext):
             if not isinstance(source_info, str):
                 self.__val.report_public_error(_ex.ERuntimeValidation(f"Expected storage_info to be a table name, [{storage_key}] refers to dadta storage"))
 
-        pass  # Not implemented yet, only required when imports are sent back to the platform
+        if not isinstance(source_info, _eapi.FileStat):
+            self.__val.report_public_error(_ex.ERuntimeValidation(
+                "set_source_metadata() for table/SQL sources is not yet supported"))
+
+        attrs = [_meta.TagUpdate(
+            _meta.TagOperation.CREATE_OR_REPLACE_ATTR,
+            "trac_import_location_key", _types.MetadataCodec.encode_value(storage_key))]
+
+        attrs.append(_meta.TagUpdate(
+            _meta.TagOperation.CREATE_OR_REPLACE_ATTR,
+            "original_file_name", _types.MetadataCodec.encode_value(source_info.file_name)))
+
+        attrs.append(_meta.TagUpdate(
+            _meta.TagOperation.CREATE_OR_REPLACE_ATTR,
+            "original_file_size", _types.MetadataCodec.encode_value(source_info.size)))
+
+        if source_info.mtime is not None:
+            attrs.append(_meta.TagUpdate(
+                _meta.TagOperation.CREATE_OR_REPLACE_ATTR,
+                "trac_file_modified_date", _types.MetadataCodec.encode_value(source_info.mtime)))
+
+        data_view = self.__local_ctx[dataset_name]
+        self.__local_ctx[dataset_name] = data_view.with_attrs(attrs)
 
     def set_attribute(self, dataset_name: str, attribute_name: str, value: tp.Any):
 
         _val.validate_signature(self.set_attribute, dataset_name, attribute_name, value)
 
-        pass  # Not implemented yet, only required when imports are sent back to the platform
+        self.__val.check_item_valid_identifier(dataset_name, TracContextValidator.DATASET)
+        self.__val.check_item_available_in_context(dataset_name, TracContextValidator.DATASET)
+
+        attr_update = _meta.TagUpdate(
+            _meta.TagOperation.CREATE_OR_REPLACE_ATTR,
+            attribute_name, _types.MetadataCodec.encode_value(value))
+
+        data_view = self.__local_ctx[dataset_name]
+        self.__local_ctx[dataset_name] = data_view.with_attrs([attr_update])
 
     def set_schema(self, dataset_name: str, schema: _meta.SchemaDefinition):
 

--- a/tracdap-runtime/python/src/tracdap/rt/_impl/exec/context.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_impl/exec/context.py
@@ -643,6 +643,7 @@ class TracDataContextImpl(TracContextImpl, _eapi.TracDataContext):
 
         self.__val.check_item_valid_identifier(dataset_name, TracContextValidator.DATASET)
         self.__val.check_item_available_in_context(dataset_name, TracContextValidator.DATASET)
+        self.__val.check_attr_name_not_reserved(attribute_name)
 
         attr_update = _meta.TagUpdate(
             _meta.TagOperation.CREATE_OR_REPLACE_ATTR,
@@ -1009,6 +1010,11 @@ class TracContextValidator(TracContextErrorReporter):
 
         if item_name not in self.__local_ctx:
             self._report_error(f"{item_type} {item_name} is not available in the current context")
+
+    def check_attr_name_not_reserved(self, attribute_name: str):
+
+        if self._RESERVED_IDENTIFIER.match(attribute_name):
+            self._report_error(f"Attribute name {attribute_name} is a reserved identifier")
 
     def check_item_not_available_in_context(self, item_name: str, item_type: str):
 

--- a/tracdap-runtime/python/src/tracdap/rt/_impl/exec/context.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_impl/exec/context.py
@@ -605,19 +605,17 @@ class TracDataContextImpl(TracContextImpl, _eapi.TracDataContext):
         self.__val.check_storage_valid_identifier(storage_key)
         self.__val.check_storage_available(self.__storage_map, storage_key)
 
-        storage = self.__storage_map[storage_key]
+        if isinstance(source_info, _eapi.FileStat):
+            self.__val.check_storage_type(self.__storage_map, storage_key, _eapi.TracFileStorage)
 
-        if isinstance(storage, _eapi.TracFileStorage):
-            if not isinstance(source_info, _eapi.FileStat):
-                self.__val.report_public_error(_ex.ERuntimeValidation(f"Expected storage_info to be a FileStat, [{storage_key}] refers to file storage"))
-
-        if isinstance(storage, _eapi.TracDataStorage):
-            if not isinstance(source_info, str):
-                self.__val.report_public_error(_ex.ERuntimeValidation(f"Expected storage_info to be a table name, [{storage_key}] refers to dadta storage"))
-
-        if not isinstance(source_info, _eapi.FileStat):
+        elif isinstance(source_info, str):
+            self.__val.check_storage_type(self.__storage_map, storage_key, _eapi.TracDataStorage)
             self.__val.report_public_error(_ex.ERuntimeValidation(
                 "set_source_metadata() for table/SQL sources is not yet supported"))
+
+        else:
+            self.__val.report_public_error(_ex.ERuntimeValidation(
+                f"Expected storage_info to be a FileStat or table name, got [{type(source_info).__name__}]"))
 
         attrs = [_meta.TagUpdate(
             _meta.TagOperation.CREATE_OR_REPLACE_ATTR,
@@ -634,7 +632,7 @@ class TracDataContextImpl(TracContextImpl, _eapi.TracDataContext):
         if source_info.mtime is not None:
             attrs.append(_meta.TagUpdate(
                 _meta.TagOperation.CREATE_OR_REPLACE_ATTR,
-                "trac_file_modified_date", _types.MetadataCodec.encode_value(source_info.mtime)))
+                "original_file_modified_date", _types.MetadataCodec.encode_value(source_info.mtime)))
 
         data_view = self.__local_ctx[dataset_name]
         self.__local_ctx[dataset_name] = data_view.with_attrs(attrs)

--- a/tracdap-runtime/python/src/tracdap/rt/_impl/exec/functions.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_impl/exec/functions.py
@@ -15,6 +15,7 @@
 
 import abc
 import copy
+import dataclasses as dc
 import io
 import pathlib
 import typing as tp
@@ -460,7 +461,7 @@ class SaveDataFunc(_LoadSaveDataFunc, NodeFunction[_data.DataSpec]):
             raise _ex.EUnexpected()
 
         if data_item.attrs:
-            saved_spec.attrs.extend(data_item.attrs)
+            saved_spec = dc.replace(saved_spec, attrs=[*saved_spec.attrs, *data_item.attrs])
 
         return saved_spec
 

--- a/tracdap-runtime/python/src/tracdap/rt/_impl/exec/functions.py
+++ b/tracdap-runtime/python/src/tracdap/rt/_impl/exec/functions.py
@@ -309,7 +309,7 @@ class DataItemFunc(NodeFunction[_data.DataItem]):
 
         # Handle file data views
         if data_view.object_type == _meta.ObjectType.FILE:
-            return data_view.file_item
+            return data_view.file_item.with_attrs(data_view.attrs) if data_view.attrs else data_view.file_item
 
         # TODO: Support selecting data item described by self.node
 
@@ -318,7 +318,7 @@ class DataItemFunc(NodeFunction[_data.DataItem]):
         part = data_view.parts[part_key]
         delta = part[0]  # selects delta=0
 
-        return delta
+        return delta.with_attrs(data_view.attrs) if data_view.attrs else delta
 
 
 class _LoadSaveDataFunc(abc.ABC):
@@ -448,16 +448,21 @@ class SaveDataFunc(_LoadSaveDataFunc, NodeFunction[_data.DataSpec]):
             return _data.DataSpec.create_empty_spec(data_item.object_type, data_item.schema_type)
 
         if data_item.object_type == _api.ObjectType.FILE:
-            return self._save_file(data_item, data_spec, data_copy)
+            saved_spec = self._save_file(data_item, data_spec, data_copy)
 
         elif data_item.schema_type == _api.SchemaType.TABLE_SCHEMA:
-            return self._save_table(data_item, data_spec, data_copy)
+            saved_spec = self._save_table(data_item, data_spec, data_copy)
 
         elif data_item.schema_type == _api.SchemaType.STRUCT_SCHEMA:
-            return self._save_struct(data_item, data_spec, data_copy)
+            saved_spec = self._save_struct(data_item, data_spec, data_copy)
 
         else:
             raise _ex.EUnexpected()
+
+        if data_item.attrs:
+            saved_spec.attrs.extend(data_item.attrs)
+
+        return saved_spec
 
     def _save_file(self, data_item, data_spec, data_copy):
 
@@ -773,6 +778,9 @@ class JobResultFunc(NodeFunction[_cfg.JobResult]):
         job_result.objectIds.append(storage_id)
         job_result.objects[output_key] = output_obj
         job_result.objects[storage_key] = storage_obj
+
+        if data_spec.attrs:
+            job_result.attrs[output_key] = _cfg.JobResultAttrs(data_spec.attrs)
 
         # Currently, jobs do not ever produce external schemas
 

--- a/tracdap-runtime/python/test/tracdap_test/rt/impl/exec/test_source_provenance.py
+++ b/tracdap-runtime/python/test/tracdap_test/rt/impl/exec/test_source_provenance.py
@@ -94,6 +94,17 @@ class SourceProvenanceContextTest(unittest.TestCase):
             _ex.ERuntimeValidation,
             lambda: self.ctx.set_attribute("unknown_dataset", "business_date", dt.date(2024, 1, 1)))
 
+    def test_set_attribute_reserved_name(self):
+
+        for reserved_name in ["trac_model_type", "_hidden_attr"]:
+
+            self.assertRaises(
+                _ex.ERuntimeValidation,
+                lambda name=reserved_name: self.ctx.set_attribute("my_dataset", name, "some_value"))
+
+            attrs = _attrs_by_name(self.local_ctx["my_dataset"])
+            self.assertEqual({}, attrs)
+
     def test_set_source_metadata_file_stat_ok(self):
 
         file_stat = trac.FileStat(

--- a/tracdap-runtime/python/test/tracdap_test/rt/impl/exec/test_source_provenance.py
+++ b/tracdap-runtime/python/test/tracdap_test/rt/impl/exec/test_source_provenance.py
@@ -1,0 +1,243 @@
+#  Licensed to the Fintech Open Source Foundation (FINOS) under one or
+#  more contributor license agreements. See the NOTICE file distributed
+#  with this work for additional information regarding copyright ownership.
+#  FINOS licenses this file to you under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with the
+#  License. You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import dataclasses
+import datetime as dt
+import unittest
+import unittest.mock as mock
+
+import tracdap.rt.api.experimental as trac
+import tracdap.rt.config as _cfg
+import tracdap.rt.exceptions as _ex
+import tracdap.rt.metadata as _meta
+
+import tracdap.rt._impl.core.data as _data  # noqa
+import tracdap.rt._impl.core.type_system as _types  # noqa
+import tracdap.rt._impl.exec.context as _ctx  # noqa
+import tracdap.rt._impl.exec.functions as _func  # noqa
+
+import tracdap_test.resources.test_models as test_models
+
+
+_test_import_def = _meta.ModelDefinition(
+
+    language="python",
+    repository="trac_integrated",
+    entryPoint=f"{test_models.TestImportModel.__module__}.{test_models.TestImportModel.__name__}",
+
+    parameters=test_models.TestImportModel().define_parameters(),
+    inputs=test_models.TestImportModel().define_inputs(),
+    outputs=test_models.TestImportModel().define_outputs())
+
+
+def _attrs_by_name(view: _data.DataView):
+    return {update.attrName: update for update in view.attrs}
+
+
+class SourceProvenanceContextTest(unittest.TestCase):
+
+    """Test TracDataContextImpl.set_attribute() / set_source_metadata(), which record
+    provenance facts as TagUpdates on the dataset's DataView."""
+
+    FILE_STORAGE_KEY = "test_file_storage"
+    SQL_STORAGE_KEY = "test_sql_storage"
+
+    def setUp(self):
+
+        self.local_ctx = {}
+        self.dynamic_outputs = []
+
+        self.storage_map = {
+            self.FILE_STORAGE_KEY: mock.Mock(spec=trac.TracFileStorage),
+            self.SQL_STORAGE_KEY: mock.Mock(spec=trac.TracDataStorage)}
+
+        self.ctx = _ctx.TracDataContextImpl(
+            _test_import_def, test_models.TestImportModel,
+            self.local_ctx, self.dynamic_outputs, self.storage_map)
+
+        self.ctx.add_data_import("my_dataset")
+
+    def test_set_attribute_ok(self):
+
+        self.ctx.set_attribute("my_dataset", "business_date", dt.date(2024, 1, 1))
+
+        attrs = _attrs_by_name(self.local_ctx["my_dataset"])
+        self.assertIn("business_date", attrs)
+
+        update = attrs["business_date"]
+        self.assertEqual(_meta.TagOperation.CREATE_OR_REPLACE_ATTR, update.operation)
+        self.assertEqual(dt.date(2024, 1, 1), _types.MetadataCodec.decode_value(update.value))
+
+    def test_set_attribute_accumulates(self):
+
+        self.ctx.set_attribute("my_dataset", "attr_one", "value_one")
+        self.ctx.set_attribute("my_dataset", "attr_two", "value_two")
+
+        attrs = _attrs_by_name(self.local_ctx["my_dataset"])
+        self.assertEqual({"attr_one", "attr_two"}, set(attrs.keys()))
+
+    def test_set_attribute_dataset_not_available(self):
+
+        self.assertRaises(
+            _ex.ERuntimeValidation,
+            lambda: self.ctx.set_attribute("unknown_dataset", "business_date", dt.date(2024, 1, 1)))
+
+    def test_set_source_metadata_file_stat_ok(self):
+
+        file_stat = trac.FileStat(
+            file_name="data.csv", file_type=trac.FileType.FILE,
+            storage_path="/imports/data.csv", size=1234,
+            mtime=dt.datetime(2024, 1, 1, 12, 0, 0))
+
+        self.ctx.set_source_metadata("my_dataset", self.FILE_STORAGE_KEY, file_stat)
+
+        attrs = _attrs_by_name(self.local_ctx["my_dataset"])
+        self.assertEqual(
+            {"trac_import_location_key", "original_file_name", "original_file_size", "trac_file_modified_date"},
+            set(attrs.keys()))
+
+        self.assertEqual(self.FILE_STORAGE_KEY, _types.MetadataCodec.decode_value(attrs["trac_import_location_key"].value))
+        self.assertEqual("data.csv", _types.MetadataCodec.decode_value(attrs["original_file_name"].value))
+        self.assertEqual(1234, _types.MetadataCodec.decode_value(attrs["original_file_size"].value))
+        self.assertEqual(dt.datetime(2024, 1, 1, 12, 0, 0), _types.MetadataCodec.decode_value(attrs["trac_file_modified_date"].value))
+
+    def test_set_source_metadata_file_stat_no_mtime(self):
+
+        file_stat = trac.FileStat(
+            file_name="data.csv", file_type=trac.FileType.FILE,
+            storage_path="/imports/data.csv", size=1234, mtime=None)
+
+        self.ctx.set_source_metadata("my_dataset", self.FILE_STORAGE_KEY, file_stat)
+
+        attrs = _attrs_by_name(self.local_ctx["my_dataset"])
+        self.assertEqual(
+            {"trac_import_location_key", "original_file_name", "original_file_size"},
+            set(attrs.keys()))
+
+    def test_set_source_metadata_string_source_not_supported(self):
+
+        self.assertRaises(
+            _ex.ERuntimeValidation,
+            lambda: self.ctx.set_source_metadata("my_dataset", self.SQL_STORAGE_KEY, "some_table"))
+
+        # Should raise cleanly with no partial attrs written, rather than silently no-oping
+        attrs = _attrs_by_name(self.local_ctx["my_dataset"])
+        self.assertEqual({}, attrs)
+
+    def test_set_source_metadata_wrong_type_for_file_storage(self):
+
+        self.assertRaises(
+            _ex.ERuntimeValidation,
+            lambda: self.ctx.set_source_metadata("my_dataset", self.FILE_STORAGE_KEY, "not_a_file_stat"))
+
+
+class SourceProvenanceDataPlumbingTest(unittest.TestCase):
+
+    """Test that attrs set on a DataView survive the transformations models actually apply
+    (set_schema / put_table), and that DataSpecFunc-style rebuilds don't drop them."""
+
+    def _tag_update(self, name: str, value):
+        return _meta.TagUpdate(_meta.TagOperation.CREATE_OR_REPLACE_ATTR, name, _types.MetadataCodec.encode_value(value))
+
+    def test_data_view_with_attrs_accumulates(self):
+
+        view = _data.DataView.create_empty()
+        view = view.with_attrs([self._tag_update("a", "1")])
+        view = view.with_attrs([self._tag_update("b", "2")])
+
+        self.assertEqual(["a", "b"], [u.attrName for u in view.attrs])
+
+    def test_data_item_with_attrs(self):
+
+        item = _data.DataItem.create_empty()
+        item = item.with_attrs([self._tag_update("a", "1")])
+
+        self.assertEqual(["a"], [u.attrName for u in item.attrs])
+
+    def test_add_item_to_view_preserves_attrs(self):
+
+        schema = _meta.SchemaDefinition(
+            _meta.SchemaType.TABLE, _meta.PartType.PART_ROOT,
+            _meta.TableSchema(fields=[_meta.FieldSchema("field_1", fieldType=_meta.BasicType.STRING)]))
+
+        view = _data.DataView.for_trac_schema(schema)
+        view = view.with_attrs([self._tag_update("trac_import_location_key", "test_storage")])
+
+        item = _data.DataItem.for_table(None, view.arrow_schema, schema)
+        updated_view = _data.DataMapping.add_item_to_view(view, _data.DataPartKey.for_root(), item)
+
+        self.assertEqual(["trac_import_location_key"], [u.attrName for u in updated_view.attrs])
+
+
+class SourceProvenanceJobResultTest(unittest.TestCase):
+
+    """Test that JobResultFunc._process_data_spec forwards DataSpec.attrs into job_result.attrs,
+    mirroring the existing GraphOutput.attrs forwarding path."""
+
+    @staticmethod
+    def _data_spec(object_id: str, storage_id: str, attrs):
+
+        primary_id = _meta.TagHeader(objectType=_meta.ObjectType.DATA, objectId=object_id, objectVersion=1)
+        storage_tag_id = _meta.TagHeader(objectType=_meta.ObjectType.STORAGE, objectId=storage_id, objectVersion=1)
+
+        spec = _data.DataSpec.create_data_spec(
+            "data_item_key", _meta.DataDefinition(), _meta.StorageDefinition())
+        spec = spec.with_ids(primary_id, storage_tag_id)
+
+        return dataclasses.replace(spec, attrs=attrs)
+
+    def test_process_data_spec_forwards_attrs(self):
+
+        attrs = [_meta.TagUpdate(
+            _meta.TagOperation.CREATE_OR_REPLACE_ATTR,
+            "trac_import_location_key", _types.MetadataCodec.encode_value("test_storage"))]
+
+        data_spec = self._data_spec("data-1", "storage-1", attrs)
+        job_result = _cfg.JobResult()
+
+        _func.JobResultFunc._process_data_spec("my_output", data_spec, job_result)
+
+        output_key = "DATA-data-1-v1"
+        self.assertIn(output_key, job_result.attrs)
+        self.assertEqual(attrs, job_result.attrs[output_key].attrs)
+
+    def test_process_data_spec_multiple_outputs(self):
+
+        attrs_1 = [_meta.TagUpdate(_meta.TagOperation.CREATE_OR_REPLACE_ATTR, "attr_1", _types.MetadataCodec.encode_value("v1"))]
+        attrs_2 = [_meta.TagUpdate(_meta.TagOperation.CREATE_OR_REPLACE_ATTR, "attr_2", _types.MetadataCodec.encode_value("v2"))]
+
+        data_spec_1 = self._data_spec("data-1", "storage-1", attrs_1)
+        data_spec_2 = self._data_spec("data-2", "storage-2", attrs_2)
+
+        job_result = _cfg.JobResult()
+
+        _func.JobResultFunc._process_data_spec("output_one", data_spec_1, job_result)
+        _func.JobResultFunc._process_data_spec("output_two", data_spec_2, job_result)
+
+        self.assertEqual(attrs_1, job_result.attrs["DATA-data-1-v1"].attrs)
+        self.assertEqual(attrs_2, job_result.attrs["DATA-data-2-v1"].attrs)
+
+    def test_process_data_spec_no_attrs_not_forwarded(self):
+
+        data_spec = self._data_spec("data-1", "storage-1", [])
+        job_result = _cfg.JobResult()
+
+        _func.JobResultFunc._process_data_spec("my_output", data_spec, job_result)
+
+        self.assertNotIn("DATA-data-1-v1", job_result.attrs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tracdap-runtime/python/test/tracdap_test/rt/impl/exec/test_source_provenance.py
+++ b/tracdap-runtime/python/test/tracdap_test/rt/impl/exec/test_source_provenance.py
@@ -105,13 +105,13 @@ class SourceProvenanceContextTest(unittest.TestCase):
 
         attrs = _attrs_by_name(self.local_ctx["my_dataset"])
         self.assertEqual(
-            {"trac_import_location_key", "original_file_name", "original_file_size", "trac_file_modified_date"},
+            {"trac_import_location_key", "original_file_name", "original_file_size", "original_file_modified_date"},
             set(attrs.keys()))
 
         self.assertEqual(self.FILE_STORAGE_KEY, _types.MetadataCodec.decode_value(attrs["trac_import_location_key"].value))
         self.assertEqual("data.csv", _types.MetadataCodec.decode_value(attrs["original_file_name"].value))
         self.assertEqual(1234, _types.MetadataCodec.decode_value(attrs["original_file_size"].value))
-        self.assertEqual(dt.datetime(2024, 1, 1, 12, 0, 0), _types.MetadataCodec.decode_value(attrs["trac_file_modified_date"].value))
+        self.assertEqual(dt.datetime(2024, 1, 1, 12, 0, 0), _types.MetadataCodec.decode_value(attrs["original_file_modified_date"].value))
 
     def test_set_source_metadata_file_stat_no_mtime(self):
 

--- a/tracdap-services/tracdap-svc-orch/src/main/java/org/finos/tracdap/svc/orch/jobs/ExportDataJob.java
+++ b/tracdap-services/tracdap-svc-orch/src/main/java/org/finos/tracdap/svc/orch/jobs/ExportDataJob.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Fintech Open Source Foundation (FINOS) under one or
+ * more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * FINOS licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.finos.tracdap.svc.orch.jobs;
+
+import org.finos.tracdap.common.exception.EUnexpected;
+import org.finos.tracdap.common.metadata.MetadataBundle;
+import org.finos.tracdap.common.metadata.MetadataUtil;
+import org.finos.tracdap.common.metadata.ResourceBundle;
+import org.finos.tracdap.config.JobConfig;
+import org.finos.tracdap.config.JobResult;
+import org.finos.tracdap.metadata.*;
+
+import java.util.*;
+
+
+public class ExportDataJob extends RunModelOrFlow implements IJobLogic {
+
+    @Override
+    public List<TagSelector> requiredMetadata(JobDefinition job) {
+
+        if (job.getJobType() != JobType.EXPORT_DATA)
+            throw new EUnexpected();
+
+        var exportData = job.getExportData();
+
+        var resources = new ArrayList<TagSelector>(exportData.getInputsCount() + 1);
+        resources.add(exportData.getModel());
+        resources.addAll(exportData.getInputsMap().values());
+        resources.addAll(exportData.getPriorOutputsMap().values());
+
+        return resources;
+    }
+
+    @Override
+    public List<String> requiredResources(JobDefinition job, MetadataBundle metadata) {
+
+        var resources = new HashSet<String>();
+
+        addRequiredStorage(metadata, resources);
+
+        var modelObj = metadata.getObject(job.getExportData().getModel());
+        var modelRepo = modelObj.getModel().getRepository();
+        resources.add(modelRepo);
+
+        resources.addAll(job.getExportData().getStorageAccessList());
+
+        return new ArrayList<>(resources);
+    }
+
+    @Override
+    public JobDefinition applyJobTransform(JobDefinition job, MetadataBundle metadata, ResourceBundle resources) {
+
+        // No transformations currently required
+        return job;
+    }
+
+    @Override
+    public MetadataBundle applyMetadataTransform(JobDefinition job, MetadataBundle metadata, ResourceBundle resources) {
+
+        return metadata;
+    }
+
+    @Override
+    public Map<ObjectType, Integer> expectedOutputs(JobDefinition job, MetadataBundle metadata) {
+
+        var exportDataJob = job.getExportData();
+
+        var modelObj = metadata.getObject(exportDataJob.getModel());
+        var model = modelObj.getModel();
+
+        return expectedOutputs(model.getOutputsMap(), exportDataJob.getPriorOutputsMap());
+    }
+
+    @Override
+    public JobResult processResult(JobConfig jobConfig, JobResult jobResult, Map<String, TagHeader> resultIds) {
+
+        var exportData = jobConfig.getJob().getExportData();
+
+        var modelKey = MetadataUtil.objectKey(exportData.getModel());
+        var modelId = jobConfig.getObjectMappingMap().get(modelKey);
+        var modelDef = jobConfig.getObjectsMap().get(MetadataUtil.objectKey(modelId)).getModel();
+
+        return processResult(
+                jobResult,
+                modelDef.getOutputsMap(),
+                exportData.getOutputAttrsList(),
+                Map.of(), resultIds);
+    }
+}

--- a/tracdap-services/tracdap-svc-orch/src/main/java/org/finos/tracdap/svc/orch/jobs/ImportDataJob.java
+++ b/tracdap-services/tracdap-svc-orch/src/main/java/org/finos/tracdap/svc/orch/jobs/ImportDataJob.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Fintech Open Source Foundation (FINOS) under one or
+ * more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * FINOS licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.finos.tracdap.svc.orch.jobs;
+
+import org.finos.tracdap.common.exception.EUnexpected;
+import org.finos.tracdap.common.metadata.MetadataBundle;
+import org.finos.tracdap.common.metadata.MetadataUtil;
+import org.finos.tracdap.common.metadata.ResourceBundle;
+import org.finos.tracdap.config.JobConfig;
+import org.finos.tracdap.config.JobResult;
+import org.finos.tracdap.metadata.*;
+
+import java.util.*;
+
+
+public class ImportDataJob extends RunModelOrFlow implements IJobLogic {
+
+    @Override
+    public List<TagSelector> requiredMetadata(JobDefinition job) {
+
+        if (job.getJobType() != JobType.IMPORT_DATA)
+            throw new EUnexpected();
+
+        var importData = job.getImportData();
+
+        var resources = new ArrayList<TagSelector>(importData.getInputsCount() + 1);
+        resources.add(importData.getModel());
+        resources.addAll(importData.getInputsMap().values());
+        resources.addAll(importData.getPriorOutputsMap().values());
+
+        return resources;
+    }
+
+    @Override
+    public List<String> requiredResources(JobDefinition job, MetadataBundle metadata) {
+
+        var resources = new HashSet<String>();
+
+        addRequiredStorage(metadata, resources);
+
+        var modelObj = metadata.getObject(job.getImportData().getModel());
+        var modelRepo = modelObj.getModel().getRepository();
+        resources.add(modelRepo);
+
+        resources.addAll(job.getImportData().getStorageAccessList());
+
+        return new ArrayList<>(resources);
+    }
+
+    @Override
+    public JobDefinition applyJobTransform(JobDefinition job, MetadataBundle metadata, ResourceBundle resources) {
+
+        // No transformations currently required
+        return job;
+    }
+
+    @Override
+    public MetadataBundle applyMetadataTransform(JobDefinition job, MetadataBundle metadata, ResourceBundle resources) {
+
+        return metadata;
+    }
+
+    @Override
+    public Map<ObjectType, Integer> expectedOutputs(JobDefinition job, MetadataBundle metadata) {
+
+        var importDataJob = job.getImportData();
+
+        var modelObj = metadata.getObject(importDataJob.getModel());
+        var model = modelObj.getModel();
+
+        return expectedOutputs(model.getOutputsMap(), importDataJob.getPriorOutputsMap());
+    }
+
+    @Override
+    public JobResult processResult(JobConfig jobConfig, JobResult jobResult, Map<String, TagHeader> resultIds) {
+
+        var importData = jobConfig.getJob().getImportData();
+
+        var modelKey = MetadataUtil.objectKey(importData.getModel());
+        var modelId = jobConfig.getObjectMappingMap().get(modelKey);
+        var modelDef = jobConfig.getObjectsMap().get(MetadataUtil.objectKey(modelId)).getModel();
+
+        return processResult(
+                jobResult,
+                modelDef.getOutputsMap(),
+                importData.getOutputAttrsList(),
+                Map.of(), resultIds);
+    }
+}

--- a/tracdap-services/tracdap-svc-orch/src/main/java/org/finos/tracdap/svc/orch/jobs/JobLogic.java
+++ b/tracdap-services/tracdap-svc-orch/src/main/java/org/finos/tracdap/svc/orch/jobs/JobLogic.java
@@ -34,7 +34,9 @@ public class JobLogic {
             JOB_TYPES = Map.ofEntries(
                     Map.entry(JobType.IMPORT_MODEL, ImportModelJob.class.getDeclaredConstructor()),
                     Map.entry(JobType.RUN_MODEL, RunModelJob.class.getDeclaredConstructor()),
-                    Map.entry(JobType.RUN_FLOW, RunFlowJob.class.getDeclaredConstructor()));
+                    Map.entry(JobType.RUN_FLOW, RunFlowJob.class.getDeclaredConstructor()),
+                    Map.entry(JobType.IMPORT_DATA, ImportDataJob.class.getDeclaredConstructor()),
+                    Map.entry(JobType.EXPORT_DATA, ExportDataJob.class.getDeclaredConstructor()));
         }
         catch (NoSuchMethodException e) {
 

--- a/tracdap-services/tracdap-svc-orch/src/main/java/org/finos/tracdap/svc/orch/service/JobProcessorHelpers.java
+++ b/tracdap-services/tracdap-svc-orch/src/main/java/org/finos/tracdap/svc/orch/service/JobProcessorHelpers.java
@@ -542,6 +542,9 @@ public class JobProcessorHelpers {
                     .setAttrName(TRAC_UPDATE_JOB)
                     .setValue(MetadataCodec.encodeValue(jobState.jobKey)));
 
+            attrs.addAttrs(TagUpdate.newBuilder()
+                    .setAttrName(TRAC_JOB_TYPE_ATTR)
+                    .setValue(MetadataCodec.encodeValue(jobState.jobType.name())));
 
             if (objectId.getObjectVersion() == MetadataConstants.OBJECT_FIRST_VERSION) {
 

--- a/tracdap-services/tracdap-svc-orch/src/test/java/org/finos/tracdap/svc/orch/api/JobValidationTest.java
+++ b/tracdap-services/tracdap-svc-orch/src/test/java/org/finos/tracdap/svc/orch/api/JobValidationTest.java
@@ -960,6 +960,13 @@ public class JobValidationTest {
     }
 
     private TagSelector createDataImportModel(List<TagUpdate> tags) {
+        return createDataImportModel(tags, Map.of(), Map.of());
+    }
+
+    private TagSelector createDataImportModel(
+            List<TagUpdate> tags,
+            Map<String, BasicType> paramTypes,
+            Map<String, SchemaDefinition> inputSchemas) {
 
         var modelDef = ModelDefinition.newBuilder()
                 .setLanguage("python")
@@ -971,8 +978,20 @@ public class JobValidationTest {
                 .putOutputs("output_data", ModelOutputSchema.newBuilder()
                         .setObjectType(ObjectType.DATA)
                         .setSchema(SampleData.BASIC_TABLE_SCHEMA)
-                        .build())
-                .build();
+                        .build());
+
+        for (var param : paramTypes.entrySet()) {
+            modelDef.putParameters(param.getKey(), ModelParameter.newBuilder()
+                    .setParamType(TypeSystem.descriptor(param.getValue()))
+                    .build());
+        }
+
+        for (var input : inputSchemas.entrySet()) {
+            modelDef.putInputs(input.getKey(), ModelInputSchema.newBuilder()
+                    .setObjectType(ObjectType.DATA)
+                    .setSchema(input.getValue())
+                    .build());
+        }
 
         var writeRequest = MetadataWriteRequest.newBuilder()
                 .setTenant(TEST_TENANT)
@@ -989,6 +1008,10 @@ public class JobValidationTest {
     }
 
     private TagSelector createDataExportModel(List<TagUpdate> tags) {
+        return createDataExportModel(tags, Map.of());
+    }
+
+    private TagSelector createDataExportModel(List<TagUpdate> tags, Map<String, BasicType> paramTypes) {
 
         var modelDef = ModelDefinition.newBuilder()
                 .setLanguage("python")
@@ -1000,8 +1023,13 @@ public class JobValidationTest {
                 .putInputs("input_data", ModelInputSchema.newBuilder()
                         .setObjectType(ObjectType.DATA)
                         .setSchema(SampleData.BASIC_TABLE_SCHEMA)
-                        .build())
-                .build();
+                        .build());
+
+        for (var param : paramTypes.entrySet()) {
+            modelDef.putParameters(param.getKey(), ModelParameter.newBuilder()
+                    .setParamType(TypeSystem.descriptor(param.getValue()))
+                    .build());
+        }
 
         var writeRequest = MetadataWriteRequest.newBuilder()
                 .setTenant(TEST_TENANT)
@@ -1168,6 +1196,84 @@ public class JobValidationTest {
     }
 
     @Test
+    public void importData_missingParameter() {
+
+        var modelTags = List.of(TagUpdate.newBuilder()
+                .setAttrName("model_key")
+                .setValue(MetadataCodec.encodeValue("import_data_missing_parameter"))
+                .build());
+
+        var modelSelector = createDataImportModel(modelTags, Map.of("storage_key", BasicType.STRING), Map.of());
+
+        var job = JobDefinition.newBuilder()
+                .setJobType(JobType.IMPORT_DATA)
+                .setImportData(ImportDataJob.newBuilder()
+                        .setModel(modelSelector)
+                        .addStorageAccess("UNIT_TEST_EXTERNAL_STORAGE"));
+
+        var request = JobRequest.newBuilder()
+                .setTenant(TEST_TENANT)
+                .setJob(job)
+                .build();
+
+        var e = Assertions.assertThrows(StatusRuntimeException.class, () -> orchClient.validateJob(request));
+        Assertions.assertEquals(Status.Code.FAILED_PRECONDITION, e.getStatus().getCode());
+    }
+
+    @Test
+    public void importData_wrongParameterType() {
+
+        var modelTags = List.of(TagUpdate.newBuilder()
+                .setAttrName("model_key")
+                .setValue(MetadataCodec.encodeValue("import_data_wrong_parameter_type"))
+                .build());
+
+        var modelSelector = createDataImportModel(modelTags, Map.of("storage_key", BasicType.STRING), Map.of());
+
+        var job = JobDefinition.newBuilder()
+                .setJobType(JobType.IMPORT_DATA)
+                .setImportData(ImportDataJob.newBuilder()
+                        .setModel(modelSelector)
+                        .putParameters("storage_key", MetadataCodec.encodeValue(123))  // Wrong type, model expects a string
+                        .addStorageAccess("UNIT_TEST_EXTERNAL_STORAGE"));
+
+        var request = JobRequest.newBuilder()
+                .setTenant(TEST_TENANT)
+                .setJob(job)
+                .build();
+
+        var e = Assertions.assertThrows(StatusRuntimeException.class, () -> orchClient.validateJob(request));
+        Assertions.assertEquals(Status.Code.FAILED_PRECONDITION, e.getStatus().getCode());
+    }
+
+    @Test
+    public void importData_wrongInputSchema() {
+
+        var modelTags = List.of(TagUpdate.newBuilder()
+                .setAttrName("model_key")
+                .setValue(MetadataCodec.encodeValue("import_data_wrong_input_schema"))
+                .build());
+
+        var modelSelector = createDataImportModel(
+                modelTags, Map.of(), Map.of("reference_data", SampleData.BASIC_TABLE_SCHEMA));
+
+        var job = JobDefinition.newBuilder()
+                .setJobType(JobType.IMPORT_DATA)
+                .setImportData(ImportDataJob.newBuilder()
+                        .setModel(modelSelector)
+                        .putInputs("reference_data", altDataSelector)  // Wrong schema, model expects basic data
+                        .addStorageAccess("UNIT_TEST_EXTERNAL_STORAGE"));
+
+        var request = JobRequest.newBuilder()
+                .setTenant(TEST_TENANT)
+                .setJob(job)
+                .build();
+
+        var e = Assertions.assertThrows(StatusRuntimeException.class, () -> orchClient.validateJob(request));
+        Assertions.assertEquals(Status.Code.FAILED_PRECONDITION, e.getStatus().getCode());
+    }
+
+    @Test
     public void exportData_validateOk() {
 
         var modelTags = List.of(TagUpdate.newBuilder()
@@ -1309,6 +1415,85 @@ public class JobValidationTest {
                         .setModel(modelSelector)
                         .putInputs("input_data", basicDataSelector)
                         .addStorageAccess("STORAGE_THAT_IS_NOT_CONFIGURED"));
+
+        var request = JobRequest.newBuilder()
+                .setTenant(TEST_TENANT)
+                .setJob(job)
+                .build();
+
+        var e = Assertions.assertThrows(StatusRuntimeException.class, () -> orchClient.validateJob(request));
+        Assertions.assertEquals(Status.Code.FAILED_PRECONDITION, e.getStatus().getCode());
+    }
+
+    @Test
+    public void exportData_missingParameter() {
+
+        var modelTags = List.of(TagUpdate.newBuilder()
+                .setAttrName("model_key")
+                .setValue(MetadataCodec.encodeValue("export_data_missing_parameter"))
+                .build());
+
+        var modelSelector = createDataExportModel(modelTags, Map.of("storage_key", BasicType.STRING));
+
+        var job = JobDefinition.newBuilder()
+                .setJobType(JobType.EXPORT_DATA)
+                .setExportData(ExportDataJob.newBuilder()
+                        .setModel(modelSelector)
+                        .putInputs("input_data", basicDataSelector)
+                        .addStorageAccess("UNIT_TEST_EXTERNAL_STORAGE"));
+
+        var request = JobRequest.newBuilder()
+                .setTenant(TEST_TENANT)
+                .setJob(job)
+                .build();
+
+        var e = Assertions.assertThrows(StatusRuntimeException.class, () -> orchClient.validateJob(request));
+        Assertions.assertEquals(Status.Code.FAILED_PRECONDITION, e.getStatus().getCode());
+    }
+
+    @Test
+    public void exportData_wrongParameterType() {
+
+        var modelTags = List.of(TagUpdate.newBuilder()
+                .setAttrName("model_key")
+                .setValue(MetadataCodec.encodeValue("export_data_wrong_parameter_type"))
+                .build());
+
+        var modelSelector = createDataExportModel(modelTags, Map.of("storage_key", BasicType.STRING));
+
+        var job = JobDefinition.newBuilder()
+                .setJobType(JobType.EXPORT_DATA)
+                .setExportData(ExportDataJob.newBuilder()
+                        .setModel(modelSelector)
+                        .putInputs("input_data", basicDataSelector)
+                        .putParameters("storage_key", MetadataCodec.encodeValue(123))  // Wrong type, model expects a string
+                        .addStorageAccess("UNIT_TEST_EXTERNAL_STORAGE"));
+
+        var request = JobRequest.newBuilder()
+                .setTenant(TEST_TENANT)
+                .setJob(job)
+                .build();
+
+        var e = Assertions.assertThrows(StatusRuntimeException.class, () -> orchClient.validateJob(request));
+        Assertions.assertEquals(Status.Code.FAILED_PRECONDITION, e.getStatus().getCode());
+    }
+
+    @Test
+    public void exportData_wrongInputSchema() {
+
+        var modelTags = List.of(TagUpdate.newBuilder()
+                .setAttrName("model_key")
+                .setValue(MetadataCodec.encodeValue("export_data_wrong_input_schema"))
+                .build());
+
+        var modelSelector = createDataExportModel(modelTags);
+
+        var job = JobDefinition.newBuilder()
+                .setJobType(JobType.EXPORT_DATA)
+                .setExportData(ExportDataJob.newBuilder()
+                        .setModel(modelSelector)
+                        .putInputs("input_data", altDataSelector)  // Wrong schema, model expects basic data
+                        .addStorageAccess("UNIT_TEST_EXTERNAL_STORAGE"));
 
         var request = JobRequest.newBuilder()
                 .setTenant(TEST_TENANT)

--- a/tracdap-services/tracdap-svc-orch/src/test/java/org/finos/tracdap/svc/orch/api/JobValidationTest.java
+++ b/tracdap-services/tracdap-svc-orch/src/test/java/org/finos/tracdap/svc/orch/api/JobValidationTest.java
@@ -1503,4 +1503,142 @@ public class JobValidationTest {
         var e = Assertions.assertThrows(StatusRuntimeException.class, () -> orchClient.validateJob(request));
         Assertions.assertEquals(Status.Code.FAILED_PRECONDITION, e.getStatus().getCode());
     }
+
+    @Test
+    public void importData_reservedOutputAttr() {
+
+        var modelTags = List.of(TagUpdate.newBuilder()
+                .setAttrName("model_key")
+                .setValue(MetadataCodec.encodeValue("import_data_reserved_output_attr"))
+                .build());
+
+        var modelSelector = createDataImportModel(modelTags);
+
+        var job = JobDefinition.newBuilder()
+                .setJobType(JobType.IMPORT_DATA)
+                .setImportData(ImportDataJob.newBuilder()
+                        .setModel(modelSelector)
+                        .addStorageAccess("UNIT_TEST_EXTERNAL_STORAGE")
+                        .addOutputAttrs(TagUpdate.newBuilder()
+                                .setAttrName("trac_import_location_key")
+                                .setValue(MetadataCodec.encodeValue("spoofed_location"))));
+
+        var request = JobRequest.newBuilder()
+                .setTenant(TEST_TENANT)
+                .setJob(job)
+                .build();
+
+        var e = Assertions.assertThrows(StatusRuntimeException.class, () -> orchClient.validateJob(request));
+        Assertions.assertEquals(Status.Code.INVALID_ARGUMENT, e.getStatus().getCode());
+    }
+
+    @Test
+    public void importData_importsMustBeEmpty() {
+
+        var modelTags = List.of(TagUpdate.newBuilder()
+                .setAttrName("model_key")
+                .setValue(MetadataCodec.encodeValue("import_data_imports_must_be_empty"))
+                .build());
+
+        var modelSelector = createDataImportModel(modelTags);
+
+        var job = JobDefinition.newBuilder()
+                .setJobType(JobType.IMPORT_DATA)
+                .setImportData(ImportDataJob.newBuilder()
+                        .setModel(modelSelector)
+                        .addStorageAccess("UNIT_TEST_EXTERNAL_STORAGE")
+                        .putImports("import_one", basicDataSelector));
+
+        var request = JobRequest.newBuilder()
+                .setTenant(TEST_TENANT)
+                .setJob(job)
+                .build();
+
+        var e = Assertions.assertThrows(StatusRuntimeException.class, () -> orchClient.validateJob(request));
+        Assertions.assertEquals(Status.Code.INVALID_ARGUMENT, e.getStatus().getCode());
+    }
+
+    @Test
+    public void importData_importAttrsMustBeEmpty() {
+
+        var modelTags = List.of(TagUpdate.newBuilder()
+                .setAttrName("model_key")
+                .setValue(MetadataCodec.encodeValue("import_data_import_attrs_must_be_empty"))
+                .build());
+
+        var modelSelector = createDataImportModel(modelTags);
+
+        var job = JobDefinition.newBuilder()
+                .setJobType(JobType.IMPORT_DATA)
+                .setImportData(ImportDataJob.newBuilder()
+                        .setModel(modelSelector)
+                        .addStorageAccess("UNIT_TEST_EXTERNAL_STORAGE")
+                        .addImportAttrs(TagUpdate.newBuilder()
+                                .setAttrName("business_date")
+                                .setValue(MetadataCodec.encodeValue("2024-01-01"))));
+
+        var request = JobRequest.newBuilder()
+                .setTenant(TEST_TENANT)
+                .setJob(job)
+                .build();
+
+        var e = Assertions.assertThrows(StatusRuntimeException.class, () -> orchClient.validateJob(request));
+        Assertions.assertEquals(Status.Code.INVALID_ARGUMENT, e.getStatus().getCode());
+    }
+
+    @Test
+    public void exportData_reservedOutputAttr() {
+
+        var modelTags = List.of(TagUpdate.newBuilder()
+                .setAttrName("model_key")
+                .setValue(MetadataCodec.encodeValue("export_data_reserved_output_attr"))
+                .build());
+
+        var modelSelector = createDataExportModel(modelTags);
+
+        var job = JobDefinition.newBuilder()
+                .setJobType(JobType.EXPORT_DATA)
+                .setExportData(ExportDataJob.newBuilder()
+                        .setModel(modelSelector)
+                        .putInputs("input_data", basicDataSelector)
+                        .addStorageAccess("UNIT_TEST_EXTERNAL_STORAGE")
+                        .addOutputAttrs(TagUpdate.newBuilder()
+                                .setAttrName("trac_job_output")
+                                .setValue(MetadataCodec.encodeValue("spoofed"))));
+
+        var request = JobRequest.newBuilder()
+                .setTenant(TEST_TENANT)
+                .setJob(job)
+                .build();
+
+        var e = Assertions.assertThrows(StatusRuntimeException.class, () -> orchClient.validateJob(request));
+        Assertions.assertEquals(Status.Code.INVALID_ARGUMENT, e.getStatus().getCode());
+    }
+
+    @Test
+    public void exportData_exportsMustBeEmpty() {
+
+        var modelTags = List.of(TagUpdate.newBuilder()
+                .setAttrName("model_key")
+                .setValue(MetadataCodec.encodeValue("export_data_exports_must_be_empty"))
+                .build());
+
+        var modelSelector = createDataExportModel(modelTags);
+
+        var job = JobDefinition.newBuilder()
+                .setJobType(JobType.EXPORT_DATA)
+                .setExportData(ExportDataJob.newBuilder()
+                        .setModel(modelSelector)
+                        .putInputs("input_data", basicDataSelector)
+                        .addStorageAccess("UNIT_TEST_EXTERNAL_STORAGE")
+                        .putExports("export_one", basicDataSelector));
+
+        var request = JobRequest.newBuilder()
+                .setTenant(TEST_TENANT)
+                .setJob(job)
+                .build();
+
+        var e = Assertions.assertThrows(StatusRuntimeException.class, () -> orchClient.validateJob(request));
+        Assertions.assertEquals(Status.Code.INVALID_ARGUMENT, e.getStatus().getCode());
+    }
 }

--- a/tracdap-services/tracdap-svc-orch/src/test/java/org/finos/tracdap/svc/orch/api/JobValidationTest.java
+++ b/tracdap-services/tracdap-svc-orch/src/test/java/org/finos/tracdap/svc/orch/api/JobValidationTest.java
@@ -958,4 +958,364 @@ public class JobValidationTest {
         var e = Assertions.assertThrows(StatusRuntimeException.class, () -> orchClient.validateJob(jobRequest));
         Assertions.assertEquals(Status.Code.FAILED_PRECONDITION, e.getStatus().getCode());
     }
+
+    private TagSelector createDataImportModel(List<TagUpdate> tags) {
+
+        var modelDef = ModelDefinition.newBuilder()
+                .setLanguage("python")
+                .setRepository("UNIT_TEST_REPO")
+                .setVersion("v1.0.0")
+                .setPath("src/")
+                .setEntryPoint("acme.models.test_model.BasicDataImportModel")
+                .setModelType(ModelType.DATA_IMPORT_MODEL)
+                .putOutputs("output_data", ModelOutputSchema.newBuilder()
+                        .setObjectType(ObjectType.DATA)
+                        .setSchema(SampleData.BASIC_TABLE_SCHEMA)
+                        .build())
+                .build();
+
+        var writeRequest = MetadataWriteRequest.newBuilder()
+                .setTenant(TEST_TENANT)
+                .setObjectType(ObjectType.MODEL)
+                .setDefinition(ObjectDefinition.newBuilder()
+                        .setObjectType(ObjectType.MODEL)
+                        .setModel(modelDef))
+                .addAllTagUpdates(tags)
+                .build();
+
+        var modelId = metaClient.createObject(writeRequest);
+
+        return MetadataUtil.selectorFor(modelId);
+    }
+
+    private TagSelector createDataExportModel(List<TagUpdate> tags) {
+
+        var modelDef = ModelDefinition.newBuilder()
+                .setLanguage("python")
+                .setRepository("UNIT_TEST_REPO")
+                .setVersion("v1.0.0")
+                .setPath("src/")
+                .setEntryPoint("acme.models.test_model.BasicDataExportModel")
+                .setModelType(ModelType.DATA_EXPORT_MODEL)
+                .putInputs("input_data", ModelInputSchema.newBuilder()
+                        .setObjectType(ObjectType.DATA)
+                        .setSchema(SampleData.BASIC_TABLE_SCHEMA)
+                        .build())
+                .build();
+
+        var writeRequest = MetadataWriteRequest.newBuilder()
+                .setTenant(TEST_TENANT)
+                .setObjectType(ObjectType.MODEL)
+                .setDefinition(ObjectDefinition.newBuilder()
+                        .setObjectType(ObjectType.MODEL)
+                        .setModel(modelDef))
+                .addAllTagUpdates(tags)
+                .build();
+
+        var modelId = metaClient.createObject(writeRequest);
+
+        return MetadataUtil.selectorFor(modelId);
+    }
+
+    @Test
+    public void importData_validateOk() {
+
+        var modelTags = List.of(TagUpdate.newBuilder()
+                .setAttrName("model_key")
+                .setValue(MetadataCodec.encodeValue("import_data_validate_ok"))
+                .build());
+
+        var modelSelector = createDataImportModel(modelTags);
+
+        var job = JobDefinition.newBuilder()
+                .setJobType(JobType.IMPORT_DATA)
+                .setImportData(ImportDataJob.newBuilder()
+                        .setModel(modelSelector)
+                        .addStorageAccess("UNIT_TEST_EXTERNAL_STORAGE"));
+
+        var request = JobRequest.newBuilder()
+                .setTenant(TEST_TENANT)
+                .setJob(job)
+                .build();
+
+        var response = orchClient.validateJob(request);
+
+        Assertions.assertEquals(JobStatusCode.VALIDATED, response.getStatusCode());
+    }
+
+    @Test
+    public void importData_badInput() {
+
+        // Model is required and is missing entirely
+
+        var job = JobDefinition.newBuilder()
+                .setJobType(JobType.IMPORT_DATA)
+                .setImportData(ImportDataJob.newBuilder()
+                        .addStorageAccess("UNIT_TEST_EXTERNAL_STORAGE"));
+
+        var request = JobRequest.newBuilder()
+                .setTenant(TEST_TENANT)
+                .setJob(job)
+                .build();
+
+        var e = Assertions.assertThrows(StatusRuntimeException.class, () -> orchClient.validateJob(request));
+        Assertions.assertEquals(Status.Code.INVALID_ARGUMENT, e.getStatus().getCode());
+    }
+
+    @Test
+    public void importData_outputsMustBeEmpty() {
+
+        var modelTags = List.of(TagUpdate.newBuilder()
+                .setAttrName("model_key")
+                .setValue(MetadataCodec.encodeValue("import_data_outputs_must_be_empty"))
+                .build());
+
+        var modelSelector = createDataImportModel(modelTags);
+
+        var job = JobDefinition.newBuilder()
+                .setJobType(JobType.IMPORT_DATA)
+                .setImportData(ImportDataJob.newBuilder()
+                        .setModel(modelSelector)
+                        .addStorageAccess("UNIT_TEST_EXTERNAL_STORAGE")
+                        .putOutputs("output_data", basicDataSelector));
+
+        var request = JobRequest.newBuilder()
+                .setTenant(TEST_TENANT)
+                .setJob(job)
+                .build();
+
+        var e = Assertions.assertThrows(StatusRuntimeException.class, () -> orchClient.validateJob(request));
+        Assertions.assertEquals(Status.Code.INVALID_ARGUMENT, e.getStatus().getCode());
+    }
+
+    @Test
+    public void importData_wrongResourceType() {
+
+        var modelTags = List.of(TagUpdate.newBuilder()
+                .setAttrName("model_key")
+                .setValue(MetadataCodec.encodeValue("import_data_wrong_resource_type"))
+                .build());
+
+        var modelSelector = createDataImportModel(modelTags);
+
+        var job = JobDefinition.newBuilder()
+                .setJobType(JobType.IMPORT_DATA)
+                .setImportData(ImportDataJob.newBuilder()
+                        .setModel(modelSelector)
+                        .addStorageAccess("UNIT_TEST_STORAGE"));  // INTERNAL_STORAGE, not EXTERNAL_STORAGE
+
+        var request = JobRequest.newBuilder()
+                .setTenant(TEST_TENANT)
+                .setJob(job)
+                .build();
+
+        var e = Assertions.assertThrows(StatusRuntimeException.class, () -> orchClient.validateJob(request));
+        Assertions.assertEquals(Status.Code.FAILED_PRECONDITION, e.getStatus().getCode());
+    }
+
+    @Test
+    public void importData_wrongModelType() {
+
+        var modelTags = List.of(TagUpdate.newBuilder()
+                .setAttrName("model_key")
+                .setValue(MetadataCodec.encodeValue("import_data_wrong_model_type"))
+                .build());
+
+        // A standard model, not a data import model
+        var modelSelector = createBasicModel(
+                SampleData.BASIC_TABLE_SCHEMA,
+                SampleData.BASIC_TABLE_SCHEMA_V2,
+                modelTags);
+
+        var job = JobDefinition.newBuilder()
+                .setJobType(JobType.IMPORT_DATA)
+                .setImportData(ImportDataJob.newBuilder()
+                        .setModel(modelSelector)
+                        .addStorageAccess("UNIT_TEST_EXTERNAL_STORAGE"));
+
+        var request = JobRequest.newBuilder()
+                .setTenant(TEST_TENANT)
+                .setJob(job)
+                .build();
+
+        var e = Assertions.assertThrows(StatusRuntimeException.class, () -> orchClient.validateJob(request));
+        Assertions.assertEquals(Status.Code.FAILED_PRECONDITION, e.getStatus().getCode());
+    }
+
+    @Test
+    public void importData_missingResources() {
+
+        var modelTags = List.of(TagUpdate.newBuilder()
+                .setAttrName("model_key")
+                .setValue(MetadataCodec.encodeValue("import_data_missing_resources"))
+                .build());
+
+        var modelSelector = createDataImportModel(modelTags);
+
+        var job = JobDefinition.newBuilder()
+                .setJobType(JobType.IMPORT_DATA)
+                .setImportData(ImportDataJob.newBuilder()
+                        .setModel(modelSelector)
+                        .addStorageAccess("STORAGE_THAT_IS_NOT_CONFIGURED"));
+
+        var request = JobRequest.newBuilder()
+                .setTenant(TEST_TENANT)
+                .setJob(job)
+                .build();
+
+        var e = Assertions.assertThrows(StatusRuntimeException.class, () -> orchClient.validateJob(request));
+        Assertions.assertEquals(Status.Code.FAILED_PRECONDITION, e.getStatus().getCode());
+    }
+
+    @Test
+    public void exportData_validateOk() {
+
+        var modelTags = List.of(TagUpdate.newBuilder()
+                .setAttrName("model_key")
+                .setValue(MetadataCodec.encodeValue("export_data_validate_ok"))
+                .build());
+
+        var modelSelector = createDataExportModel(modelTags);
+
+        var job = JobDefinition.newBuilder()
+                .setJobType(JobType.EXPORT_DATA)
+                .setExportData(ExportDataJob.newBuilder()
+                        .setModel(modelSelector)
+                        .putInputs("input_data", basicDataSelector)
+                        .addStorageAccess("UNIT_TEST_EXTERNAL_STORAGE"));
+
+        var request = JobRequest.newBuilder()
+                .setTenant(TEST_TENANT)
+                .setJob(job)
+                .build();
+
+        var response = orchClient.validateJob(request);
+
+        Assertions.assertEquals(JobStatusCode.VALIDATED, response.getStatusCode());
+    }
+
+    @Test
+    public void exportData_badInput() {
+
+        // Model is required and is missing entirely
+
+        var job = JobDefinition.newBuilder()
+                .setJobType(JobType.EXPORT_DATA)
+                .setExportData(ExportDataJob.newBuilder()
+                        .addStorageAccess("UNIT_TEST_EXTERNAL_STORAGE"));
+
+        var request = JobRequest.newBuilder()
+                .setTenant(TEST_TENANT)
+                .setJob(job)
+                .build();
+
+        var e = Assertions.assertThrows(StatusRuntimeException.class, () -> orchClient.validateJob(request));
+        Assertions.assertEquals(Status.Code.INVALID_ARGUMENT, e.getStatus().getCode());
+    }
+
+    @Test
+    public void exportData_outputsMustBeEmpty() {
+
+        var modelTags = List.of(TagUpdate.newBuilder()
+                .setAttrName("model_key")
+                .setValue(MetadataCodec.encodeValue("export_data_outputs_must_be_empty"))
+                .build());
+
+        var modelSelector = createDataExportModel(modelTags);
+
+        var job = JobDefinition.newBuilder()
+                .setJobType(JobType.EXPORT_DATA)
+                .setExportData(ExportDataJob.newBuilder()
+                        .setModel(modelSelector)
+                        .putInputs("input_data", basicDataSelector)
+                        .addStorageAccess("UNIT_TEST_EXTERNAL_STORAGE")
+                        .putOutputs("unexpected_output", basicDataSelector));
+
+        var request = JobRequest.newBuilder()
+                .setTenant(TEST_TENANT)
+                .setJob(job)
+                .build();
+
+        var e = Assertions.assertThrows(StatusRuntimeException.class, () -> orchClient.validateJob(request));
+        Assertions.assertEquals(Status.Code.INVALID_ARGUMENT, e.getStatus().getCode());
+    }
+
+    @Test
+    public void exportData_wrongResourceType() {
+
+        var modelTags = List.of(TagUpdate.newBuilder()
+                .setAttrName("model_key")
+                .setValue(MetadataCodec.encodeValue("export_data_wrong_resource_type"))
+                .build());
+
+        var modelSelector = createDataExportModel(modelTags);
+
+        var job = JobDefinition.newBuilder()
+                .setJobType(JobType.EXPORT_DATA)
+                .setExportData(ExportDataJob.newBuilder()
+                        .setModel(modelSelector)
+                        .putInputs("input_data", basicDataSelector)
+                        .addStorageAccess("UNIT_TEST_REPO"));  // MODEL_REPOSITORY, not EXTERNAL_STORAGE
+
+        var request = JobRequest.newBuilder()
+                .setTenant(TEST_TENANT)
+                .setJob(job)
+                .build();
+
+        var e = Assertions.assertThrows(StatusRuntimeException.class, () -> orchClient.validateJob(request));
+        Assertions.assertEquals(Status.Code.FAILED_PRECONDITION, e.getStatus().getCode());
+    }
+
+    @Test
+    public void exportData_wrongModelType() {
+
+        var modelTags = List.of(TagUpdate.newBuilder()
+                .setAttrName("model_key")
+                .setValue(MetadataCodec.encodeValue("export_data_wrong_model_type"))
+                .build());
+
+        // A data import model, not a data export model
+        var modelSelector = createDataImportModel(modelTags);
+
+        var job = JobDefinition.newBuilder()
+                .setJobType(JobType.EXPORT_DATA)
+                .setExportData(ExportDataJob.newBuilder()
+                        .setModel(modelSelector)
+                        .putInputs("input_data", basicDataSelector)
+                        .addStorageAccess("UNIT_TEST_EXTERNAL_STORAGE"));
+
+        var request = JobRequest.newBuilder()
+                .setTenant(TEST_TENANT)
+                .setJob(job)
+                .build();
+
+        var e = Assertions.assertThrows(StatusRuntimeException.class, () -> orchClient.validateJob(request));
+        Assertions.assertEquals(Status.Code.FAILED_PRECONDITION, e.getStatus().getCode());
+    }
+
+    @Test
+    public void exportData_missingResources() {
+
+        var modelTags = List.of(TagUpdate.newBuilder()
+                .setAttrName("model_key")
+                .setValue(MetadataCodec.encodeValue("export_data_missing_resources"))
+                .build());
+
+        var modelSelector = createDataExportModel(modelTags);
+
+        var job = JobDefinition.newBuilder()
+                .setJobType(JobType.EXPORT_DATA)
+                .setExportData(ExportDataJob.newBuilder()
+                        .setModel(modelSelector)
+                        .putInputs("input_data", basicDataSelector)
+                        .addStorageAccess("STORAGE_THAT_IS_NOT_CONFIGURED"));
+
+        var request = JobRequest.newBuilder()
+                .setTenant(TEST_TENANT)
+                .setJob(job)
+                .build();
+
+        var e = Assertions.assertThrows(StatusRuntimeException.class, () -> orchClient.validateJob(request));
+        Assertions.assertEquals(Status.Code.FAILED_PRECONDITION, e.getStatus().getCode());
+    }
 }

--- a/tracdap-services/tracdap-svc-orch/src/test/java/org/finos/tracdap/svc/orch/jobs/ImportExportDataTest.java
+++ b/tracdap-services/tracdap-svc-orch/src/test/java/org/finos/tracdap/svc/orch/jobs/ImportExportDataTest.java
@@ -250,6 +250,9 @@ public class ImportExportDataTest {
         var fieldCountAttr = dataTag.getAttrsOrThrow("trac_schema_field_count");
         var rowCountAttr = dataTag.getAttrsOrThrow("trac_data_row_count");
         var jobTypeAttr = dataTag.getAttrsOrThrow("trac_job_type");
+        var importLocationAttr = dataTag.getAttrsOrThrow("trac_import_location_key");
+        var originalFileNameAttr = dataTag.getAttrsOrThrow("original_file_name");
+        var originalFileSizeAttr = dataTag.getAttrsOrThrow("original_file_size");
 
         Assertions.assertEquals("import_export_data:customer_loans", MetadataCodec.decodeStringValue(outputAttr));
         Assertions.assertEquals(5, MetadataCodec.decodeIntegerValue(fieldCountAttr));
@@ -257,6 +260,10 @@ public class ImportExportDataTest {
         Assertions.assertEquals(1, dataDef.getPartsCount());
         Assertions.assertTrue(dataTag.containsAttrs("trac_create_job"));
         Assertions.assertEquals(JobType.IMPORT_DATA.name(), MetadataCodec.decodeStringValue(jobTypeAttr));
+        Assertions.assertEquals(EXTERNAL_STORAGE_KEY, MetadataCodec.decodeStringValue(importLocationAttr));
+        Assertions.assertEquals("sample_data.parquet", MetadataCodec.decodeStringValue(originalFileNameAttr));
+        Assertions.assertTrue(MetadataCodec.decodeIntegerValue(originalFileSizeAttr) > 0);
+        Assertions.assertTrue(dataTag.containsAttrs("original_file_modified_date"));
 
         var storageReq = MetadataReadRequest.newBuilder()
                 .setTenant(TEST_TENANT)

--- a/tracdap-services/tracdap-svc-orch/src/test/java/org/finos/tracdap/svc/orch/jobs/ImportExportDataTest.java
+++ b/tracdap-services/tracdap-svc-orch/src/test/java/org/finos/tracdap/svc/orch/jobs/ImportExportDataTest.java
@@ -249,12 +249,14 @@ public class ImportExportDataTest {
         var outputAttr = dataTag.getAttrsOrThrow("e2e_test_data");
         var fieldCountAttr = dataTag.getAttrsOrThrow("trac_schema_field_count");
         var rowCountAttr = dataTag.getAttrsOrThrow("trac_data_row_count");
+        var jobTypeAttr = dataTag.getAttrsOrThrow("trac_job_type");
 
         Assertions.assertEquals("import_export_data:customer_loans", MetadataCodec.decodeStringValue(outputAttr));
         Assertions.assertEquals(5, MetadataCodec.decodeIntegerValue(fieldCountAttr));
         Assertions.assertTrue(MetadataCodec.decodeIntegerValue(rowCountAttr) > 0);
         Assertions.assertEquals(1, dataDef.getPartsCount());
         Assertions.assertTrue(dataTag.containsAttrs("trac_create_job"));
+        Assertions.assertEquals(JobType.IMPORT_DATA.name(), MetadataCodec.decodeStringValue(jobTypeAttr));
 
         var storageReq = MetadataReadRequest.newBuilder()
                 .setTenant(TEST_TENANT)

--- a/tracdap-services/tracdap-svc-orch/src/test/java/org/finos/tracdap/svc/orch/jobs/ImportExportDataTest.java
+++ b/tracdap-services/tracdap-svc-orch/src/test/java/org/finos/tracdap/svc/orch/jobs/ImportExportDataTest.java
@@ -1,0 +1,393 @@
+/*
+ * Licensed to the Fintech Open Source Foundation (FINOS) under one or
+ * more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * FINOS licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.finos.tracdap.svc.orch.jobs;
+
+import org.finos.tracdap.api.*;
+import org.finos.tracdap.common.metadata.MetadataCodec;
+import org.finos.tracdap.common.metadata.MetadataUtil;
+import org.finos.tracdap.metadata.*;
+import org.finos.tracdap.metadata.ImportDataJob;
+import org.finos.tracdap.metadata.ExportDataJob;
+import org.finos.tracdap.svc.admin.TracAdminService;
+import org.finos.tracdap.svc.data.TracDataService;
+import org.finos.tracdap.svc.meta.TracMetadataService;
+import org.finos.tracdap.svc.orch.TracOrchestratorService;
+import org.finos.tracdap.test.helpers.GitHelpers;
+import org.finos.tracdap.test.helpers.PlatformTest;
+
+import com.google.protobuf.ByteString;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.List;
+
+
+@Tag("integration")
+@Tag("int-e2e")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class ImportExportDataTest {
+
+    private static final String TEST_TENANT = "ACME_CORP";
+    private static final String E2E_CONFIG = "config/trac-e2e.yaml";
+    private static final String E2E_TENANTS = "config/trac-e2e-tenants.yaml";
+    private static final String IMPORT_SOURCE_PATH = "examples/models/python/data/inputs/staging/sample_data.parquet";
+    private static final String EXTERNAL_STORAGE_KEY = "TEST_EXTERNAL_STORAGE";
+
+    @RegisterExtension
+    public static final PlatformTest platform = PlatformTest.forConfig(E2E_CONFIG, List.of(E2E_TENANTS))
+            .runDbDeploy(true)
+            .runCacheDeploy(true)
+            .addTenant(TEST_TENANT)
+            .prepareLocalExecutor(true)
+            .startService(TracMetadataService.class)
+            .startService(TracDataService.class)
+            .startService(TracOrchestratorService.class)
+            .startService(TracAdminService.class)
+            .build();
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    static TagHeader importModelId;
+    static TagHeader exportModelId;
+    static SchemaDefinition exportInputSchema;
+
+    static TagHeader jobId_importDataModel;
+    static TagHeader jobId_exportDataModel;
+
+    static TagHeader jobId_importData;
+    static TagHeader exportInputDataId;
+    static TagHeader jobId_exportData;
+
+    @Test @Order(101)
+    void prepareExternalStorage() throws Exception {
+
+        var externalStorageDir = platform.workingDir().resolve("external_storage");
+        Files.createDirectories(externalStorageDir);
+
+        var sourcePath = platform.tracRepoDir().resolve(IMPORT_SOURCE_PATH);
+        Files.copy(sourcePath, externalStorageDir.resolve("sample_data.parquet"), StandardCopyOption.REPLACE_EXISTING);
+    }
+
+    @Test @Order(102)
+    void importDataModel() throws Exception {
+
+        log.info("Running IMPORT_MODEL job for SimpleDataImport...");
+
+        var modelVersion = GitHelpers.getCurrentCommit();
+        var modelStub = ModelDefinition.newBuilder()
+                .setLanguage("python")
+                .setRepository("TRAC_LOCAL_REPO")
+                .setPath("examples/models/python/src")
+                .setEntryPoint("tutorial.data_import.SimpleDataImport")
+                .setVersion(modelVersion)
+                .build();
+
+        var modelAttrs = List.of(TagUpdate.newBuilder()
+                .setAttrName("e2e_test_model")
+                .setValue(MetadataCodec.encodeValue("import_export_data:simple_data_import"))
+                .build());
+
+        var jobAttrs = List.of(TagUpdate.newBuilder()
+                .setAttrName("e2e_test_job")
+                .setValue(MetadataCodec.encodeValue("import_export_data:import_simple_data_import"))
+                .build());
+
+        jobId_importDataModel = Helpers.startModelImport(platform, TEST_TENANT, modelStub, modelAttrs, jobAttrs);
+    }
+
+    @Test @Order(103)
+    void importDataModel_result() {
+
+        var modelTag = Helpers.waitForModelImport(platform, TEST_TENANT, jobId_importDataModel);
+        var modelDef = modelTag.getDefinition().getModel();
+
+        Assertions.assertEquals(ModelType.DATA_IMPORT_MODEL, modelDef.getModelType());
+        Assertions.assertEquals("tutorial.data_import.SimpleDataImport", modelDef.getEntryPoint());
+        Assertions.assertTrue(modelDef.getOutputsMap().containsKey("customer_loans"));
+
+        importModelId = modelTag.getHeader();
+    }
+
+    @Test @Order(104)
+    void exportDataModel() throws Exception {
+
+        log.info("Running IMPORT_MODEL job for DataExportExample...");
+
+        var modelVersion = GitHelpers.getCurrentCommit();
+        var modelStub = ModelDefinition.newBuilder()
+                .setLanguage("python")
+                .setRepository("TRAC_LOCAL_REPO")
+                .setPath("examples/models/python/src")
+                .setEntryPoint("tutorial.data_export.DataExportExample")
+                .setVersion(modelVersion)
+                .build();
+
+        var modelAttrs = List.of(TagUpdate.newBuilder()
+                .setAttrName("e2e_test_model")
+                .setValue(MetadataCodec.encodeValue("import_export_data:data_export_example"))
+                .build());
+
+        var jobAttrs = List.of(TagUpdate.newBuilder()
+                .setAttrName("e2e_test_job")
+                .setValue(MetadataCodec.encodeValue("import_export_data:import_data_export_example"))
+                .build());
+
+        jobId_exportDataModel = Helpers.startModelImport(platform, TEST_TENANT, modelStub, modelAttrs, jobAttrs);
+    }
+
+    @Test @Order(105)
+    void exportDataModel_result() {
+
+        var modelTag = Helpers.waitForModelImport(platform, TEST_TENANT, jobId_exportDataModel);
+        var modelDef = modelTag.getDefinition().getModel();
+
+        Assertions.assertEquals(ModelType.DATA_EXPORT_MODEL, modelDef.getModelType());
+        Assertions.assertEquals("tutorial.data_export.DataExportExample", modelDef.getEntryPoint());
+        Assertions.assertTrue(modelDef.getInputsMap().containsKey("profit_by_region"));
+
+        exportModelId = modelTag.getHeader();
+        exportInputSchema = modelDef.getInputsOrThrow("profit_by_region").getSchema();
+    }
+
+    @Test @Order(201)
+    void importData() {
+
+        var orchClient = platform.orchClientBlocking();
+
+        var importData = ImportDataJob.newBuilder()
+                .setModel(MetadataUtil.selectorFor(importModelId))
+                .putParameters("storage_key", MetadataCodec.encodeValue(EXTERNAL_STORAGE_KEY))
+                .putParameters("source_file", MetadataCodec.encodeValue("sample_data.parquet"))
+                .addStorageAccess(EXTERNAL_STORAGE_KEY)
+                .addOutputAttrs(TagUpdate.newBuilder()
+                        .setAttrName("e2e_test_data")
+                        .setValue(MetadataCodec.encodeValue("import_export_data:customer_loans")))
+                .build();
+
+        var jobRequest = JobRequest.newBuilder()
+                .setTenant(TEST_TENANT)
+                .setJob(JobDefinition.newBuilder()
+                        .setJobType(JobType.IMPORT_DATA)
+                        .setImportData(importData))
+                .addJobAttrs(TagUpdate.newBuilder()
+                        .setAttrName("e2e_test_job")
+                        .setValue(MetadataCodec.encodeValue("import_export_data:import_data")))
+                .build();
+
+        jobId_importData = Helpers.startJob(orchClient, jobRequest).getJobId();
+    }
+
+    @Test @Order(202)
+    void importData_result() {
+
+        var metaClient = platform.metaClientBlocking();
+        var orchClient = platform.orchClientBlocking();
+
+        var jobStatus = Helpers.waitForJob(orchClient, TEST_TENANT, jobId_importData);
+        var jobKey = MetadataUtil.objectKey(jobStatus.getJobId());
+
+        Assertions.assertEquals(JobStatusCode.SUCCEEDED, jobStatus.getStatusCode());
+
+        var jobReq = MetadataReadRequest.newBuilder()
+                .setTenant(TEST_TENANT)
+                .setSelector(MetadataUtil.selectorFor(jobStatus.getJobId()))
+                .build();
+
+        var jobTag = metaClient.readObject(jobReq);
+        var importDataJob = jobTag.getDefinition().getJob().getImportData();
+
+        Assertions.assertEquals(JobType.IMPORT_DATA, jobTag.getDefinition().getJob().getJobType());
+        Assertions.assertEquals(MetadataUtil.objectKey(importModelId), MetadataUtil.objectKey(importDataJob.getModel()));
+        Assertions.assertTrue(importDataJob.getStorageAccessList().contains(EXTERNAL_STORAGE_KEY));
+
+        var dataSearch = MetadataSearchRequest.newBuilder()
+                .setTenant(TEST_TENANT)
+                .setSearchParams(SearchParameters.newBuilder()
+                        .setObjectType(ObjectType.DATA)
+                        .setSearch(SearchExpression.newBuilder()
+                                .setTerm(SearchTerm.newBuilder()
+                                        .setAttrName("trac_create_job")
+                                        .setAttrType(BasicType.STRING)
+                                        .setOperator(SearchOperator.EQ)
+                                        .setSearchValue(MetadataCodec.encodeValue(jobKey)))))
+                .build();
+
+        var dataSearchResult = metaClient.search(dataSearch);
+        Assertions.assertEquals(1, dataSearchResult.getSearchResultCount());
+
+        var searchResult = dataSearchResult.getSearchResult(0);
+        var dataReq = MetadataReadRequest.newBuilder()
+                .setTenant(TEST_TENANT)
+                .setSelector(MetadataUtil.selectorFor(searchResult.getHeader()))
+                .build();
+
+        var dataTag = metaClient.readObject(dataReq);
+        var dataDef = dataTag.getDefinition().getData();
+        var outputAttr = dataTag.getAttrsOrThrow("e2e_test_data");
+        var fieldCountAttr = dataTag.getAttrsOrThrow("trac_schema_field_count");
+        var rowCountAttr = dataTag.getAttrsOrThrow("trac_data_row_count");
+
+        Assertions.assertEquals("import_export_data:customer_loans", MetadataCodec.decodeStringValue(outputAttr));
+        Assertions.assertEquals(5, MetadataCodec.decodeIntegerValue(fieldCountAttr));
+        Assertions.assertTrue(MetadataCodec.decodeIntegerValue(rowCountAttr) > 0);
+        Assertions.assertEquals(1, dataDef.getPartsCount());
+        Assertions.assertTrue(dataTag.containsAttrs("trac_create_job"));
+
+        var storageReq = MetadataReadRequest.newBuilder()
+                .setTenant(TEST_TENANT)
+                .setSelector(dataDef.getStorageId())
+                .build();
+
+        var storageTag = metaClient.readObject(storageReq);
+
+        Assertions.assertEquals(ObjectType.STORAGE, storageTag.getDefinition().getObjectType());
+        Assertions.assertTrue(storageTag.containsAttrs("trac_create_job"));
+    }
+
+    @Test @Order(301)
+    void prepareExportInput() {
+
+        log.info("Loading export input data...");
+
+        var dataClient = platform.dataClientBlocking();
+
+        var csvContent = "region,gross_profit\r\nmunster,1000.50\r\nleinster,2000.75\r\n"
+                .getBytes(StandardCharsets.UTF_8);
+
+        var writeRequest = DataWriteRequest.newBuilder()
+                .setTenant(TEST_TENANT)
+                .setSchema(exportInputSchema)
+                .setFormat("text/csv")
+                .setContent(ByteString.copyFrom(csvContent))
+                .addTagUpdates(TagUpdate.newBuilder()
+                        .setAttrName("e2e_test_dataset")
+                        .setValue(MetadataCodec.encodeValue("import_export_data:profit_by_region")))
+                .build();
+
+        exportInputDataId = dataClient.createSmallDataset(writeRequest);
+    }
+
+    @Test @Order(302)
+    void exportData() {
+
+        var orchClient = platform.orchClientBlocking();
+
+        var exportData = ExportDataJob.newBuilder()
+                .setModel(MetadataUtil.selectorFor(exportModelId))
+                .putParameters("storage_key", MetadataCodec.encodeValue(EXTERNAL_STORAGE_KEY))
+                .putParameters("no_overwrite", MetadataCodec.encodeValue(false))
+                .putParameters("export_comment", MetadataCodec.encodeValue("import_export_data e2e test"))
+                .putInputs("profit_by_region", MetadataUtil.selectorFor(exportInputDataId))
+                .addStorageAccess(EXTERNAL_STORAGE_KEY)
+                .build();
+
+        var jobRequest = JobRequest.newBuilder()
+                .setTenant(TEST_TENANT)
+                .setJob(JobDefinition.newBuilder()
+                        .setJobType(JobType.EXPORT_DATA)
+                        .setExportData(exportData))
+                .addJobAttrs(TagUpdate.newBuilder()
+                        .setAttrName("e2e_test_job")
+                        .setValue(MetadataCodec.encodeValue("import_export_data:export_data")))
+                .build();
+
+        jobId_exportData = Helpers.startJob(orchClient, jobRequest).getJobId();
+    }
+
+    @Test @Order(303)
+    void exportData_result() throws Exception {
+
+        var metaClient = platform.metaClientBlocking();
+        var orchClient = platform.orchClientBlocking();
+
+        var jobStatus = Helpers.waitForJob(orchClient, TEST_TENANT, jobId_exportData);
+        var jobKey = MetadataUtil.objectKey(jobStatus.getJobId());
+
+        Assertions.assertEquals(JobStatusCode.SUCCEEDED, jobStatus.getStatusCode());
+
+        var jobReq = MetadataReadRequest.newBuilder()
+                .setTenant(TEST_TENANT)
+                .setSelector(MetadataUtil.selectorFor(jobStatus.getJobId()))
+                .build();
+
+        var jobTag = metaClient.readObject(jobReq);
+        var exportDataJob = jobTag.getDefinition().getJob().getExportData();
+
+        Assertions.assertEquals(JobType.EXPORT_DATA, jobTag.getDefinition().getJob().getJobType());
+        Assertions.assertEquals(MetadataUtil.objectKey(exportModelId), MetadataUtil.objectKey(exportDataJob.getModel()));
+
+        // Export has no TRAC output - confirm deliberately, not just assumed
+        var dataSearch = MetadataSearchRequest.newBuilder()
+                .setTenant(TEST_TENANT)
+                .setSearchParams(SearchParameters.newBuilder()
+                        .setObjectType(ObjectType.DATA)
+                        .setSearch(SearchExpression.newBuilder()
+                                .setTerm(SearchTerm.newBuilder()
+                                        .setAttrName("trac_create_job")
+                                        .setAttrType(BasicType.STRING)
+                                        .setOperator(SearchOperator.EQ)
+                                        .setSearchValue(MetadataCodec.encodeValue(jobKey)))))
+                .build();
+
+        var dataSearchResult = metaClient.search(dataSearch);
+        Assertions.assertEquals(0, dataSearchResult.getSearchResultCount());
+
+        var exportedFile = platform.workingDir().resolve("external_storage/data_export_example/profit_by_region.csv");
+        Assertions.assertTrue(Files.exists(exportedFile));
+
+        var exportedContent = Files.readString(exportedFile, StandardCharsets.UTF_8);
+        var exportedLines = exportedContent.strip().split("\n");
+
+        Assertions.assertEquals(3, exportedLines.length);
+        Assertions.assertTrue(exportedLines[0].contains("region"));
+        Assertions.assertTrue(exportedLines[0].contains("gross_profit"));
+        Assertions.assertTrue(exportedContent.contains("munster"));
+        Assertions.assertTrue(exportedContent.contains("leinster"));
+    }
+
+    @Test @Order(401)
+    void importData_missingResource() {
+
+        var orchClient = platform.orchClientBlocking();
+
+        var importData = ImportDataJob.newBuilder()
+                .setModel(MetadataUtil.selectorFor(importModelId))
+                .putParameters("storage_key", MetadataCodec.encodeValue("STORAGE_THAT_IS_NOT_CONFIGURED"))
+                .putParameters("source_file", MetadataCodec.encodeValue("sample_data.parquet"))
+                .addStorageAccess("STORAGE_THAT_IS_NOT_CONFIGURED")
+                .build();
+
+        var jobRequest = JobRequest.newBuilder()
+                .setTenant(TEST_TENANT)
+                .setJob(JobDefinition.newBuilder()
+                        .setJobType(JobType.IMPORT_DATA)
+                        .setImportData(importData))
+                .build();
+
+        var e = Assertions.assertThrows(StatusRuntimeException.class, () -> orchClient.validateJob(jobRequest));
+        Assertions.assertEquals(Status.Code.FAILED_PRECONDITION, e.getStatus().getCode());
+    }
+}

--- a/tracdap-services/tracdap-svc-orch/src/test/java/org/finos/tracdap/svc/orch/jobs/ImportModelTest.java
+++ b/tracdap-services/tracdap-svc-orch/src/test/java/org/finos/tracdap/svc/orch/jobs/ImportModelTest.java
@@ -104,12 +104,14 @@ public abstract class ImportModelTest {
 
         var modelDef = modelTag.getDefinition().getModel();
         var modelAttr = modelTag.getAttrsOrThrow("e2e_test_model");
+        var jobTypeAttr = modelTag.getAttrsOrThrow("trac_job_type");
 
         Assertions.assertEquals("import_model:schema_files", MetadataCodec.decodeStringValue(modelAttr));
         Assertions.assertEquals("tutorial.schema_files.PnlAggregationSchemas", modelDef.getEntryPoint());
         Assertions.assertTrue(modelDef.getParametersMap().containsKey("eur_usd_rate"));
         Assertions.assertTrue(modelDef.getInputsMap().containsKey("customer_loans"));
         Assertions.assertTrue(modelDef.getOutputsMap().containsKey("profit_by_region"));
+        Assertions.assertEquals(JobType.IMPORT_MODEL.name(), MetadataCodec.decodeStringValue(jobTypeAttr));
     }
 
     @Test

--- a/tracdap-services/tracdap-svc-orch/src/test/java/org/finos/tracdap/svc/orch/jobs/RunFlowTest.java
+++ b/tracdap-services/tracdap-svc-orch/src/test/java/org/finos/tracdap/svc/orch/jobs/RunFlowTest.java
@@ -756,11 +756,13 @@ public class RunFlowTest {
         var outputAttr = dataTag.getAttrsOrThrow("e2e_test_data");
         var fieldCountAttr = dataTag.getAttrsOrThrow("trac_schema_field_count");
         var rowCountAttr = dataTag.getAttrsOrThrow("trac_data_row_count");
+        var jobTypeAttr = dataTag.getAttrsOrThrow("trac_job_type");
 
         Assertions.assertEquals("run_flow:data_output", MetadataCodec.decodeStringValue(outputAttr));
         Assertions.assertTrue(MetadataCodec.decodeIntegerValue(fieldCountAttr) > 0);
         Assertions.assertTrue(MetadataCodec.decodeIntegerValue(rowCountAttr) > 0);
         Assertions.assertEquals(1, dataDef.getPartsCount());
+        Assertions.assertEquals(JobType.RUN_FLOW.name(), MetadataCodec.decodeStringValue(jobTypeAttr));
 
         outputDataId = dataTag.getHeader();
     }

--- a/tracdap-services/tracdap-svc-orch/src/test/java/org/finos/tracdap/svc/orch/jobs/RunModelTest.java
+++ b/tracdap-services/tracdap-svc-orch/src/test/java/org/finos/tracdap/svc/orch/jobs/RunModelTest.java
@@ -634,11 +634,13 @@ public class RunModelTest {
         var outputAttr = dataTag.getAttrsOrThrow("e2e_test_data");
         var fieldCountAttr = dataTag.getAttrsOrThrow("trac_schema_field_count");
         var rowCountAttr = dataTag.getAttrsOrThrow("trac_data_row_count");
+        var jobTypeAttr = dataTag.getAttrsOrThrow("trac_job_type");
 
         Assertions.assertEquals("run_model:data_output", MetadataCodec.decodeStringValue(outputAttr));
         Assertions.assertTrue(MetadataCodec.decodeIntegerValue(fieldCountAttr) > 0);
         Assertions.assertTrue(MetadataCodec.decodeIntegerValue(rowCountAttr) > 0);
         Assertions.assertEquals(1, dataDef.getPartsCount());
+        Assertions.assertEquals(JobType.RUN_MODEL.name(), MetadataCodec.decodeStringValue(jobTypeAttr));
 
         outputDataId = dataTag.getHeader();
     }


### PR DESCRIPTION
Summary 
---

This PR introduces the capability to run Data Import and Data Export job types, closing the gap between "import/export exist as job types in the metadata model" and "the platform actually runs them"


Details 
---
The key elements introduced by this PR are:
-  ImportDataJob/ExportDataJob orchestrator logic, following the existing RunModelOrFlow-based pattern (required metadata/resources, expected outputs, result processing)                                                                                                                                                          
- Job registration in JobLogic, static validation in JobValidator, and consistency checks in JobConsistencyValidator — including model-type checks, storage-resource-type checks, and explicit rejection of the not-yet-wired imports/exports/importAttrs proto fields rather than silently ignoring them                                                                                                                                                      
- Source-provenance runtime mechanism: TracDataContext.set_source_metadata()/set_attribute() now actually record facts (original filename, size, modified date, import location, arbitrary business attrs) as TagUpdates that flow through to the created object's metadata, proven end-to-end via SimpleDataImport                                
- trac_model_type added as a controlled, searchable model tag attribute                                                                              

**Testing**                                                                                                                                                                                                                                                                                                                              
- New e2e integration test (ImportExportDataTest, tag int-e2e): full import → export round trip against local external storage, asserting provenance attrs, storage object creation, and file content on disk; plus a negative case for a misconfigured storage resource                                                                               
- 19 new JobValidationTest cases covering: happy path, bad input, wrong resource/model type, missing/wrong parameters, wrong input schema, reserved output attrs, and disallowed Attrs fields                                                                                                
- Unit tests for the source-provenance plumbing (test_source_provenance.py) covering set_attribute/set_source_metadata, attribute survival through view/item transformations, and JobResult forwarding — including a guard against reserved (trac_*/_*) attribute being written by an import model
 - ObjectUpdateLogicTest for the new trac_model_type tag   
  
**Known limitations / explicitly out of scope**
 - Cloud storage backends are not supported, process proven on Local External Strorage resources only
 - Import from SQL source, format-parameterised models, pure-schema inputs, and open-ended output registration 
 - Custom import/export models' guardrails (what a client model can do with TracDataContext) is an open decision  