### PR TITLE
Suppressions for OpenTelemetry CVEs & fix version selection

### DIFF
--- a/.github/workflows/compliance.yaml
+++ b/.github/workflows/compliance.yaml
@@ -171,7 +171,7 @@ jobs:
           PIP_AUDIT_PROGRESS_SPINNER: "off"
         run: |
           pip install pip-audit
-          pip-audit
+          pip-audit --ignore-vuln PYSEC-2026-3740
 
   web_api_compliance:
 

--- a/dev/compliance/owasp-false-positives.xml
+++ b/dev/compliance/owasp-false-positives.xml
@@ -337,4 +337,89 @@
         <packageUrl regex="true">^pkg:npm/extract\-zip@.*$</packageUrl>
         <cve>CVE-2026-56876</cve>
     </suppress>
+
+
+    <!-- OpenTelemetry: pulled in by Google Cloud libs (no update yet available) and io.grpc/grpc-bom -->
+    <!-- (update has breaking API changes) -->
+    <suppress>
+        <packageUrl regex="true">^pkg:maven/io\.grpc/grpc-opentelemetry@.*$</packageUrl>
+        <cve>CVE-2026-54285</cve>
+    </suppress>
+
+    <!-- OpenTelemetry: pulled in by Google Cloud libs (no update yet available) -->
+    <suppress>
+        <packageUrl regex="true">^pkg:maven/io\.opentelemetry/opentelemetry-api@.*$</packageUrl>
+        <cve>CVE-2026-54285</cve>
+    </suppress>
+
+    <suppress>
+        <packageUrl regex="true">^pkg:maven/io\.opentelemetry/opentelemetry-common@.*$</packageUrl>
+        <cve>CVE-2026-54285</cve>
+    </suppress>
+
+    <suppress>
+        <packageUrl regex="true">^pkg:maven/io\.opentelemetry/opentelemetry-context@.*$</packageUrl>
+        <cve>CVE-2026-54285</cve>
+    </suppress>
+
+    <suppress>
+        <packageUrl regex="true">^pkg:maven/io\.opentelemetry\.contrib/opentelemetry-gcp-resources@.*$</packageUrl>
+        <cve>CVE-2026-29181</cve>
+    </suppress>
+
+    <suppress>
+        <packageUrl regex="true">^pkg:maven/io\.opentelemetry\.contrib/opentelemetry-gcp-resources@.*$</packageUrl>
+        <cve>CVE-2026-39883</cve>
+    </suppress>
+
+    <suppress>
+        <packageUrl regex="true">^pkg:maven/io\.opentelemetry\.contrib/opentelemetry-gcp-resources@.*$</packageUrl>
+        <cve>CVE-2026-24051</cve>
+    </suppress>
+
+    <suppress>
+        <packageUrl regex="true">^pkg:maven/io\.opentelemetry\.contrib/opentelemetry-gcp-resources@.*$</packageUrl>
+        <cve>CVE-2026-39882</cve>
+    </suppress>
+
+    <suppress>
+        <packageUrl regex="true">^pkg:maven/io\.opentelemetry\.contrib/opentelemetry-gcp-resources@.*$</packageUrl>
+        <cve>CVE-2026-41178</cve>
+    </suppress>
+
+    <suppress>
+        <packageUrl regex="true">^pkg:maven/io\.opentelemetry\.contrib/opentelemetry-gcp-resources@.*$</packageUrl>
+        <cve>CVE-2026-54285</cve>
+    </suppress>
+
+    <suppress>
+        <packageUrl regex="true">^pkg:maven/io\.opentelemetry/opentelemetry-sdk@.*$</packageUrl>
+        <cve>CVE-2026-54285</cve>
+    </suppress>
+
+    <suppress>
+        <packageUrl regex="true">^pkg:maven/io\.opentelemetry/opentelemetry-sdk-common@.*$</packageUrl>
+        <cve>CVE-2026-54285</cve>
+    </suppress>
+
+    <suppress>
+        <packageUrl regex="true">^pkg:maven/io\.opentelemetry/opentelemetry-sdk-extension-autoconfigure-spi@.*$</packageUrl>
+        <cve>CVE-2026-54285</cve>
+    </suppress>
+
+    <suppress>
+        <packageUrl regex="true">^pkg:maven/io\.opentelemetry/opentelemetry-sdk-logs@.*$</packageUrl>
+        <cve>CVE-2026-54285</cve>
+    </suppress>
+
+    <suppress>
+        <packageUrl regex="true">^pkg:maven/io\.opentelemetry/opentelemetry-sdk-metrics@.*$</packageUrl>
+        <cve>CVE-2026-54285</cve>
+    </suppress>
+
+    <suppress>
+        <packageUrl regex="true">^pkg:maven/io\.opentelemetry/opentelemetry-sdk-trace@.*$</packageUrl>
+        <cve>CVE-2026-54285</cve>
+    </suppress>
+
 </suppressions>

--- a/dev/version.sh
+++ b/dev/version.sh
@@ -50,13 +50,9 @@ elif [ ${prior_version_found} = 0 ]; then
       next_patch_version=`echo "${prior_version}" | sed "s/-.*$//"`
   fi
 
-  # Next patch version exists but is not in the revision history -> release branch exists
-  if [ `git tag | grep "^v${next_patch_version}$"` ]; then
-      next_minor_version=`echo "${next_patch_version}" | awk -F. '{$2=$2+1; $3=0; print}' OFS=.`
-      version_number=${next_minor_version}-SNAPSHOT
-  else
-      version_number=${next_patch_version}-SNAPSHOT
-  fi
+  # A same-numbered tag elsewhere in the tag list proves nothing about this branch's history:
+  # if it were an ancestor, git describe would already have returned it as prior_version_tag.
+  version_number=${next_patch_version}-SNAPSHOT
 
 else
 

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -30,7 +30,7 @@ ext {
     guava_version = '33.4.8-jre'
     gson_version = '2.13.1'
     proto_version = '4.31.1'
-    grpc_version = '1.74.0'
+    grpc_version = '1.84.0'
     gapi_version = '2.60.0'
 
     // Data technologies

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -67,7 +67,7 @@ ext {
     // Plugins
 
     aws_sdk_version = '2.53.1'
-    gcp_sdk_version = '26.87.0'
+    gcp_sdk_version = '26.86.0'
     azure_sdk_version = '1.2.36'
 
     apache_sshd_version = "2.12.1"

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -30,7 +30,7 @@ ext {
     guava_version = '33.4.8-jre'
     gson_version = '2.13.1'
     proto_version = '4.31.1'
-    grpc_version = '1.84.0'
+    grpc_version = '1.74.0'
     gapi_version = '2.60.0'
 
     // Data technologies

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -67,7 +67,7 @@ ext {
     // Plugins
 
     aws_sdk_version = '2.53.1'
-    gcp_sdk_version = '26.86.0'
+    gcp_sdk_version = '26.87.0'
     azure_sdk_version = '1.2.36'
 
     apache_sshd_version = "2.12.1"

--- a/tracdap-libs/tracdap-lib-test/src/main/java/org/finos/tracdap/test/helpers/PlatformTest.java
+++ b/tracdap-libs/tracdap-lib-test/src/main/java/org/finos/tracdap/test/helpers/PlatformTest.java
@@ -657,7 +657,14 @@ public class PlatformTest implements BeforeAllCallback, AfterAllCallback {
                 venvPb.command("python3", "-m", "venv", venvPath.toString());
 
                 var venvP = venvPb.start();
-                venvP.waitFor(60, TimeUnit.SECONDS);
+                var venvCompleted = venvP.waitFor(60, TimeUnit.SECONDS);
+
+                if (!venvCompleted || venvP.exitValue() != 0) {
+
+                    var status = venvCompleted ? "exit code = " + venvP.exitValue() : "timed out";
+                    throw new RuntimeException(String.format(
+                            "Failed to create the test venv (%s): %s", status, venvPb.command()));
+                }
 
                 log.info("Installing TRAC runtime for Python...");
 
@@ -686,8 +693,15 @@ public class PlatformTest implements BeforeAllCallback, AfterAllCallback {
                 pipPB.environment().put(VENV_ENV_VAR, venvPath.toString());
 
                 var pipP = pipPB.start();
-                pipP.waitFor(2, TimeUnit.MINUTES);
+                var pipCompleted = pipP.waitFor(2, TimeUnit.MINUTES);
 
+                if (!pipCompleted || pipP.exitValue() != 0) {
+
+                    var status = pipCompleted ? "exit code = " + pipP.exitValue() : "timed out";
+                    throw new RuntimeException(String.format(
+                            "Failed to set up the test venv, pip install did not succeed (%s): %s",
+                            status, String.join(" ", pipInstall)));
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes for OpenTelemetry CVEs:

- Add suppressions for the CVEs, because the GCP SDK doesn't yet have a fixed version

`grpc-opentelemetry` is also pulled in by [grpc-java](https://github.com/grpc/grpc-java/releases).  Attempting to update that broke a lot of things.  Left on the very old 1.74.0 but we may be forced to update once the GCP inclusions are cleared.

The checks as presently configured won't let me merge this unless all problems are fixed at once.  Thus AlexF's fix to version selection is also pulled in from https://github.com/finos/tracdap/pull/748/.
