### PR TITLE
Stop dev/version.sh forcing a minor bump from a disconnected release

### DIFF
--- a/dev/version.sh
+++ b/dev/version.sh
@@ -50,13 +50,9 @@ elif [ ${prior_version_found} = 0 ]; then
       next_patch_version=`echo "${prior_version}" | sed "s/-.*$//"`
   fi
 
-  # Next patch version exists but is not in the revision history -> release branch exists
-  if [ `git tag | grep "^v${next_patch_version}$"` ]; then
-      next_minor_version=`echo "${next_patch_version}" | awk -F. '{$2=$2+1; $3=0; print}' OFS=.`
-      version_number=${next_minor_version}-SNAPSHOT
-  else
-      version_number=${next_patch_version}-SNAPSHOT
-  fi
+  # A same-numbered tag elsewhere in the tag list proves nothing about this branch's history:
+  # if it were an ancestor, git describe would already have returned it as prior_version_tag.
+  version_number=${next_patch_version}-SNAPSHOT
 
 else
 

--- a/tracdap-libs/tracdap-lib-test/src/main/java/org/finos/tracdap/test/helpers/PlatformTest.java
+++ b/tracdap-libs/tracdap-lib-test/src/main/java/org/finos/tracdap/test/helpers/PlatformTest.java
@@ -657,7 +657,14 @@ public class PlatformTest implements BeforeAllCallback, AfterAllCallback {
                 venvPb.command("python3", "-m", "venv", venvPath.toString());
 
                 var venvP = venvPb.start();
-                venvP.waitFor(60, TimeUnit.SECONDS);
+                var venvCompleted = venvP.waitFor(60, TimeUnit.SECONDS);
+
+                if (!venvCompleted || venvP.exitValue() != 0) {
+
+                    var status = venvCompleted ? "exit code = " + venvP.exitValue() : "timed out";
+                    throw new RuntimeException(String.format(
+                            "Failed to create the test venv (%s): %s", status, venvPb.command()));
+                }
 
                 log.info("Installing TRAC runtime for Python...");
 
@@ -686,8 +693,15 @@ public class PlatformTest implements BeforeAllCallback, AfterAllCallback {
                 pipPB.environment().put(VENV_ENV_VAR, venvPath.toString());
 
                 var pipP = pipPB.start();
-                pipP.waitFor(2, TimeUnit.MINUTES);
+                var pipCompleted = pipP.waitFor(2, TimeUnit.MINUTES);
 
+                if (!pipCompleted || pipP.exitValue() != 0) {
+
+                    var status = pipCompleted ? "exit code = " + pipP.exitValue() : "timed out";
+                    throw new RuntimeException(String.format(
+                            "Failed to set up the test venv, pip install did not succeed (%s): %s",
+                            status, String.join(" ", pipInstall)));
+                }
             }
         }
     }


### PR DESCRIPTION
The `end-to-end` CI job (`.github/workflows/integration.yaml`) has been failing on every branch built from `main` since tag `v0.10.1` was cut on a disconnected maintenance branch (2026-08-21). `dev/version.sh` treats the mere existence of that tag anywhere in the repo as evidence a release branch exists, and jumps every `main`-line SNAPSHOT build to the next minor version (`0.11.0-SNAPSHOT`) — even though the tag is unreachable from `main`.                                                                                  
                                                                                                                                                                                That desyncs the runtime wheel's version from the four Python ext plugins which hardcode `tracdap-runtime == 0.10.*`. `end-to-end` builds the runtime and all four plugins from source in the same job and `pip install`s them together — pip then refuses to resolve `tracdap-runtime==0.11.0.dev0` against a plugin requiring `==0.10.*`.  

`PlatformTest.java`'s test-venv setup discards the `pip install` subprocess's exit code, so this failure was silent — the broken venv gets used anyway, and every job that tries to run a Python model then fails downstream with an unrelated `ModuleNotFoundError`.

- **`dev/version.sh`**: removed the minor-version-bump branch. SNAPSHOT builds now always compute as the next patch version. `dev/version.ps1` uses an unrelated versioning scheme and isn't affected.       

- **`PlatformTest.java`**: both the venv-creation and pip-install subprocesses now check their exit code/timeout and raise a clear `RuntimeException` on failure, instead of silently continuing with a broken venv. 

**Notes for reviewers** - `dev/version.sh` drives version numbering for both the Java/Gradle and Python builds repo-wide, not just this CI job.  